### PR TITLE
TEIID-2312 - Adding ability to define security-domain for ldap, salesfor...

### DIFF
--- a/api/src/main/java/org/teiid/resource/spi/ConnectionContext.java
+++ b/api/src/main/java/org/teiid/resource/spi/ConnectionContext.java
@@ -21,6 +21,9 @@
  */
 package org.teiid.resource.spi;
 
+import java.util.Set;
+
+import javax.resource.spi.security.PasswordCredential;
 import javax.security.auth.Subject;
 
 /**
@@ -41,4 +44,34 @@ public class ConnectionContext {
 	public static void setSubject(Subject subject) {
 		SUBJECT.set(subject);
 	}	
+	
+	public static String getUserName(Subject subject, BasicManagedConnectionFactory mcf, String defalt) {
+		Set<PasswordCredential> creds = subject.getPrivateCredentials(PasswordCredential.class);
+		if (creds != null && creds.size() > 0) {
+			for (PasswordCredential cred : creds) {
+				if (cred.getManagedConnectionFactory().equals(mcf)) {
+					if (cred.getUserName() != null) {
+						return cred.getUserName();
+					}
+				}
+			}
+		}
+		return defalt;
+	}
+	
+	public static String getPassword(Subject subject, BasicManagedConnectionFactory mcf, String userName, String defalt) {
+		Set<PasswordCredential> creds = subject.getPrivateCredentials(PasswordCredential.class);
+		if (creds != null && creds.size() > 0) {
+			for (PasswordCredential cred : creds) {
+				if (cred.getManagedConnectionFactory().equals(mcf)) {
+					if (cred.getUserName().equals(userName)) {
+						if (cred.getPassword() != null) {
+							return new String(cred.getPassword());
+						}
+					}
+				}
+			}
+		}
+		return defalt;
+	}
 }

--- a/build/kits/jboss-as7/docs/teiid/teiid-releasenotes.html
+++ b/build/kits/jboss-as7/docs/teiid/teiid-releasenotes.html
@@ -32,6 +32,7 @@
 	<li>TEIID-2311 <b>Permission Conditions</b> - data roles can now specify SQL conditions that will enforce row-based security and physical table insert/update checked constraints.  See the Reference Guide for more.
 	<li>TEIID-2341 <b>Join Planning Improvements</b> - ANSI join structures can now be preserved with the preserve hint, i.e. FROM /*+ PRESERVE */ (tbl1 INNER JOIN tbl2 ON ...), which is similar to the Oracle ORDERED hint.  
 	Also sources restircted to only outer joins can have INNER or effectively INNER joins pushed to them.
+	<li>TEIID-2312 <b>Ldap, Salesforce, google-spreadsheet and ws (basic auth) translators can now define "security-domain" in their resource-adaptor configuration for security. When defined along with caller-identity the logged in user's credentials are passed to source for authentication. 
 </ul>
 
 <h2><a name="Compatibility">Compatibility Issues</a></h2>

--- a/connectors/connector-google/src/main/java/org/teiid/resource/adapter/google/SpreadsheetConnectionImpl.java
+++ b/connectors/connector-google/src/main/java/org/teiid/resource/adapter/google/SpreadsheetConnectionImpl.java
@@ -22,6 +22,8 @@
 
 package org.teiid.resource.adapter.google;
 
+import javax.security.auth.Subject;
+
 import org.teiid.logging.LogConstants;
 import org.teiid.logging.LogManager;
 import org.teiid.resource.adapter.google.auth.AuthHeaderFactory;
@@ -34,6 +36,7 @@ import org.teiid.resource.adapter.google.gdata.SpreadsheetMetadataExtractor;
 import org.teiid.resource.adapter.google.metadata.SpreadsheetInfo;
 import org.teiid.resource.adapter.google.result.RowsResult;
 import org.teiid.resource.spi.BasicConnection;
+import org.teiid.resource.spi.ConnectionContext;
 
 
 
@@ -48,11 +51,23 @@ public class SpreadsheetConnectionImpl extends BasicConnection implements Google
 	
 	public SpreadsheetConnectionImpl(SpreadsheetManagedConnectionFactory config) {
 		this.config = config;
-		checkConfig(config);
+		
+		String userName = config.getUsername().trim();
+		String password = config.getPassword(); // not trimming the password as space could be part of it.
+
+		// if security-domain is specified and caller identity is used; then use
+		// credentials from subject
+		Subject subject = ConnectionContext.getSubject();
+		if (subject != null) {
+			userName = ConnectionContext.getUserName(subject, this.config, userName);
+			password = ConnectionContext.getPassword(subject, this.config, userName, password);
+		}
+		
+		checkConfig(userName, password);		
 		
 		AuthHeaderFactory authHeaderFactory = null;
 		if (SpreadsheetManagedConnectionFactory.CLIENT_LOGIN.equals(config.getAuthMethod())){
-			authHeaderFactory = new ClientLoginHeaderFactory(config.getUsername(),config.getPassword() );
+			authHeaderFactory = new ClientLoginHeaderFactory(userName, password);
 		} else {
 			authHeaderFactory = new OAuth2HeaderFactory(config.getRefreshToken().trim());
 		}
@@ -63,16 +78,17 @@ public class SpreadsheetConnectionImpl extends BasicConnection implements Google
 		gdata.setHeaderFactory(authHeaderFactory);
 		dataProtocol.setSpreadSheetBrowser(gdata);
 		
-		LogManager.logInfo(LogConstants.CTX_CONNECTOR,SpreadsheetManagedConnectionFactory.UTIL.
-				getString("init") ); //$NON-NLS-1$
+		LogManager.logInfo(LogConstants.CTX_CONNECTOR,SpreadsheetManagedConnectionFactory.UTIL.getString("init") ); //$NON-NLS-1$
 	}
 	
