### PR TITLE
TEIID-2213 fix the jboss kit build issue

### DIFF
--- a/connectors/connector-infinispan/pom.xml
+++ b/connectors/connector-infinispan/pom.xml
@@ -43,11 +43,13 @@
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core</artifactId>
             <version>${version.infinispan}</version>
+            <scope>provided</scope>
         </dependency> 
         <dependency>
           <groupId>org.infinispan</groupId>
           <artifactId>infinispan-client-hotrod</artifactId>
           <version>${version.infinispan}</version>
+          <scope>provided</scope>
         </dependency>  
         
 	    <dependency>


### PR DESCRIPTION
fix the jboss kit build issue, the extra jar's were being added because the scope wasn't set