-	private void checkConfig(SpreadsheetManagedConnectionFactory config2) {
+	private void checkConfig(String userName, String password) {
+
 		//SpreadsheetName should be set
 		if (config.getSpreadsheetName()==null ||  config.getSpreadsheetName().trim().equals("")){ //$NON-NLS-1$
 			throw new SpreadsheetAuthException(SpreadsheetManagedConnectionFactory.UTIL.
 					getString("provide_spreadsheetname",SpreadsheetManagedConnectionFactory.SPREADSHEET_NAME));		 //$NON-NLS-1$
 		}
+		
 		//Auth method must be either CLIENT_LOGIN or OAUTH2
 		if (config.getAuthMethod()==null ||  (!config.getAuthMethod().equals(SpreadsheetManagedConnectionFactory.CLIENT_LOGIN)
 		 && !config.getAuthMethod().equals(SpreadsheetManagedConnectionFactory.OAUTH2_LOGIN))){
@@ -81,27 +97,19 @@ public class SpreadsheetConnectionImpl extends BasicConnection implements Google
 							SpreadsheetManagedConnectionFactory.OAUTH2_LOGIN));		
 		}
 		
-		//Client login requires to suppoly username and password
+		//Client login requires username and password
 		if (config.getAuthMethod().equals(SpreadsheetManagedConnectionFactory.CLIENT_LOGIN)){
-			if (config.getUsername() == null || config.getPassword() == null ||
-					config.getUsername().trim().equals("") || //$NON-NLS-1$
-					config.getPassword().trim().equals("") //$NON-NLS-1$
-					){
-				throw new SpreadsheetAuthException(SpreadsheetManagedConnectionFactory.UTIL.
-						getString("client_login_requires_pass"));	 //$NON-NLS-1$
+			if (userName == null || password == null || userName.equals("") || password.equals("")) { //$NON-NLS-1$ //$NON-NLS-2$
+				throw new SpreadsheetAuthException(SpreadsheetManagedConnectionFactory.UTIL.getString("client_login_requires_pass"));	 //$NON-NLS-1$
 			}
 		}
 		
 		//OAuth login requires refreshToken
 		if (config.getAuthMethod().equals(SpreadsheetManagedConnectionFactory.OAUTH2_LOGIN)){
-			if (config.getRefreshToken() == null ||
-					config.getRefreshToken().trim().equals("")  //$NON-NLS-1$
-					){
-				throw new SpreadsheetAuthException(SpreadsheetManagedConnectionFactory.UTIL.
-						getString("oauth_requires_pass"));	 //$NON-NLS-1$
+			if (config.getRefreshToken() == null || config.getRefreshToken().trim().equals("")){ //$NON-NLS-1$
+				throw new SpreadsheetAuthException(SpreadsheetManagedConnectionFactory.UTIL.getString("oauth_requires_pass"));	 //$NON-NLS-1$
 			}
 		}
-		
 	}
 
 	/** 

--- a/connectors/connector-ldap/src/main/resources/org/teiid/resource/adapter/ldap/i18n.properties
+++ b/connectors/connector-ldap/src/main/resources/org/teiid/resource/adapter/ldap/i18n.properties
@@ -22,8 +22,8 @@
 
 #
 LDAPConnection.urlPropNotFound=Ldap URL property not found.
-LDAPConnection.adminUserDNPropNotFound=Ldap Admin User DN property not found.
-LDAPConnection.adminUserPassPropNotFound=Ldap Admin password property not found.
+LDAPConnection.adminUserDNPropNotFound=Ldap Admin User DN property not found nor security-domain specified for the resource-adaptor.
+LDAPConnection.adminUserPassPropNotFound=Ldap Admin password property not found nor security-domain specified for the resource-adaptor.
 LDAPConnection.directoryNamingError=Initializing LDAP directory context failed. Please check LDAP connection properties, including username and password: {0}
 LDAPConnection.contextCloseError=The Connection failed to close LDAP context: {0}
 


### PR DESCRIPTION
...ce, ws(basic auth) and google-spreadsheet to consume the user name and credentails from the security context. This enables user to pass-in logged in credentials to these sources
