### PR TITLE
TEIID-2329

### DIFF
--- a/api/src/main/java/org/teiid/language/Insert.java
+++ b/api/src/main/java/org/teiid/language/Insert.java
@@ -3,17 +3,17 @@
  * See the COPYRIGHT.txt file distributed with this work for information
  * regarding copyright ownership.  Some portions may be licensed
  * to Red Hat, Inc. under one or more contributor license agreements.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
@@ -29,28 +29,28 @@ import org.teiid.language.visitor.LanguageObjectVisitor;
 
 
 public class Insert extends BaseLanguageObject implements BatchedCommand {
-    
+
     private NamedTable table;
     private List<ColumnReference> columns;
     private InsertValueSource valueSource;
     private Iterator<? extends List<?>> parameterValues;
-  
+
     public Insert(NamedTable group, List<ColumnReference> elements, InsertValueSource valueSource) {
         this.table = group;
         this.columns = elements;
         this.valueSource = valueSource;
     }
-    
+
     public NamedTable getTable() {
-        return table;
+        return this.table;
     }
 
     public List<ColumnReference> getColumns() {
-        return columns;
+        return this.columns;
     }
 
     public InsertValueSource getValueSource() {
-        return valueSource;
+        return this.valueSource;
     }
 
     public void acceptVisitor(LanguageObjectVisitor visitor) {
@@ -64,16 +64,16 @@ public class Insert extends BaseLanguageObject implements BatchedCommand {
     public void setColumns(List<ColumnReference> elements) {
         this.columns = elements;
     }
-    
+
     public void setValueSource(InsertValueSource values) {
     	this.valueSource = values;
     }
-    
+
     @Override
-    public Iterator<? extends List<?>> getParameterValues() {
-    	return parameterValues;
+	public Iterator<? extends List<?>> getParameterValues() {
+    	return this.parameterValues;
     }
-    
+
     public void setParameterValues(Iterator<? extends List<?>> parameterValues) {
 		this.parameterValues = parameterValues;
 	}

--- a/build/assembly/embedded-dist.xml
+++ b/build/assembly/embedded-dist.xml
@@ -92,6 +92,8 @@
             <include>org.jboss.teiid.connectors:translator-object</include>
             <include>org.jboss.teiid.connectors:translator-google</include>
             <include>org.jboss.teiid.connectors:google-api</include>
+            <include>org.jboss.teiid.connectors:mongodb</include>
+            <include>org.jboss.teiid.connectors:mongodb-api</include>
         </includes>
 
         <binaries>        
@@ -121,6 +123,7 @@
             <include>org.jboss.teiid.connectors:connector-ws</include>
             <include>org.jboss.teiid.connectors:connector-infinispan</include>
             <include>org.jboss.teiid.connectors:connector-google</include>
+            <include>org.jboss.teiid.connectors:connector-mongodb</include>
         </includes>
 
         <binaries>        

--- a/build/assembly/jboss-as7/dist.xml
+++ b/build/assembly/jboss-as7/dist.xml
@@ -274,6 +274,31 @@
           <fileMode>0644</fileMode>
         </binaries>
     </moduleSet>
+
+    <moduleSet>
+        <includeSubModules>true</includeSubModules>
+        <useAllReactorProjects>true</useAllReactorProjects>
+
+        <includes>
+            <include>org.jboss.teiid.connectors:connector-mongodb:rar</include>
+        </includes>
+
+        <binaries>   
+          <outputFileNameMapping>teiid-${module.artifactId}.rar</outputFileNameMapping>     
+          <includeDependencies>true</includeDependencies>
+          <unpack>true</unpack>
+            <dependencySets>
+                <dependencySet>
+                    <useProjectArtifact>true</useProjectArtifact>
+                    <unpack>false</unpack>
+                    <useTransitiveDependencies>false</useTransitiveDependencies>
+                    <useDefaultExcludes>true</useDefaultExcludes>
+                </dependencySet>
+            </dependencySets>          
+          <outputDirectory>modules/system/layers/base/org/jboss/teiid/resource-adapter/mongodb/main</outputDirectory>
+          <fileMode>0644</fileMode>
+        </binaries>
+    </moduleSet>
     
     <moduleSet>
         <includeSubModules>true</includeSubModules>
@@ -471,6 +496,31 @@
           <fileMode>0644</fileMode>
         </binaries>
     </moduleSet>
+
+    <moduleSet>
+        <includeSubModules>true</includeSubModules>
+        <useAllReactorProjects>true</useAllReactorProjects>
+
+        <includes>
+            <include>org.jboss.teiid.connectors:mongodb-api</include>
+        </includes>
+
+        <binaries>        
+          <includeDependencies>true</includeDependencies>
+          <unpack>false</unpack>
+            <dependencySets>
+                <dependencySet>
+                    <useProjectArtifact>true</useProjectArtifact>
+                    <unpack>false</unpack>
+                    <useTransitiveDependencies>false</useTransitiveDependencies>
+                    <useDefaultExcludes>true</useDefaultExcludes>
+                </dependencySet>
+            </dependencySets>          
+          <outputDirectory>modules/system/layers/base/org/jboss/teiid/translator/mongodb/api/main</outputDirectory>
+          <fileMode>0644</fileMode>
+        </binaries>
+    </moduleSet>
+
     <moduleSet>
         <includeSubModules>true</includeSubModules>
         <useAllReactorProjects>true</useAllReactorProjects>
@@ -653,6 +703,31 @@
               <fileMode>0644</fileMode>
           </binaries>
       </moduleSet>
+    <moduleSet>
+        <includeSubModules>true</includeSubModules>
+        <useAllReactorProjects>true</useAllReactorProjects>
+
+        <includes>
+            <include>org.jboss.teiid.connectors:translator-mongodb</include>
+        </includes>
+
+        <binaries>        
+          <includeDependencies>true</includeDependencies>
+          <unpack>false</unpack>
+            <dependencySets>
+                <dependencySet>
+                    <useProjectArtifact>true</useProjectArtifact>
+                    <unpack>false</unpack>
+                    <useTransitiveDependencies>false</useTransitiveDependencies>
+                    <useDefaultExcludes>true</useDefaultExcludes>
+                </dependencySet>
+            </dependencySets>          
+          <outputDirectory>modules/system/layers/base/org/jboss/teiid/translator/mongodb/main</outputDirectory>
+          <fileMode>0644</fileMode>
+        </binaries>
+      
+    </moduleSet>
+      
     <!-- Include the JOPR plugin     
     <moduleSet>
         <includeSubModules>true</includeSubModules>

--- a/build/kits/jboss-as7/bin/scripts/teiid-domain-mode-install.cli
+++ b/build/kits/jboss-as7/bin/scripts/teiid-domain-mode-install.cli
@@ -67,6 +67,7 @@ connect
 /profile=ha/subsystem=teiid/translator=map-cache:add(module=org.jboss.teiid.translator.object)
 /profile=ha/subsystem=teiid/translator=google-spreadsheet:add(module=org.jboss.teiid.translator.google)
 /profile=ha/subsystem=teiid/translator=odata:add(module=org.jboss.teiid.translator.odata)
+/profile=ha/subsystem=teiid/translator=mongodb:add(module=org.jboss.teiid.translator.mongodb)
 
 
 /profile=ha/subsystem=datasources/jdbc-driver=teiid:add(driver-name=teiid, driver-module-name=org.jboss.teiid.client, driver-class-name=org.teiid.jdbc.TeiidDriver, driver-xa-datasource-class-name=org.teiid.jdbc.TeiidDataSource)
@@ -78,6 +79,7 @@ connect
 /profile=ha/subsystem=resource-adapters/resource-adapter=ldap:add(module=org.jboss.teiid.resource-adapter.ldap)
 /profile=ha/subsystem=resource-adapters/resource-adapter=salesforce:add(module=org.jboss.teiid.resource-adapter.salesforce)
 /profile=ha/subsystem=resource-adapters/resource-adapter=webservice:add(module=org.jboss.teiid.resource-adapter.webservice)
+/profile=ha/subsystem=resource-adapters/resource-adapter=mongodb:add(module=org.jboss.teiid.resource-adapter.mongodb)
 
 deploy --server-groups=main-server-group ../modules/org/jboss/teiid/main/deployments/teiid-odata-${project.version}.war
 

--- a/build/kits/jboss-as7/bin/scripts/teiid-standalone-mode-install.cli
+++ b/build/kits/jboss-as7/bin/scripts/teiid-standalone-mode-install.cli
@@ -64,6 +64,7 @@ connect
 /subsystem=teiid/translator=map-cache:add(module=org.jboss.teiid.translator.object)
 /subsystem=teiid/translator=google-spreadsheet:add(module=org.jboss.teiid.translator.google)
 /subsystem=teiid/translator=odata:add(module=org.jboss.teiid.translator.odata)
+/subsystem=teiid/translator=mongodb:add(module=org.jboss.teiid.translator.mongodb)
 
 
 /subsystem=datasources/jdbc-driver=teiid:add(driver-name=teiid, driver-module-name=org.jboss.teiid.client, driver-class-name=org.teiid.jdbc.TeiidDriver, driver-xa-datasource-class-name=org.teiid.jdbc.TeiidDataSource)
@@ -75,6 +76,6 @@ connect
 /subsystem=resource-adapters/resource-adapter=ldap:add(module=org.jboss.teiid.resource-adapter.ldap)
 /subsystem=resource-adapters/resource-adapter=salesforce:add(module=org.jboss.teiid.resource-adapter.salesforce)
 /subsystem=resource-adapters/resource-adapter=webservice:add(module=org.jboss.teiid.resource-adapter.webservice)
-
+/subsystem=resource-adapters/resource-adapter=mongodb:add(module=org.jboss.teiid.resource-adapter.mongodb)
 
 /:reload

--- a/build/kits/jboss-as7/docs/teiid/datasources/mongodb/create-mongodb-ds.cli
+++ b/build/kits/jboss-as7/docs/teiid/datasources/mongodb/create-mongodb-ds.cli
@@ -1,0 +1,4 @@
+/subsystem=resource-adapters/resource-adapter=mongodb/connection-definitions=mongodbDS:add(jndi-name=java:/mongodbDS, class-name=org.teiid.resource.adapter.mongodb.MongoDBManagedConnectionFactory, enabled=true, use-java-context=true)
+/subsystem=resource-adapters/resource-adapter=mongodb/connection-definitions=mongodbDS/config-properties=RemoteServerList:add(value=localhost:27017)
+/subsystem=resource-adapters/resource-adapter=mongodb/connection-definitions=mongodbDS/config-properties=Database:add(value=test)
+/subsystem=resource-adapters/resource-adapter=mongodb:activate

--- a/build/kits/jboss-as7/docs/teiid/datasources/mongodb/mongodb.xml
+++ b/build/kits/jboss-as7/docs/teiid/datasources/mongodb/mongodb.xml
@@ -1,0 +1,27 @@
+<!-- If susbsytem is already defined, only copy the contents under it and edit to suit your needs -->
+<subsystem xmlns="urn:jboss:domain:resource-adapters:1.1">
+    <resource-adapters>
+        <resource-adapter id="webservice">
+            <module slot="main" id="org.jboss.teiid.resource-adapter.mongodb"/>
+            <transaction-support>NoTransaction</transaction-support>
+            <connection-definitions>
+                <connection-definition class-name="org.teiid.resource.adapter.mongodb.MongoDBManagedConnectionFactory" 
+                        jndi-name="java:/mongoDS" 
+                        enabled="true" 
+                        use-java-context="true" 
+                        pool-name="teiid-mongodb-ds">
+                        
+                      <!-- MongoDB server list (host:port[;host:port...]) -->
+                      <config-property name="RemoteServerList">localhost:27017</config-property>
+                      <!-- Database Name in the MongoDB -->
+                      <config-property name="Database">test</config-property>
+                        <!-- 
+                            Uncomment these properties to supply user name and password
+                        <config-property name="Username">user</config-property>
+                        <config-property name="Password">user</config-property>
+                        -->  
+                </connection-definition>
+            </connection-definitions>
+        </resource-adapter>
+    </resource-adapters>
+</subsystem>

--- a/build/kits/jboss-as7/docs/teiid/datasources/mongodb/readme.txt
+++ b/build/kits/jboss-as7/docs/teiid/datasources/mongodb/readme.txt
@@ -1,0 +1,3 @@
+In Teiid, for web-service(SOAP, REST/HTTP) datasource a JCA connector is provided and deployed at the install time. To create
+web service datasource connection edit the "standalone-teiid.xml" file or "doamin-teiid.xml" file and add 
+the contents of the ws.xml under "resource-adapters" subsystem section.

--- a/build/kits/jboss-as7/modules/system/layers/base/org/jboss/teiid/resource-adapter/mongodb/main/module.xml
+++ b/build/kits/jboss-as7/modules/system/layers/base/org/jboss/teiid/resource-adapter/mongodb/main/module.xml
@@ -1,0 +1,16 @@
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.teiid.resource-adapter.mongodb">
+   
+    <resources>
+        <resource-root path="connector-mongodb-${project.version}.jar"/>
+        <resource-root path="."/>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="javax.resource.api"/>
+        <module name="org.jboss.teiid.common-core"/>
+        <module name="org.jboss.teiid.api"/>
+        <module name="org.jboss.teiid.translator.mongodb.api"/>
+    </dependencies>
+</module>

--- a/build/kits/jboss-as7/modules/system/layers/base/org/jboss/teiid/translator/mongodb/api/main/module.xml
+++ b/build/kits/jboss-as7/modules/system/layers/base/org/jboss/teiid/translator/mongodb/api/main/module.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.0" name="org.jboss.teiid.translator.mongodb.api">
+    <resources>
+        <resource-root path="mongodb-api-${project.version}.jar" />
+        <resource-root path="mongo-java-driver-2.11.1.jar" />
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="javax.resource.api"/>
+        <module name="org.jboss.teiid.common-core" />
+        <module name="org.jboss.teiid.api" />
+    </dependencies>
+</module>

--- a/build/kits/jboss-as7/modules/system/layers/base/org/jboss/teiid/translator/mongodb/main/module.xml
+++ b/build/kits/jboss-as7/modules/system/layers/base/org/jboss/teiid/translator/mongodb/main/module.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.0" name="org.jboss.teiid.translator.mongodb">
+    <resources>
+        <resource-root path="translator-mongodb-${project.version}.jar" />
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="javax.resource.api"/>
+        <module name="org.jboss.teiid.common-core" />
+        <module name="org.jboss.teiid.api" />
+        <module name="org.jboss.teiid.translator.mongodb.api" />    
+        <module name="org.jboss.teiid.translator.jdbc" />
+    </dependencies>
+</module>

--- a/build/kits/jboss-as7/standalone/configuration/standalone-teiid.xml
+++ b/build/kits/jboss-as7/standalone/configuration/standalone-teiid.xml
@@ -267,6 +267,15 @@
                 <resource-adapter id="webservice">
                     <module slot="main" id="org.jboss.teiid.resource-adapter.webservice"/>
                 </resource-adapter>
+               <resource-adapter id="mongodb">
+                    <module slot="main" id="org.jboss.teiid.resource-adapter.mongodb"/>
+                    <connection-definitions>
+                        <connection-definition class-name="org.teiid.resource.adapter.mongodb.MongoDBManagedConnectionFactory" jndi-name="java:/mongodbDS" enabled="true" use-java-context="true" pool-name="mongodbDS">
+                            <config-property name="RemoteServerList">localhost:27017</config-property>
+                            <config-property name="Database">test</config-property>
+                        </connection-definition>
+                    </connection-definitions>
+                </resource-adapter>
             </resource-adapters>        
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:sar:1.0"/>
@@ -351,7 +360,7 @@
             <translator name="infinispan-cache" module="org.jboss.teiid.translator.object"/>
             <translator name="map-cache" module="org.jboss.teiid.translator.object"/>
             <translator name="odata" module="org.jboss.teiid.translator.odata"/>
-            
+            <translator name="mongodb" module="org.jboss.teiid.translator.mongodb"/>
             
         </subsystem>        
         <subsystem xmlns="urn:jboss:domain:threads:1.1">

--- a/connectors/connector-mongodb/pom.xml
+++ b/connectors/connector-mongodb/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>connectors</artifactId>
+        <groupId>org.jboss.teiid</groupId>
+        <version>8.4.0.Alpha2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>connector-mongodb</artifactId>
+    <groupId>org.jboss.teiid.connectors</groupId>
+    <name>MongoDB Connector</name>
+    <packaging>rar</packaging>
+    <description>This connector reads data from MongoDB</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.teiid</groupId>
+            <artifactId>teiid-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.teiid</groupId>
+            <artifactId>teiid-common-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.resource</groupId>
+            <artifactId>connector-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.teiid.connectors</groupId>
+            <artifactId>mongodb-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>build_jar</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                          <archive>
+                            <manifestFile>src/main/rar/META-INF/MANIFEST.MF</manifestFile>
+                          </archive>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>deploy_jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>lib</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/connectors/connector-mongodb/src/main/java/org/teiid/resource/adapter/mongodb/MongoDBConnectionImpl.java
+++ b/connectors/connector-mongodb/src/main/java/org/teiid/resource/adapter/mongodb/MongoDBConnectionImpl.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+
+package org.teiid.resource.adapter.mongodb;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.resource.ResourceException;
+
+import org.teiid.core.BundleUtil;
+import org.teiid.mongodb.MongoDBConnection;
+import org.teiid.resource.spi.BasicConnection;
+
+import com.mongodb.DB;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
+
+
+public class MongoDBConnectionImpl extends BasicConnection implements MongoDBConnection {
+	static final BundleUtil UTIL = BundleUtil.getBundleUtil(MongoDBConnectionImpl.class);
+
+	private MongoClient client;
+	private String database;
+
+	public MongoDBConnectionImpl(String database, List<ServerAddress> servers,
+			MongoCredential credential, MongoClientOptions options) {
+		if (credential == null) {
+			this.client = new MongoClient(servers, options);
+		}
+		else {
+			this.client = new MongoClient(servers, Arrays.asList(credential), options);
+		}
+		this.database = database;
+	}
+
+	@Override
+	public DB getDatabase() {
+		return this.client.getDB(this.database);
+	}
+
+	@Override
+	public void close() throws ResourceException {
+		if (this.client != null) {
+			this.client.close();
+		}
+	}
+}

--- a/connectors/connector-mongodb/src/main/java/org/teiid/resource/adapter/mongodb/MongoDBManagedConnectionFactory.java
+++ b/connectors/connector-mongodb/src/main/java/org/teiid/resource/adapter/mongodb/MongoDBManagedConnectionFactory.java
@@ -1,0 +1,174 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.resource.adapter.mongodb;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.InvalidPropertyException;
+
+import org.teiid.core.BundleUtil;
+import org.teiid.resource.spi.BasicConnectionFactory;
+import org.teiid.resource.spi.BasicManagedConnectionFactory;
+
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCredential;
+import com.mongodb.ServerAddress;
+
+public class MongoDBManagedConnectionFactory extends BasicManagedConnectionFactory{
+	private static final long serialVersionUID = -4945630936957298180L;
+
+	public static final BundleUtil UTIL = BundleUtil.getBundleUtil(MongoDBManagedConnectionFactory.class);
+
+	private String remoteServerList=null;
+	private String username;
+	private String password;
+	private String database;
+
+	@Override
+	@SuppressWarnings("serial")
+	public BasicConnectionFactory<MongoDBConnectionImpl> createConnectionFactory() throws ResourceException {
+		if (this.remoteServerList == null) {
+			throw new InvalidPropertyException(UTIL.getString("no_server")); //$NON-NLS-1$
+		}
+		if (this.database == null) {
+			throw new InvalidPropertyException(UTIL.getString("no_database")); //$NON-NLS-1$
+		}
+
+		final List<ServerAddress> servers = getServers();
+
+		//TODO: need to define all the properties on the ra.xml and build this correctly
+		final MongoClientOptions options = MongoClientOptions.builder().build();
+
+		return new BasicConnectionFactory<MongoDBConnectionImpl>() {
+			@Override
+			public MongoDBConnectionImpl getConnection() throws ResourceException {
+				MongoCredential credential = null;
+				if (MongoDBManagedConnectionFactory.this.username != null && MongoDBManagedConnectionFactory.this.password != null) {
+					credential = MongoCredential.createMongoCRCredential(MongoDBManagedConnectionFactory.this.username, MongoDBManagedConnectionFactory.this.database, MongoDBManagedConnectionFactory.this.password.toCharArray());
+				}
+				return new MongoDBConnectionImpl(MongoDBManagedConnectionFactory.this.database, servers, credential, options);
+			}
+		};
+	}
+
+	/**
+	 * Returns the <code>host:port[;host:port...]</code> list that identifies the remote servers
+	 * to include in this cluster;
+	 * @return <code>host:port[;host:port...]</code> list
+	 */
+   public String getRemoteServerList() {
+        return this.remoteServerList;
+    }
+
+    /**
+     * Set the list of remote servers that make up the MongoDB cluster.
+     * @param remoteServerList the server list in appropriate <code>server:port;server2:port2</code> format.
+     */
+    public void setRemoteServerList( String remoteServerList ) {
+        this.remoteServerList = remoteServerList;
+    }
+
+	public String getUsername() {
+		return this.username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public String getPassword() {
+		return this.password;
+	}
+
+	public void setPassword(String googlePassword) {
+		this.password = googlePassword;
+	}
+
+	public String getDatabase() {
+		return this.database;
+	}
+
+	public void setDatabase(String database) {
+		this.database = database;
+	}
+
+
+	protected List<ServerAddress> getServers() throws ResourceException {
+		List<ServerAddress> addresses = new ArrayList<ServerAddress>();
+		StringTokenizer st = new StringTokenizer(getRemoteServerList(), ";"); //$NON-NLS-1$
+		while (st.hasMoreTokens()) {
+			String token = st.nextToken();
+			int idx = token.indexOf(':');
+			if (idx < 0) {
+				throw new InvalidPropertyException(UTIL.getString("no_database")); //$NON-NLS-1$
+			}
+			try {
+				addresses.add(new ServerAddress(token.substring(0, idx), Integer.valueOf(token.substring(idx+1))));
+			} catch(UnknownHostException e) {
+				throw new ResourceException(e);
+			}
+		}
+		return addresses;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((this.remoteServerList == null) ? 0 : this.remoteServerList.hashCode());
+		result = prime * result + ((this.database == null) ? 0 : this.database.hashCode());
+		result = prime * result + ((this.username == null) ? 0 : this.username.hashCode());
+		result = prime * result + ((this.password == null) ? 0 : this.password.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		MongoDBManagedConnectionFactory other = (MongoDBManagedConnectionFactory) obj;
+		if (!checkEquals(this.remoteServerList, other.remoteServerList)) {
+			return false;
+		}
+		if (!checkEquals(this.database, other.database)) {
+			return false;
+		}
+		if (!checkEquals(this.username, other.username)) {
+			return false;
+		}
+		if (!checkEquals(this.password, other.password)) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/connectors/connector-mongodb/src/main/java/org/teiid/resource/adapter/mongodb/MongoDBResourceAdapter.java
+++ b/connectors/connector-mongodb/src/main/java/org/teiid/resource/adapter/mongodb/MongoDBResourceAdapter.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.resource.adapter.mongodb;
+
+import org.teiid.resource.spi.BasicResourceAdapter;
+
+public class MongoDBResourceAdapter extends BasicResourceAdapter {
+
+	@Override
+	public int hashCode() {
+		return super.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		return true;
+	}
+}

--- a/connectors/connector-mongodb/src/main/rar/META-INF/MANIFEST.MF
+++ b/connectors/connector-mongodb/src/main/rar/META-INF/MANIFEST.MF
@@ -1,0 +1,1 @@
+Dependencies: org.jboss.teiid.common-core,org.jboss.teiid.api,javax.api,org.jboss.teiid.translator.mongodb.api

--- a/connectors/connector-mongodb/src/main/rar/META-INF/ra.xml
+++ b/connectors/connector-mongodb/src/main/rar/META-INF/ra.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<connector version="1.5">
+
+   <vendor-name>Red Hat Middleware LLC</vendor-name>
+   <eis-type>Teiid Text Connector</eis-type>
+   <resourceadapter-version>1.0</resourceadapter-version>
+   <license>
+      <description>
+ JBoss, Home of Professional Open Source.
+ Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ as indicated by the @author tags. See the copyright.txt file in the
+ distribution for a full listing of individual contributors.
+
+ This is free software; you can redistribute it and/or modify it
+ under the terms of the GNU Lesser General Public License as
+ published by the Free Software Foundation; either version 2.1 of
+ the License, or (at your option) any later version.
+
+ This software is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this software; if not, write to the Free
+ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+      </description>
+      <license-required>true</license-required>
+   </license>
+   <resourceadapter>
+      <resourceadapter-class>org.teiid.resource.adapter.mongodb.MongoDBResourceAdapter</resourceadapter-class>
+
+      <outbound-resourceadapter>
+         <connection-definition>
+            <managedconnectionfactory-class>org.teiid.resource.adapter.mongodb.MongoDBManagedConnectionFactory</managedconnectionfactory-class>
+
+            <config-property>
+               <description>{$display:"Server List", $description:"Server List (host:port[;host:port...]) to connect to", $required:"true"}</description>
+               <config-property-name>RemoteServerList</config-property-name>
+               <config-property-type>java.lang.String</config-property-type>
+            </config-property> 
+            
+            <config-property>
+               <description>{$display:"User Name", $description:"MongoDB Account User Name", $required:"false"}</description>
+               <config-property-name>Username</config-property-name>
+               <config-property-type>java.lang.String</config-property-type>
+            </config-property>
+            
+            <config-property>
+               <description>{$display:"Password",$description:"MongoDB Account Password",$required:"false",$masked:"true"}</description> 
+               <config-property-name>Password</config-property-name>
+               <config-property-type>java.lang.String</config-property-type>
+            </config-property> 
+            
+            <config-property>
+               <description>{$display:"Database",$description:"MongoDB Database Name",$required:"true"}</description> 
+               <config-property-name>Database</config-property-name>
+               <config-property-type>java.lang.String</config-property-type>
+            </config-property>             
+            
+            <connectionfactory-interface>javax.resource.cci.ConnectionFactory</connectionfactory-interface>
+            <connectionfactory-impl-class>org.teiid.resource.spi.WrappedConnectionFactory</connectionfactory-impl-class>
+            <connection-interface>javax.resource.cci.Connection</connection-interface>
+            <connection-impl-class>org.teiid.resource.spi.WrappedConnection</connection-impl-class>
+
+         </connection-definition>
+         
+         <transaction-support>NoTransaction</transaction-support>
+        
+        <authentication-mechanism>
+            <authentication-mechanism-type>BasicPassword</authentication-mechanism-type>
+            <credential-interface>javax.resource.spi.security.PasswordCredential</credential-interface>
+        </authentication-mechanism>
+        <reauthentication-support>false</reauthentication-support>
+      </outbound-resourceadapter>
+   </resourceadapter>
+</connector>

--- a/connectors/connector-mongodb/src/main/resources/org/teiid/resource/adapter/mongodb/i18n.properties
+++ b/connectors/connector-mongodb/src/main/resources/org/teiid/resource/adapter/mongodb/i18n.properties
@@ -1,0 +1,25 @@
+#
+# JBoss, Home of Professional Open Source.
+# See the COPYRIGHT.txt file distributed with this work for information
+# regarding copyright ownership.  Some portions may be licensed
+# to Red Hat, Inc. under one or more contributor license agreements.
+# 
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# 
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+# 
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA.
+#
+
+#
+no_server=No host and port information supplied for the mongodb connection
+no_database=No database name specified for mongodb connection

--- a/connectors/mongodb-api/pom.xml
+++ b/connectors/mongodb-api/pom.xml
@@ -1,0 +1,24 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>connectors</artifactId>
+        <groupId>org.jboss.teiid</groupId>
+        <version>8.4.0.Alpha2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>mongodb-api</artifactId>
+    <groupId>org.jboss.teiid.connectors</groupId>
+    <name>Salesforce API</name>
+    <description>The java API for the MongoDB</description>
+    <dependencies>
+        <dependency>
+            <groupId>javax.resource</groupId>
+            <artifactId>connector-api</artifactId>
+            <scope>provided</scope>
+        </dependency>     
+        <dependency>
+          <groupId>org.mongodb</groupId>
+          <artifactId>mongo-java-driver</artifactId>
+          <version>2.11.1</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/connectors/mongodb-api/src/main/java/org/teiid/mongodb/MongoDBConnection.java
+++ b/connectors/mongodb-api/src/main/java/org/teiid/mongodb/MongoDBConnection.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.mongodb;
+
+import javax.resource.cci.Connection;
+
+import com.mongodb.DB;
+
+public interface MongoDBConnection extends Connection {
+	public DB getDatabase();
+}

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -6,7 +6,6 @@
     <version>8.4.0.Beta3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.jboss.teiid</groupId>
   <artifactId>connectors</artifactId>
   <packaging>pom</packaging>
   <name>Connectors</name>
@@ -98,11 +97,11 @@
     <module>translator-file</module>
     <module>translator-salesforce</module>
     <module>connector-file</module>
-        <module>connector-google</module>
+    <module>connector-google</module>
     <module>connector-salesforce</module>
     <module>connector-ldap</module>
     <module>salesforce-api</module>
-        <module>google-api</module>
+    <module>google-api</module>
     <module>connector-ws</module>
     <module>sandbox</module>
     <module>translator-ws</module>
@@ -112,5 +111,8 @@
     <module>translator-object</module>
     <module>connector-infinispan</module>
     <module>translator-odata</module>
+    <module>mongodb-api</module>
+    <module>connector-mongodb</module>
+    <module>translator-mongodb</module>
   </modules>
 </project>

--- a/connectors/translator-mongodb/pom.xml
+++ b/connectors/translator-mongodb/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>connectors</artifactId>
+        <groupId>org.jboss.teiid</groupId>
+        <version>8.4.0.Alpha2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>translator-mongodb</artifactId>
+    <groupId>org.jboss.teiid.connectors</groupId>
+    <name>MongoDB Translator</name>
+    <description>This translator provides access to MongoDB</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.teiid</groupId>
+            <artifactId>teiid-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.teiid</groupId>
+            <artifactId>teiid-common-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.resource</groupId>
+            <artifactId>connector-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.teiid.connectors</groupId>
+            <artifactId>mongodb-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>   
+        <dependency>
+            <groupId>org.jboss.teiid.connectors</groupId>
+            <artifactId>translator-jdbc</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency> 
+    </dependencies>
+
+    <build>
+        <outputDirectory>target/classes</outputDirectory>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/*.xml</include>
+                    <include>**/*.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>**/*.xml</exclude>
+                    <exclude>**/*.properties</exclude>
+                </excludes>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/ColumnAlias.java
+++ b/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/ColumnAlias.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.mongodb;
+
+class ColumnAlias {
+	String projName;
+	String selName;
+
+	public ColumnAlias(String pName, String sName) {
+		this.projName = pName;
+		this.selName = sName;
+	}
+	@Override
+	public String toString() {
+		return this.projName+":"+this.selName; //$NON-NLS-1$
+	}
+}

--- a/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBBaseExecution.java
+++ b/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBBaseExecution.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.mongodb;
+
+import org.teiid.metadata.RuntimeMetadata;
+import org.teiid.mongodb.MongoDBConnection;
+import org.teiid.translator.ExecutionContext;
+
+import com.mongodb.DB;
+
+public class MongoDBBaseExecution {
+	protected ExecutionContext executionContext;
+	protected RuntimeMetadata metadata;
+	protected MongoDBConnection connection;
+	protected DB mongoDB;
+
+	protected MongoDBBaseExecution(ExecutionContext executionContext, RuntimeMetadata metadata, MongoDBConnection connection) {
+		this.executionContext = executionContext;
+		this.metadata = metadata;
+		this.connection = connection;
+		this.mongoDB = connection.getDatabase();
+	}
+}

--- a/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBDirectQueryExecution.java
+++ b/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBDirectQueryExecution.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.mongodb;
+
+import java.util.List;
+
+import org.teiid.language.Argument;
+import org.teiid.language.Command;
+import org.teiid.metadata.RuntimeMetadata;
+import org.teiid.mongodb.MongoDBConnection;
+import org.teiid.translator.DataNotAvailableException;
+import org.teiid.translator.ExecutionContext;
+import org.teiid.translator.ProcedureExecution;
+import org.teiid.translator.TranslatorException;
+
+public class MongoDBDirectQueryExecution extends MongoDBBaseExecution implements ProcedureExecution {
+
+	public MongoDBDirectQueryExecution(List<Argument> arguments, Command command,
+			ExecutionContext executionContext, RuntimeMetadata metadata,
+			MongoDBConnection connection, String nativeQuery, boolean returnsArray) {
+		super(executionContext, metadata, connection);
+
+
+	}
+
+	@Override
+	public List<?> next() throws TranslatorException, DataNotAvailableException {
+		return null;
+	}
+
+	@Override
+	public void execute() throws TranslatorException {
+	}
+
+	@Override
+	public List<?> getOutputParameterValues() throws TranslatorException {
+		return null;
+	}
+
+	@Override
+	public void close() {
+	}
+
+	@Override
+	public void cancel() throws TranslatorException {
+	}
+}

--- a/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBExecutionFactory.java
+++ b/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBExecutionFactory.java
@@ -1,0 +1,347 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.mongodb;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.SQLXML;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import javax.resource.cci.ConnectionFactory;
+
+import org.teiid.language.Argument;
+import org.teiid.language.Call;
+import org.teiid.language.Command;
+import org.teiid.language.QueryExpression;
+import org.teiid.language.visitor.SQLStringVisitor;
+import org.teiid.metadata.RuntimeMetadata;
+import org.teiid.mongodb.MongoDBConnection;
+import org.teiid.translator.ExecutionContext;
+import org.teiid.translator.ExecutionFactory;
+import org.teiid.translator.ProcedureExecution;
+import org.teiid.translator.ResultSetExecution;
+import org.teiid.translator.SourceSystemFunctions;
+import org.teiid.translator.Translator;
+import org.teiid.translator.TranslatorException;
+import org.teiid.translator.UpdateExecution;
+import org.teiid.translator.jdbc.AliasModifier;
+import org.teiid.translator.jdbc.FunctionModifier;
+
+import com.mongodb.DBRef;
+
+@Translator(name="mongodb", description="MongoDB Translator, reads and writes the data to MongoDB")
+public class MongoDBExecutionFactory extends ExecutionFactory<ConnectionFactory, MongoDBConnection> {
+	protected Map<String, FunctionModifier> functionModifiers = new TreeMap<String, FunctionModifier>(String.CASE_INSENSITIVE_ORDER);
+
+	public MongoDBExecutionFactory() {
+        registerFunctionModifier("%", new AliasModifier("$mod"));//$NON-NLS-1$ //$NON-NLS-2$
+        registerFunctionModifier("+", new AliasModifier("$add"));//$NON-NLS-1$ //$NON-NLS-2$
+        registerFunctionModifier("-", new AliasModifier("$subtract"));//$NON-NLS-1$ //$NON-NLS-2$
+        registerFunctionModifier("*", new AliasModifier("$multiply"));//$NON-NLS-1$ //$NON-NLS-2$
+        registerFunctionModifier("/", new AliasModifier("$divide"));//$NON-NLS-1$ //$NON-NLS-2$
+
+        registerFunctionModifier(SourceSystemFunctions.CONCAT, new AliasModifier("$concat"));//$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.SUBSTRING, new AliasModifier("$substr"));//$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.LCASE, new AliasModifier("$toLower"));//$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.UCASE, new AliasModifier("$toUpper"));//$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.DAYOFYEAR, new AliasModifier("$dayOfYear"));//$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.DAYOFMONTH, new AliasModifier("$dayOfMonth"));//$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.DAYOFWEEK, new AliasModifier("$dayOfWeek"));//$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.YEAR, new AliasModifier("$year"));//$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.MONTH, new AliasModifier("$month"));//$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.WEEK, new AliasModifier("$week"));//$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.HOUR, new AliasModifier("$hour"));//$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.MINUTE, new AliasModifier("$minute"));//$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.SECOND, new AliasModifier("$second"));//$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.IFNULL, new AliasModifier("$ifNull")); //$NON-NLS-1$
+	}
+
+	@Override
+	public void start() throws TranslatorException {
+		super.start();
+		setSupportsOrderBy(true);
+		setSupportsSelectDistinct(true);
+		setSupportsNativeQueries(false);
+		setSourceRequiredForMetadata(false);
+
+		setSupportsOuterJoins(true);
+		setSupportedJoinCriteria(SupportedJoinCriteria.KEY);
+	}
+
+    public void registerFunctionModifier(String name, FunctionModifier modifier) {
+    	this.functionModifiers.put(name, modifier);
+    }
+
+    public Map<String, FunctionModifier> getFunctionModifiers() {
+    	return this.functionModifiers;
+    }
+
+	@Override
+	public ResultSetExecution createResultSetExecution(QueryExpression command, ExecutionContext executionContext, RuntimeMetadata metadata, MongoDBConnection connection) throws TranslatorException {
+		return new MongoDBQueryExecution(this, command, executionContext, metadata, connection);
+	}
+
+	@Override
+	public ProcedureExecution createProcedureExecution(Call command, ExecutionContext executionContext, RuntimeMetadata metadata, MongoDBConnection connection) throws TranslatorException {
+		String nativeQuery = command.getMetadataObject().getProperty(SQLStringVisitor.TEIID_NATIVE_QUERY, false);
+		if (nativeQuery != null) {
+			return new MongoDBDirectQueryExecution(command.getArguments(), command, executionContext, metadata, connection, nativeQuery, false);
+		}
+		throw new TranslatorException(MongoDBPlugin.Util.gs(MongoDBPlugin.Event.TEIID18011));
+	}
+
+	@Override
+	public UpdateExecution createUpdateExecution(Command command, ExecutionContext executionContext, RuntimeMetadata metadata, MongoDBConnection connection) throws TranslatorException {
+		return new MongoDBUpdateExecution(this, command, executionContext, metadata, connection);
+	}
+
+	@Override
+	public ProcedureExecution createDirectExecution(List<Argument> arguments, Command command, ExecutionContext executionContext, RuntimeMetadata metadata, MongoDBConnection connection) throws TranslatorException {
+		 return new MongoDBDirectQueryExecution(arguments.subList(1, arguments.size()), command, executionContext, metadata, connection, (String)arguments.get(0).getArgumentValue().getValue(), true);
+	}
+
+	@Override
+	public boolean supportsSelfJoins() {
+		return true;
+	}
+
+    @Override
+	public boolean supportsCompareCriteriaEquals() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsCompareCriteriaOrdered() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsLikeCriteria() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsOrCriteria() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsOrderByUnrelated() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsGroupBy() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsHaving() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsAggregatesSum() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsAggregatesAvg() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsAggregatesMin() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsAggregatesMax() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsAggregatesCount() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsAggregatesCountStar() {
+    	return true;
+    }
+
+    @Override
+	public List<String> getSupportedFunctions() {
+        List<String> supportedFunctions = new ArrayList<String>();
+        supportedFunctions.addAll(getDefaultSupportedFunctions());
+
+        supportedFunctions.add(SourceSystemFunctions.MOD);
+        supportedFunctions.add(SourceSystemFunctions.CONCAT);
+        supportedFunctions.add(SourceSystemFunctions.SUBSTRING);
+        supportedFunctions.add(SourceSystemFunctions.LCASE);
+        supportedFunctions.add(SourceSystemFunctions.UCASE);
+        supportedFunctions.add(SourceSystemFunctions.DAYOFYEAR);
+        supportedFunctions.add(SourceSystemFunctions.DAYOFMONTH);
+        supportedFunctions.add(SourceSystemFunctions.DAYOFWEEK);
+        supportedFunctions.add(SourceSystemFunctions.YEAR);
+        supportedFunctions.add(SourceSystemFunctions.MONTH);
+        supportedFunctions.add(SourceSystemFunctions.WEEK);
+        supportedFunctions.add(SourceSystemFunctions.HOUR);
+        supportedFunctions.add(SourceSystemFunctions.MINUTE);
+        supportedFunctions.add(SourceSystemFunctions.SECOND);
+        supportedFunctions.add(SourceSystemFunctions.IFNULL);
+
+        return supportedFunctions;
+    }
+
+	public List<String> getDefaultSupportedFunctions(){
+		return Arrays.asList(new String[] { "+", "-", "*", "/", "%"}); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+	}
+
+    @Override
+	public boolean supportsInCriteria() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsNotCriteria() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsRowLimit() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsIsNullCriteria() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsRowOffset() {
+    	return true;
+    }
+
+    @Override
+	public boolean supportsBulkUpdate() {
+    	return false;
+    }
+
+	@Override
+	public boolean supportsLikeRegex() {
+		return true;
+	}
+
+    @Override
+	public boolean supportsSelectExpression() {
+    	return true;
+    }
+
+	/**
+	 * @param field
+	 * @param expectedClass
+	 * @return
+	 */
+	public Object retrieveValue(Object value, Class<?> expectedClass) {
+		if (value == null) {
+			return null;
+		}
+
+		if (value.getClass().equals(expectedClass)) {
+			return value;
+		}
+
+		if (value instanceof DBRef) {
+			return ((DBRef)value).getId();
+		}
+		else if (value instanceof java.util.Date && expectedClass.equals(java.sql.Date.class)) {
+			return new java.sql.Date(((java.util.Date) value).getTime());
+		}
+		else if (value instanceof java.util.Date && expectedClass.equals(java.sql.Timestamp.class)) {
+			return new java.sql.Timestamp(((java.util.Date) value).getTime());
+		}
+		else if (value instanceof java.util.Date && expectedClass.equals(java.sql.Time.class)) {
+			return new java.sql.Time(((java.util.Date) value).getTime());
+		}
+		else if (value instanceof String && expectedClass.equals(BigDecimal.class)) {
+			return new BigDecimal((String)value);
+		}
+		else if (value instanceof String && expectedClass.equals(BigInteger.class)) {
+			return new BigInteger((String)value);
+		}
+		else if (value instanceof String && expectedClass.equals(Character.class)) {
+			return new Character(((String)value).charAt(0));
+		}
+		return value;
+	}
+
+	/**
+	 * Mongodb only supports certain data types, Teiid need to serialize them in other compatible
+	 * formats, and convert them back while reading them.
+	 * @param value
+	 * @return
+	 */
+	public Object convertToMongoType(Object value) throws TranslatorException {
+		if (value == null) {
+			return null;
+		}
+
+		if (value instanceof BigDecimal) {
+			return ((BigDecimal)value).toPlainString();
+		}
+		else if (value instanceof BigInteger) {
+			return ((BigInteger)value).toString();
+		}
+		else if (value instanceof Character) {
+			return ((Character)value).toString();
+		}
+		else if (value instanceof java.sql.Date) {
+			return new java.util.Date(((java.sql.Date)value).getTime());
+		}
+		else if (value instanceof java.sql.Time) {
+			return new java.util.Date(((java.sql.Time)value).getTime());
+		}
+		else if (value instanceof java.sql.Timestamp) {
+			return new java.util.Date(((java.sql.Timestamp)value).getTime());
+		}
+		else if (value instanceof Blob) {
+			//TODO:
+			throw new TranslatorException();
+		}
+		else if (value instanceof Clob) {
+			//TODO:
+			throw new TranslatorException();
+		}
+		else if (value instanceof SQLXML) {
+			//TODO:
+			throw new TranslatorException();
+		}
+		return value;
+	}
+}

--- a/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBPlugin.java
+++ b/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBPlugin.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.mongodb;
+
+import java.util.ResourceBundle;
+
+import org.teiid.core.BundleUtil;
+
+
+public class MongoDBPlugin {
+
+    public static final String PLUGIN_ID = "org.teiid.translator.mongodb" ; //$NON-NLS-1$
+
+    private static final String BUNDLE_NAME = PLUGIN_ID + ".i18n"; //$NON-NLS-1$
+    public static final BundleUtil Util = new BundleUtil(PLUGIN_ID,BUNDLE_NAME,ResourceBundle.getBundle(BUNDLE_NAME));
+
+    public static enum Event implements BundleUtil.Event{
+    	TEIID18001,
+    	TEIID18002,
+    	TEIID18003,
+    	TEIID18004,
+    	TEIID18005,
+    	TEIID18006,
+    	TEIID18007,
+    	TEIID18008,
+    	TEIID18009,
+    	TEIID18010,
+    	TEIID18011
+    }
+}

--- a/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBQueryExecution.java
+++ b/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBQueryExecution.java
@@ -1,0 +1,132 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.mongodb;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.teiid.language.QueryExpression;
+import org.teiid.language.Select;
+import org.teiid.logging.LogConstants;
+import org.teiid.logging.LogManager;
+import org.teiid.metadata.RuntimeMetadata;
+import org.teiid.mongodb.MongoDBConnection;
+import org.teiid.translator.DataNotAvailableException;
+import org.teiid.translator.ExecutionContext;
+import org.teiid.translator.ResultSetExecution;
+import org.teiid.translator.TranslatorException;
+
+import com.mongodb.AggregationOutput;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+
+public class MongoDBQueryExecution extends MongoDBBaseExecution implements ResultSetExecution {
+	private Select command;
+	private MongoDBExecutionFactory executionFactory;
+	private Iterator<DBObject> results;
+	private MongoDBSelectVisitor visitor;
+	private Class<?>[] expectedTypes;
+
+	public MongoDBQueryExecution(
+			MongoDBExecutionFactory executionFactory,
+			QueryExpression command, ExecutionContext executionContext,
+			RuntimeMetadata metadata, MongoDBConnection connection) {
+		super(executionContext, metadata, connection);
+		this.command = (Select)command;
+		this.executionFactory = executionFactory;
+		this.expectedTypes = command.getColumnTypes();
+
+	}
+
+	@Override
+	public void execute() throws TranslatorException {
+		this.visitor = new MongoDBSelectVisitor(this.executionFactory, this.metadata);
+		this.visitor.visitNode(this.command);
+
+		if (!this.visitor.exceptions.isEmpty()) {
+    		throw this.visitor.exceptions.get(0);
+    	}
+
+		LogManager.logInfo(LogConstants.CTX_CONNECTOR, this.command);
+
+		DBCollection collection = this.mongoDB.getCollection(this.visitor.collectionName);
+		if (collection != null) {
+			// TODO: check to see how to pass the hint
+			ArrayList<DBObject> ops = new ArrayList<DBObject>();
+			if (this.visitor.projectBeforeMatch) {
+				buildAggregate(ops, "$project", this.visitor.project); //$NON-NLS-1$
+			}
+			buildAggregate(ops, "$match", this.visitor.match); //$NON-NLS-1$
+			if (!this.visitor.unwindTables.isEmpty()) {
+				for (String name:this.visitor.unwindTables) {
+					buildAggregate(ops, "$unwind", "$"+name); //$NON-NLS-1$ //$NON-NLS-2$
+				}
+			}
+			buildAggregate(ops, "$group", this.visitor.group); //$NON-NLS-1$
+			buildAggregate(ops, "$match", this.visitor.having); //$NON-NLS-1$
+
+			if (!this.visitor.projectBeforeMatch) {
+				buildAggregate(ops, "$project", this.visitor.project); //$NON-NLS-1$
+			}
+			buildAggregate(ops, "$sort", this.visitor.sort); //$NON-NLS-1$
+			buildAggregate(ops, "$skip", this.visitor.skip); //$NON-NLS-1$
+			buildAggregate(ops, "$limit", this.visitor.limit); //$NON-NLS-1$
+
+			AggregationOutput output = collection.aggregate(ops.remove(0), ops.toArray(new DBObject[ops.size()]));
+			this.results = output.results().iterator();
+		}
+	}
+
+	private void buildAggregate(List<DBObject> query, String type, Object object) {
+		if (object != null) {
+			LogManager.logInfo(LogConstants.CTX_CONNECTOR, type+":"+object.toString()); //$NON-NLS-1$
+			query.add(new BasicDBObject(type, object));
+		}
+	}
+
+	@Override
+	public List<?> next() throws TranslatorException, DataNotAvailableException {
+		if (this.results != null && this.results.hasNext()) {
+			DBObject result = this.results.next();
+			if (result != null) {
+				ArrayList row = new ArrayList();
+				for (int i = 0; i < this.visitor.selectColumns.size();i++) {
+					row.add(this.executionFactory.retrieveValue(result.get(this.visitor.selectColumns.get(i)), this.expectedTypes[i]));
+				}
+				return row;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public void close() {
+		this.results = null;
+	}
+
+	@Override
+	public void cancel() throws TranslatorException {
+		close();
+	}
+}

--- a/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBSelectVisitor.java
+++ b/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBSelectVisitor.java
@@ -1,0 +1,744 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.mongodb;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Stack;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.teiid.language.*;
+import org.teiid.language.SortSpecification.Ordering;
+import org.teiid.language.visitor.HierarchyVisitor;
+import org.teiid.metadata.AbstractMetadataRecord;
+import org.teiid.metadata.ForeignKey;
+import org.teiid.metadata.RuntimeMetadata;
+import org.teiid.metadata.Table;
+import org.teiid.translator.TranslatorException;
+import org.teiid.translator.mongodb.MutableDBRef.Assosiation;
+
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import com.mongodb.QueryBuilder;
+
+public class MongoDBSelectVisitor extends HierarchyVisitor {
+	private static final String EMBEDIN = "EMBEDIN"; //$NON-NLS-1$
+	private static final String EMBEDDABLE = "EMBEDDABLE"; //$NON-NLS-1$
+
+    private AtomicInteger aliasCount = new AtomicInteger();
+	protected MongoDBExecutionFactory executionFactory;
+	protected RuntimeMetadata metadata;
+	private Select command;
+	protected ArrayList<TranslatorException> exceptions = new ArrayList<TranslatorException>();
+
+	protected Stack<DBObject> onGoingCriteria = new Stack<DBObject>();
+	protected Stack<Object> onGoingExpression  = new Stack<Object>();
+	protected ConcurrentHashMap<Object, ColumnAlias> expressionMap = new ConcurrentHashMap<Object, ColumnAlias>();
+	private HashMap<String, Object> groupByProjections = new HashMap<String, Object>();
+	protected ColumnAlias onGoingAlias;
+
+	protected MutableDBRef pushKey;
+	protected List<MutableDBRef> pullKeys = new ArrayList<MutableDBRef>();
+	protected LinkedHashMap<String, MutableDBRef> foreignKeys = new LinkedHashMap<String, MutableDBRef>();
+	protected ArrayList<MutableDBRef> tableCopiedIn = new ArrayList<MutableDBRef>();
+
+	// derived stuff
+	protected String collectionName;
+	protected NamedTable collectionTable;
+	protected BasicDBObject project = new BasicDBObject();
+	protected Integer limit;
+	protected Integer skip;
+	protected DBObject sort;
+	protected DBObject match;
+	protected DBObject having;
+	protected DBObject group;
+	protected ArrayList<String> selectColumns = new ArrayList<String>();
+	protected boolean projectBeforeMatch = false;
+	protected LinkedList<String> unwindTables = new LinkedList<String>();
+	protected TableReference joinParentTable = null;
+	protected boolean processJoin = true;
+	protected ArrayList<Condition> pendingCondictions = new ArrayList<Condition>();
+
+	public MongoDBSelectVisitor(MongoDBExecutionFactory executionFactory, RuntimeMetadata metadata) {
+		this.executionFactory = executionFactory;
+		this.metadata = metadata;
+	}
+
+    /**
+     * Appends the string form of the LanguageObject to the current buffer.
+     * @param obj the language object instance
+     */
+    public void append(LanguageObject obj) {
+        if (obj != null) {
+            visitNode(obj);
+        }
+    }
+
+    /**
+     * Simple utility to append a list of language objects to the current buffer
+     * by creating a comma-separated list.
+     * @param items a list of LanguageObjects
+     */
+    protected void append(List<? extends LanguageObject> items) {
+        if (items != null && items.size() != 0) {
+            append(items.get(0));
+            for (int i = 1; i < items.size(); i++) {
+                append(items.get(i));
+            }
+        }
+    }
+
+    /**
+     * Simple utility to append an array of language objects to the current buffer
+     * by creating a comma-separated list.
+     * @param items an array of LanguageObjects
+     */
+    protected void append(LanguageObject[] items) {
+        if (items != null && items.length != 0) {
+            append(items[0]);
+            for (int i = 1; i < items.length; i++) {
+                append(items[i]);
+            }
+        }
+    }
+
+	public static String getRecordName(AbstractMetadataRecord object) {
+		String nameInSource = object.getNameInSource();
+        if(nameInSource != null && nameInSource.length() > 0) {
+            return nameInSource;
+        }
+        return object.getName();
+    }
+
+	public String getColumnName(ColumnReference obj) {
+		String elemShortName = null;
+		AbstractMetadataRecord elementID = obj.getMetadataObject();
+        if(elementID != null) {
+            elemShortName = getRecordName(elementID);
+        } else {
+            elemShortName = obj.getName();
+        }
+		return elemShortName;
+	}
+
+	@Override
+	public void visit(DerivedColumn obj) {
+		this.onGoingAlias = buildAlias(obj.getAlias());
+		append(obj.getExpression());
+
+		Object expr = this.onGoingExpression.pop();
+
+		ColumnAlias previousAlias = this.expressionMap.putIfAbsent(expr, this.onGoingAlias);
+		if (previousAlias == null) {
+			previousAlias = this.onGoingAlias;
+		}
+
+		if (this.command != null && this.command.isDistinct()) {
+			this.groupByProjections.put(previousAlias.projName, expr);
+		}
+
+		if (obj.getExpression() instanceof ColumnReference) {
+			// the the expression is already part of group by then the projection should be $_id.{name}
+			Object id = this.groupByProjections.get("_id"); //$NON-NLS-1$
+			if (id == null && this.groupByProjections.get(previousAlias.projName) != null) {
+				// this is DISTINCT case
+				this.project.append(this.onGoingAlias.projName, "$_id."+previousAlias.projName); //$NON-NLS-1$
+				this.selectColumns.add(this.onGoingAlias.projName);
+			}
+			else if (id != null
+					&& ((id instanceof String) && id.equals(previousAlias.projName))
+					|| ((id instanceof BasicDBObject) && ((BasicDBObject) id).get(previousAlias.projName) != null)) {
+				this.project.append(this.onGoingAlias.projName, "$_id."+previousAlias.projName); //$NON-NLS-1$
+				this.selectColumns.add(this.onGoingAlias.projName);
+			}
+			else {
+				this.project.append(this.onGoingAlias.projName, expr);
+				this.selectColumns.add(this.onGoingAlias.projName);
+
+				//this.project.append(previousAlias.projName, expr);
+				//this.selectColumns.add(previousAlias.projName);
+			}
+		}
+		else {
+			// what user sees as project
+			this.selectColumns.add(previousAlias.projName);
+		}
+		this.onGoingAlias = null;
+	}
+
+	private ColumnAlias buildAlias(String alias) {
+		if (alias == null) {
+			String str = "_m"+this.aliasCount.getAndIncrement(); //$NON-NLS-1$
+			return new ColumnAlias(str, str);
+		}
+		return new ColumnAlias(alias, alias);
+	}
+
+	@Override
+	public void visit(ColumnReference obj) {
+		String elemShortName = getColumnName(obj);
+		String mongoExpr = "$"+elemShortName; //$NON-NLS-1$
+
+		if (obj.getMetadataObject() == null) {
+			for (Object expr:this.expressionMap.keySet()) {
+				ColumnAlias alias = this.expressionMap.get(expr);
+				if (alias.projName.equals(elemShortName)) {
+					this.onGoingExpression.push(expr);
+					break;
+				}
+			}
+		}
+		else {
+			if (obj.getMetadataObject().getParent() instanceof Table) {
+				Table parent = (Table)obj.getMetadataObject().getParent();
+				String embedIn = parent.getProperty(EMBEDIN, false);
+				boolean embeddable = Boolean.parseBoolean(parent.getProperty(EMBEDDABLE, false));
+				if (!parent.getName().equals(this.collectionName) && (embedIn != null || embeddable)){
+					mongoExpr = "$"+parent.getName()+"."+elemShortName; //$NON-NLS-1$ //$NON-NLS-2$
+					elemShortName = parent.getName()+"."+elemShortName; //$NON-NLS-1$
+				}
+			}
+
+			// if the column is PK column, it is DBRef, so correct de-reference needed.
+			String selectionName = elemShortName;
+			String colName = obj.getMetadataObject().getName();
+			MutableDBRef ref = this.foreignKeys.get(colName);
+			if (ref != null) {
+				selectionName = elemShortName+".$id"; //$NON-NLS-1$
+			}
+
+			this.onGoingExpression.push(mongoExpr);
+
+			if (this.onGoingAlias == null) {
+				this.expressionMap.putIfAbsent(mongoExpr, new ColumnAlias(elemShortName, selectionName));
+			}
+		}
+	}
+
+    @Override
+	public void visit(AggregateFunction obj) {
+    	if (!obj.getParameters().isEmpty()) {
+    		append(obj.getParameters());
+    	}
+    	else {
+			// this is only true for count(*) case, so we need implicit group id clause
+    		this.onGoingExpression.push(new Integer(1));
+    		this.groupByProjections.put("_id", null); //$NON-NLS-1$
+    	}
+
+    	BasicDBObject expr = null;
+		if (obj.getName().equals(AggregateFunction.COUNT)) {
+			expr = new BasicDBObject("$sum", this.onGoingExpression.pop()); //$NON-NLS-1$
+		}
+		else if (obj.getName().equals(AggregateFunction.AVG)) {
+			expr = new BasicDBObject("$avg", this.onGoingExpression.pop()); //$NON-NLS-1$
+		}
+		else if (obj.getName().equals(AggregateFunction.SUM)) {
+			expr = new BasicDBObject("$sum", this.onGoingExpression.pop()); //$NON-NLS-1$
+		}
+		else if (obj.getName().equals(AggregateFunction.MIN)) {
+			expr = new BasicDBObject("$min", this.onGoingExpression.pop()); //$NON-NLS-1$
+		}
+		else if (obj.getName().equals(AggregateFunction.MAX)) {
+			expr = new BasicDBObject("$max", this.onGoingExpression.pop()); //$NON-NLS-1$
+		}
+		else {
+			this.exceptions.add(new TranslatorException(MongoDBPlugin.Util.gs(MongoDBPlugin.Event.TEIID18005, obj.getName())));
+		}
+
+		if (expr != null) {
+			ColumnAlias alias = addToProject(expr, false);
+			if (!this.groupByProjections.values().contains(expr)) {
+				this.groupByProjections.put(alias.projName, expr);
+			}
+			this.onGoingExpression.push(expr);
+		}
+    }
+
+	private ColumnAlias addToProject(BasicDBObject expr, boolean addExprAsProject) {
+		ColumnAlias previousAlias = this.expressionMap.get(expr);
+		if (previousAlias == null) {
+			// if expression is in having clause there is will be no alias; however mongo expects this
+			// to be elevated to grouping clause
+			previousAlias = this.onGoingAlias;
+			if (this.onGoingAlias == null) {
+				this.projectBeforeMatch = true;
+				previousAlias = buildAlias(null);
+			}
+			this.expressionMap.putIfAbsent(expr, previousAlias);
+		}
+
+		if (this.project.get(previousAlias.projName) == null && !this.project.values().contains(expr)) {
+			this.project.append(previousAlias.projName, addExprAsProject?expr:1);
+		}
+		return previousAlias;
+	}
+
+	@Override
+	public void visit(Function obj) {
+    	if (this.executionFactory.getFunctionModifiers().containsKey(obj.getName())) {
+            this.executionFactory.getFunctionModifiers().get(obj.getName()).translate(obj);
+    	}
+    	BasicDBObject expr = null;
+    	List<Expression> args = obj.getParameters();
+		if (args != null) {
+			BasicDBList params = new BasicDBList();
+			for (int i = 0; i < args.size(); i++) {
+				append(args.get(i));
+				Object param = this.onGoingExpression.pop();
+				params.add(param);
+			}
+			expr = new BasicDBObject(obj.getName(), params);
+		}
+
+		if(expr != null) {
+			addToProject(expr, true);
+			this.onGoingExpression.push(expr);
+		}
+	}
+
+	@Override
+	public void visit(NamedTable obj) {
+		this.collectionTable = obj;
+		AbstractMetadataRecord metadataID = obj.getMetadataObject();
+		if (metadataID != null) {
+			this.collectionName = getRecordName(metadataID);
+		}
+		else {
+			this.collectionName = obj.getName();
+		}
+		buildForeignDocumentKeys(obj);
+	}
+
+
+	@Override
+	public void visit(Join obj) {
+
+		if (obj.getLeftItem() instanceof Join) {
+			this.processJoin = false;
+			append(obj.getLeftItem());
+			processJoin(this.joinParentTable, obj.getRightItem(), obj.getCondition());
+			this.processJoin = true;
+		}
+		else {
+			processJoin(obj.getLeftItem(), obj.getRightItem(), obj.getCondition());
+		}
+
+		if (this.processJoin) {
+			append(this.joinParentTable);
+//			for (Condition c:this.pendingCondictions) {
+//				append(c);
+//			}
+		}
+	}
+
+	private void processJoin(TableReference leftTable, TableReference rightTable, Condition cond) {
+		Table left = ((NamedTable)leftTable).getMetadataObject();
+		Table right = ((NamedTable)rightTable).getMetadataObject();
+
+        String embedInTable = left.getProperty(EMBEDIN, false);
+        boolean embeddable = Boolean.parseBoolean(left.getProperty(EMBEDDABLE, false));
+
+        boolean singleDocument = false;
+
+        // If the left table is "embedIn" then right is parent.
+        if ((embedInTable != null && embedInTable.equals(right.getName())) || embeddable) {
+        	this.joinParentTable = rightTable;
+        	this.unwindTables.addLast(left.getName());
+        	singleDocument = true;
+        }
+
+        if (!singleDocument) {
+	        embedInTable = right.getProperty(EMBEDIN, false);
+	        embeddable = Boolean.parseBoolean(right.getProperty(EMBEDDABLE, false));
+
+	        // If the right table is "embedIn" then left is parent.
+	        if ((embedInTable != null && embedInTable.equals(left.getName())) || embeddable) {
+	        	this.joinParentTable = leftTable;
+	        	this.unwindTables.addLast(right.getName());
+	        	singleDocument = true;
+	        }
+        }
+
+        if (!singleDocument) {
+        	this.exceptions.add(new TranslatorException("no relation between left and right")); //$NON-NLS-1$
+        }
+
+        if (cond != null) {
+        	this.pendingCondictions.add(cond);
+        }
+	}
+
+    @Override
+    public void visit(Select obj) {
+    	this.command = obj;
+
+        if (obj.getFrom() != null && !obj.getFrom().isEmpty()) {
+        	append(obj.getFrom());
+        }
+
+        // add ansi join conditions
+//        if (!this.onGoingCriteria.isEmpty()) {
+//        	if (this.onGoingCriteria.size() == 1) {
+//        		this.match = this.onGoingCriteria.pop();
+//        	}
+//        	else {
+//        		DBObject m = null;
+//        		for (int i = 0; i < this.onGoingCriteria.size(); i++) {
+//        			if (m == null) {
+//        				m = this.onGoingCriteria.pop();
+//        			}
+//        			m = QueryBuilder.start().and(m, this.onGoingCriteria.pop()).get();
+//        		}
+//        		this.match = m;
+//        	}
+//        }
+
+        if (obj.getWhere() != null) {
+            append(obj.getWhere());
+        }
+
+        if (!this.onGoingCriteria.isEmpty()) {
+        	if (this.match != null) {
+        		this.match = QueryBuilder.start().and(this.match, this.onGoingCriteria.pop()).get();
+        	}
+        	else {
+        		this.match = this.onGoingCriteria.pop();
+        	}
+        }
+
+        if (obj.getGroupBy() != null) {
+            append(obj.getGroupBy());
+        }
+
+    	append(obj.getDerivedColumns());
+
+    	// if group by does not exist then build the group root id based on distinct
+		if (obj.getGroupBy() == null && obj.isDistinct() && this.groupByProjections != null
+				&& !this.groupByProjections.containsKey("_id")) { //$NON-NLS-1$
+			// in distinct since there may not be group by, but mongo requires a grouping clause.
+			BasicDBObject _id = new BasicDBObject(this.groupByProjections);
+			this.groupByProjections.clear();
+			this.groupByProjections.put("_id", _id); //$NON-NLS-1$
+		}
+
+        if (obj.getHaving() != null) {
+            append(obj.getHaving());
+        }
+
+        if (!this.onGoingCriteria.isEmpty()) {
+        	this.having = this.onGoingCriteria.pop();
+        }
+
+        if (!this.groupByProjections.isEmpty()) {
+            if (!this.groupByProjections.containsKey("_id")) { //$NON-NLS-1$
+            	this.groupByProjections.put("_id", null); //$NON-NLS-1$
+            }
+        	this.group = new BasicDBObject(this.groupByProjections);
+        }
+
+        if (obj.getOrderBy() != null) {
+            append(obj.getOrderBy());
+        }
+
+        if (obj.getLimit() != null) {
+        	 append(obj.getLimit());
+        }
+    }
+
+	@Override
+	public void visit(Comparison obj) {
+        QueryBuilder query = getQueryObject(obj.getLeftExpression());
+        append(obj.getRightExpression());
+
+        Object rightExpr = this.onGoingExpression.pop();
+        if (this.expressionMap.get(rightExpr) != null) {
+        	rightExpr = this.expressionMap.get(rightExpr).projName;
+        }
+        if (query != null) {
+        	switch(obj.getOperator()) {
+	        case EQ:
+	        	query.is(rightExpr);
+	        	break;
+	        case NE:
+	        	query.notEquals(rightExpr);
+	        	break;
+	        case LT:
+	        	query.lessThan(rightExpr);
+	        	break;
+	        case LE:
+	        	query.lessThanEquals(rightExpr);
+	        	break;
+	        case GT:
+	        	query.greaterThan(rightExpr);
+	        	break;
+	        case GE:
+	        	query.greaterThanEquals(rightExpr);
+	        	break;
+	        }
+        	this.onGoingCriteria.push(query.get());
+        }
+	}
+
+	@Override
+    public void visit(AndOr obj) {
+		append(obj.getLeftCondition());
+		append(obj.getRightCondition());
+        DBObject right = this.onGoingCriteria.pop();
+        DBObject left = this.onGoingCriteria.pop();
+
+        switch(obj.getOperator()) {
+        case AND:
+        	this.onGoingCriteria.push(QueryBuilder.start().and(left, right).get());
+        	break;
+        case OR:
+        	this.onGoingCriteria.push(QueryBuilder.start().or(left, right).get());
+        	break;
+        }
+    }
+
+	@Override
+	public void visit(Literal obj) {
+		try {
+			this.onGoingExpression.push(this.executionFactory.convertToMongoType(obj.getValue()));
+		} catch (TranslatorException e) {
+			this.exceptions.add(e);
+		}
+	}
+
+	@Override
+	public void visit(In obj) {
+        QueryBuilder query = getQueryObject(obj.getLeftExpression());
+
+    	append(obj.getRightExpressions());
+
+        BasicDBList values = new BasicDBList();
+        for (int i = 0; i < obj.getRightExpressions().size(); i++) {
+        	values.add(0, this.onGoingExpression.pop());
+        }
+
+		if (query != null) {
+			if (obj.isNegated()) {
+				query.notIn(values);
+			} else {
+				query.in(values);
+			}
+			this.onGoingCriteria.push(query.get());
+		}
+	}
+
+	private QueryBuilder getQueryObject(Expression obj) {
+		// the way DBRef names handled in projection vs selection is different.
+		// in projection we want to see as "col" mapped to "col.$_id" as it is treated as sub-document
+		// where as in selection it will should be "col._id".
+		append(obj);
+
+		Object expr = this.onGoingExpression.pop();
+		ColumnAlias exprAlias = this.expressionMap.get(expr);
+		if (exprAlias == null) {
+			//exprAlias = buildAlias(null);
+			//this.expressionMap.put(expr, exprAlias);
+		}
+
+		// when expression shows up in a condition, but it is not a derived column
+		// then add implicit project on that alias.
+		return QueryBuilder.start(exprAlias.selName);
+	}
+
+	@Override
+	public void visit(IsNull obj) {
+		QueryBuilder query = getQueryObject(obj.getExpression());
+		if (query != null) {
+			if (obj.isNegated()) {
+				query.notEquals(null);
+			}
+			else {
+				query.is(null);
+			}
+			this.onGoingCriteria.push(query.get());
+		}
+	}
+
+	@Override
+	public void visit(Like obj) {
+		QueryBuilder query = getQueryObject(obj.getLeftExpression());
+		if (query != null) {
+			if (obj.isNegated()) {
+				query.not();
+			}
+
+			append(obj.getRightExpression());
+
+			StringBuilder value = new StringBuilder((String)this.onGoingExpression.pop());
+			int idx = -1;
+			while (true) {
+				idx = value.indexOf("%", idx+1);//$NON-NLS-1$
+				if (idx != -1 && idx == 0) {
+					continue;
+				}
+				if (idx != -1 && idx == value.length()-1) {
+					continue;
+				}
+
+				if (idx == -1) {
+					break;
+				}
+				value.replace(idx, idx+1, ".*"); //$NON-NLS-1$
+			}
+
+			if (value.charAt(0) != '%') {
+				value.insert(0, '^');
+			}
+
+			idx = value.length();
+			if (value.charAt(idx-1) != '%') {
+				value.insert(idx, '$');
+			}
+
+			String regex = value.toString().replaceAll("%", ""); //$NON-NLS-1$ //$NON-NLS-2$
+			query.is("/"+regex+"/"); //$NON-NLS-1$ //$NON-NLS-2$
+			//query.regex(Pattern.compile(regex));
+			this.onGoingCriteria.push(query.get());
+		}
+	}
+
+	@Override
+	public void visit(Limit obj) {
+		this.limit = new Integer(obj.getRowLimit());
+		this.skip = new Integer(obj.getRowOffset());
+	}
+
+	@Override
+	public void visit(OrderBy obj) {
+		append(obj.getSortSpecifications());
+	}
+
+	@Override
+	public void visit(SortSpecification obj) {
+		append(obj.getExpression());
+		Object expr = this.onGoingExpression.pop();
+		ColumnAlias alias = this.expressionMap.get(expr);
+		if (this.sort == null) {
+			this.sort =  new BasicDBObject(alias.projName, (obj.getOrdering() == Ordering.ASC)?1:-1);
+		}
+		else {
+			this.sort.put(alias.projName, (obj.getOrdering() == Ordering.ASC)?1:-1);
+		}
+	}
+
+	@Override
+	public void visit(GroupBy obj) {
+		if (obj.getElements().size() == 1) {
+			append(obj.getElements().get(0));
+			Object mongoExpr = this.onGoingExpression.pop();
+			this.groupByProjections.put("_id", mongoExpr); //$NON-NLS-1$
+		}
+		else {
+			BasicDBObject fields = new BasicDBObject();
+			for (Expression expr : obj.getElements()) {
+				append(expr);
+				Object mongoExpr = this.onGoingExpression.pop();
+				ColumnAlias alias = this.expressionMap.get(mongoExpr);
+				fields.put(alias.projName, mongoExpr);
+			}
+			this.groupByProjections.put("_id", fields); //$NON-NLS-1$
+
+		}
+	}
+
+	protected void buildForeignDocumentKeys(NamedTable obj) {
+		Table table = obj.getMetadataObject();
+        String embedInTable = table.getProperty(EMBEDIN, false);
+        boolean embeddable = Boolean.parseBoolean(table.getProperty(EMBEDDABLE, false));
+
+        if (embeddable) {
+        	// check to what other tables got relations to this table
+        	for (Table t:table.getParent().getTables().values()) {
+        		for (ForeignKey fk:t.getForeignKeys()) {
+        			if (fk.getReferenceTableName().equals(table.getName())){
+        				MutableDBRef ref = new MutableDBRef();
+        				ref.setParentTable(t.getName());
+        				ref.setEmbeddedTable(table.getName());
+        				ref.setColumnName(fk.getColumns().get(0).getName());
+        				ref.setReferenceColumnName(fk.getReferenceColumns().get(0));
+        				ref.setAssosiation(Assosiation.ONE);
+        				this.tableCopiedIn.add(ref);
+        			}
+        		}
+        	}
+        }
+
+    	// look through the fk, and add DBRefs for each of them.
+    	for (ForeignKey fk:table.getForeignKeys()) {
+			MutableDBRef ref = new MutableDBRef();
+			ref.setParentTable(fk.getReferenceTableName());
+			this.foreignKeys.put(fk.getColumns().get(0).getName(), ref);
+
+			try {
+				Table referenceTable = this.metadata.getTable(table.getParent().getFullName()+"."+fk.getReferenceTableName()); //$NON-NLS-1$
+				boolean embedReferenceTbl = Boolean.parseBoolean(referenceTable.getProperty(EMBEDDABLE, false));
+				if (embedReferenceTbl) {
+					MutableDBRef pullKey = new MutableDBRef();
+					pullKey.setParentTable(this.collectionName);
+					pullKey.setColumnName(fk.getColumns().get(0).getName());
+					pullKey.setReferenceColumnName(fk.getReferenceColumns().get(0));
+					pullKey.setEmbeddedTable(fk.getReferenceTableName());
+					this.pullKeys.add(pullKey);
+				}
+
+				// if matches to 1to1 or many-to-one embedded scenario, build key to query the parent
+				// document.
+				if (embedInTable != null && fk.getReferenceTableName().equalsIgnoreCase(embedInTable)) {
+					this.pushKey = new MutableDBRef();
+					this.pushKey.setParentTable(embedInTable);
+					this.pushKey.setColumnName(fk.getColumns().get(0).getName());
+					this.pushKey.setReferenceColumnName(fk.getReferenceColumns().get(0));
+					this.pushKey.setEmbeddedTable(this.collectionName);
+					this.pushKey.setAssosiation(Assosiation.MANY);
+					this.unwindTables.addLast(this.collectionName);
+
+					// check to see if the parent table has relation to this table, if yes
+					// then it is one-to-one, other wise many-to-one
+					Table parentTable = this.metadata.getTable(table.getParent().getFullName()+"."+embedInTable); //$NON-NLS-1$
+					for (ForeignKey fk1:parentTable.getForeignKeys()) {
+						if (fk1.getReferenceTableName().equals(table.getName())) {
+							this.pushKey.setAssosiation(Assosiation.ONE);
+							this.unwindTables.removeLast();
+							break;
+						}
+					}
+				}
+			} catch (TranslatorException e) {
+				this.exceptions.add(e);
+			}
+    	}
+
+        if (this.pushKey != null) {
+        	this.collectionName = embedInTable;
+        }
+	}
+}

--- a/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBUpdateExecution.java
+++ b/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBUpdateExecution.java
@@ -1,0 +1,268 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.mongodb;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.teiid.GeneratedKeys;
+import org.teiid.language.Command;
+import org.teiid.language.Insert;
+import org.teiid.language.Update;
+import org.teiid.metadata.Column;
+import org.teiid.metadata.ForeignKey;
+import org.teiid.metadata.KeyRecord;
+import org.teiid.metadata.RuntimeMetadata;
+import org.teiid.metadata.Table;
+import org.teiid.mongodb.MongoDBConnection;
+import org.teiid.translator.DataNotAvailableException;
+import org.teiid.translator.ExecutionContext;
+import org.teiid.translator.TranslatorException;
+import org.teiid.translator.UpdateExecution;
+import org.teiid.translator.mongodb.MutableDBRef.Assosiation;
+
+import com.mongodb.AggregationOutput;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.DBRef;
+import com.mongodb.WriteConcern;
+import com.mongodb.WriteResult;
+
+public class MongoDBUpdateExecution extends MongoDBBaseExecution implements UpdateExecution {
+	private Command command;
+	private MongoDBUpdateVisitor visitor;
+	private MongoDBExecutionFactory executionFactory;
+	private int[] results;
+
+	public MongoDBUpdateExecution(MongoDBExecutionFactory executionFactory,
+			Command command,
+			ExecutionContext executionContext, RuntimeMetadata metadata,
+			MongoDBConnection connection) throws TranslatorException {
+		super(executionContext, metadata, connection);
+		this.command = command;
+
+		this.visitor = new MongoDBUpdateVisitor(executionFactory, metadata);
+		this.visitor.visitNode(command);
+
+		if (!this.visitor.exceptions.isEmpty()) {
+			throw this.visitor.exceptions.get(0);
+		}
+	}
+
+	@Override
+	public void close() {
+	}
+
+	@Override
+	public void cancel() throws TranslatorException {
+	}
+
+	@Override
+	public void execute() throws TranslatorException {
+		DBCollection collection = getCollection(this.visitor.collectionName);
+
+		WriteResult result = null;
+		if (this.command instanceof Insert) {
+			// get pull key based documents to embed
+			LinkedHashMap<String, DBObject> embeddedDocuments = fetchEmbeddedDocuments();
+
+			// check if this document need to be embedded in any other document
+			if (this.visitor.pushKey != null) {
+				DBRef ref = this.visitor.pushKey.getDBRef(this.mongoDB, true);
+				DBObject match = ref.fetch();
+				if (match == null) {
+					throw new TranslatorException(MongoDBPlugin.Util.gs(MongoDBPlugin.Event.TEIID18006, this.visitor.pushKey.getParentTable(), this.visitor.pushKey.getId(), this.visitor.pushKey.getEmbeddedTable()));
+				}
+
+				BasicDBObject embeddedDoc = new BasicDBObject(this.visitor.pushKey.getEmbeddedTable(), this.visitor.getInsert(this.mongoDB, embeddedDocuments));
+				if (this.visitor.pushKey.getAssosiation() == Assosiation.MANY) {
+					result = collection.update(match, new BasicDBObject("$push", embeddedDoc), false, true, WriteConcern.ACKNOWLEDGED); //$NON-NLS-1$
+				}
+				else {
+					result = collection.update(match, new BasicDBObject("$set", embeddedDoc), false, true, WriteConcern.ACKNOWLEDGED); //$NON-NLS-1$
+				}
+			}
+			else {
+				// gets its own collection
+				result = collection.insert(this.visitor.getInsert(this.mongoDB, embeddedDocuments), WriteConcern.ACKNOWLEDGED);
+			}
+		}
+		else if (this.command instanceof Update) {
+			// get pull key based documents to embed
+			LinkedHashMap<String, DBObject> embeddedDocuments = fetchEmbeddedDocuments();
+			DBObject match = new BasicDBObject();
+			if (this.visitor.match != null) {
+				match = this.visitor.match;
+			}
+
+			result = collection.update(match, new BasicDBObject("$set", this.visitor.getUpdate(this.mongoDB, embeddedDocuments)), false, true, WriteConcern.ACKNOWLEDGED); //$NON-NLS-1$
+
+			// if the update is for the "embeddable" table, then since it is copied to other tables
+			// those references need to be updated. I know this is not atomic operation, but not sure
+			// how else to handle it.
+			if (!this.visitor.tableCopiedIn.isEmpty()) {
+				if (result.getError() == null) {
+					AggregationOutput output = collection.aggregate(new BasicDBObject("$match", match)); //$NON-NLS-1$
+					Iterator<DBObject> resultset = output.results().iterator();
+					while(resultset.hasNext()) {
+						DBObject row = resultset.next();
+						if (row != null) {
+							for (MutableDBRef ref:this.visitor.tableCopiedIn) {
+								DBCollection parent = getCollection(ref.getParentTable());
+								WriteResult update = parent.update(new BasicDBObject(ref.getColumnName()+".$id", row.get("_id")), new BasicDBObject("$set",new BasicDBObject(ref.getEmbeddedTable(), row)), false, true, WriteConcern.ACKNOWLEDGED); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+								if (update.getError() != null) {
+									throw new TranslatorException(MongoDBPlugin.Util.gs(MongoDBPlugin.Event.TEIID18009));
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		else {
+			DBObject match = new BasicDBObject();
+			if (this.visitor.match != null) {
+				match = this.visitor.match;
+			}
+
+			if (!this.visitor.tableCopiedIn.isEmpty()) {
+				AggregationOutput output = collection.aggregate(new BasicDBObject("$match", match)); //$NON-NLS-1$
+				Iterator<DBObject> resultset = output.results().iterator();
+				while(resultset.hasNext()) {
+					DBObject row = resultset.next();
+					if (row != null) {
+						for (MutableDBRef ref:this.visitor.tableCopiedIn) {
+							DBCollection parent = getCollection(ref.getParentTable());
+							AggregationOutput referenceOutput = parent.aggregate(new BasicDBObject("$match", new BasicDBObject(ref.getColumnName()+".$id", row.get("_id")))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+							if (referenceOutput.results().iterator().hasNext()) {
+								throw new TranslatorException(MongoDBPlugin.Util.gs(MongoDBPlugin.Event.TEIID18010, this.visitor.collectionName, ref.getParentTable()));
+							}
+						}
+					}
+				}
+			}
+
+			result = collection.remove(match, WriteConcern.ACKNOWLEDGED);
+		}
+
+		if (result != null) {
+			if (result.getError() != null) {
+				throw new TranslatorException(result.getError());
+			}
+			this.results = new int[1];
+			this.results[0] = result.getN();
+
+			if (this.command instanceof Insert) {
+	            if (this.executionContext.getCommandContext().isReturnAutoGeneratedKeys()) {
+	            	addAutoGeneretedKeys(result);
+	            }
+			}
+		}
+	}
+
+	private LinkedHashMap<String, DBObject> fetchEmbeddedDocuments() {
+		LinkedHashMap<String, DBObject> additionalDocuments = new LinkedHashMap<String, DBObject>();
+
+		// check if there are any other documents that can be embedded in this
+		// document
+		if (!this.visitor.pullKeys.isEmpty()) {
+			for (MutableDBRef ref:this.visitor.pullKeys) {
+				DBRef dbRef = ref.getDBRef(this.mongoDB, false);
+				DBObject document = dbRef.fetch();
+				if (document == null) {
+					continue;
+				}
+				additionalDocuments.put(ref.getEmbeddedTable(), document);
+			}
+		}
+		return additionalDocuments;
+	}
+
+	private DBCollection getCollection(String name) {
+		DBCollection collection;
+		if (!this.mongoDB.collectionExists(name)) {
+			collection = this.mongoDB.createCollection(name, null);
+
+			// since this is the first time creating the tables; create the indexes on the collection
+			Table table = this.visitor.collectionTable.getMetadataObject();
+			if (table.getPrimaryKey() != null) {
+				createIndex(collection, table.getPrimaryKey(), true);
+			}
+
+			// index on foreign keys
+			for (ForeignKey record:table.getForeignKeys()) {
+				createIndex(collection, record, false);
+			}
+
+			// index on unique
+			for (KeyRecord record:table.getUniqueKeys()) {
+				createIndex(collection, record, true);
+			}
+
+			// index on index keys
+			for (KeyRecord record:table.getIndexes()) {
+				createIndex(collection, record, false);
+			}
+		}
+		else {
+			collection = this.mongoDB.getCollection(name);
+		}
+		return collection;
+	}
+
+	private void createIndex(DBCollection collection, KeyRecord record, boolean unique) {
+		BasicDBObject key = new BasicDBObject();
+		for (Column c:record.getColumns()) {
+			key.append(MongoDBSelectVisitor.getRecordName(c), 1);
+		}
+		collection.ensureIndex(key, record.getName(), unique);
+	}
+
+	@Override
+	public int[] getUpdateCounts() throws DataNotAvailableException, TranslatorException {
+		return this.results;
+	}
+
+
+	private void addAutoGeneretedKeys(WriteResult result) {
+		Table table = this.visitor.collectionTable.getMetadataObject();
+
+		int cols = table.getPrimaryKey().getColumns().size();
+		Class<?>[] columnDataTypes = new Class<?>[cols];
+		String[] columnNames = new String[cols];
+		//this is typically expected to be an int/long, but we'll be general here.  we may eventual need the type logic off of the metadata importer
+        for (int i = 0; i < cols; i++) {
+        	columnDataTypes[i] = table.getPrimaryKey().getColumns().get(i).getJavaType();
+        	columnNames[i] = table.getPrimaryKey().getColumns().get(i).getName();
+        }
+        GeneratedKeys generatedKeys = this.executionContext.getCommandContext().returnGeneratedKeys(columnNames, columnDataTypes);
+        List<Object> vals = new ArrayList<Object>(columnDataTypes.length);
+        for (int i = 0; i < columnDataTypes.length; i++) {
+            Object value = this.executionFactory.retrieveValue(result.getField(columnNames[i]), columnDataTypes[i]);
+            vals.add(value);
+        }
+        generatedKeys.addKey(vals);
+	}
+}

--- a/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBUpdateVisitor.java
+++ b/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBUpdateVisitor.java
@@ -1,0 +1,208 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.mongodb;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.teiid.language.ColumnReference;
+import org.teiid.language.Delete;
+import org.teiid.language.Expression;
+import org.teiid.language.ExpressionValueSource;
+import org.teiid.language.Insert;
+import org.teiid.language.Literal;
+import org.teiid.language.SetClause;
+import org.teiid.language.Update;
+import org.teiid.metadata.RuntimeMetadata;
+import org.teiid.translator.TranslatorException;
+import org.teiid.translator.mongodb.MutableDBRef.Assosiation;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DB;
+import com.mongodb.DBObject;
+
+public class MongoDBUpdateVisitor extends MongoDBSelectVisitor {
+
+	protected LinkedHashMap<String, Object> columnValues = new LinkedHashMap<String, Object>();
+
+	public MongoDBUpdateVisitor(MongoDBExecutionFactory executionFactory, RuntimeMetadata metadata) {
+		super(executionFactory, metadata);
+	}
+
+	@Override
+	public void visit(Insert obj) {
+        append(obj.getTable());
+
+        this.columnValues.putAll(this.foreignKeys);
+
+        List<ColumnReference> columns = obj.getColumns();
+        List<Expression> values = ((ExpressionValueSource)obj.getValueSource()).getValues();
+
+		try {
+			for (int i = 0; i < columns.size(); i++) {
+				String colName = getColumnName(columns.get(i));
+				Expression expr = values.get(i);
+				resolveExpressionValue(colName, expr);
+			}
+		} catch (TranslatorException e) {
+			this.exceptions.add(e);
+		}
+	}
+
+	private void resolveExpressionValue(String colName, Expression expr) throws TranslatorException {
+		Object value = null;
+		if (expr instanceof Literal) {
+			value = this.executionFactory.convertToMongoType(((Literal) expr).getValue());
+		}
+		else {
+			this.exceptions.add(new TranslatorException(MongoDBPlugin.Util.gs(MongoDBPlugin.Event.TEIID18001)));
+		}
+
+		if (this.columnValues.get(colName) != null) {
+			((MutableDBRef) this.columnValues.get(colName)).setId(value);
+
+			// parent table selection query.
+			if (this.pushKey != null && this.pushKey.getReferenceColumnName().equals(colName)) {
+				this.pushKey.setId(value);
+			}
+
+			// child table selection query
+			if (!this.pullKeys.isEmpty()) {
+				for (MutableDBRef ref:this.pullKeys) {
+					if (ref.getColumnName().equals(colName)) {
+						ref.setId(value);
+					}
+				}
+			}
+		}
+		else {
+			this.columnValues.put(colName, value);
+		}
+	}
+
+	@Override
+	public void visit(Update obj) {
+        append(obj.getTable());
+
+        this.columnValues.putAll(this.foreignKeys);
+
+        List<SetClause> changes = obj.getChanges();
+        try {
+			for (SetClause clause:changes) {
+				String colName = getColumnName(clause.getSymbol());
+				Expression expr = clause.getValue();
+				resolveExpressionValue(colName, expr);
+			}
+		} catch (TranslatorException e) {
+			this.exceptions.add(e);
+		}
+
+        append(obj.getWhere());
+
+        if (!this.onGoingCriteria.isEmpty()) {
+        	this.match = this.onGoingCriteria.pop();
+        }
+	}
+
+	@Override
+	public void visit(Delete obj) {
+		append(obj.getTable());
+        append(obj.getWhere());
+
+        if (!this.onGoingCriteria.isEmpty()) {
+        	this.match = this.onGoingCriteria.pop();
+        }
+	}
+
+	public BasicDBObject getInsert(DB db, LinkedHashMap<String, DBObject> embeddedDocuments) throws TranslatorException {
+		BasicDBObject insert = new BasicDBObject();
+		for (String key:this.columnValues.keySet()) {
+			Object obj = this.columnValues.get(key);
+			if (obj instanceof MutableDBRef) {
+				insert.append(key, ((MutableDBRef)obj).getDBRef(db, true));
+			}
+			else {
+				insert.append(key, obj);
+			}
+		}
+
+		if (this.pullKeys != null) {
+			for (MutableDBRef ref: this.pullKeys) {
+				DBObject embedDoc = embeddedDocuments.get(ref.getEmbeddedTable());
+				if (embedDoc == null) {
+					throw new TranslatorException(MongoDBPlugin.Util.gs(MongoDBPlugin.Event.TEIID18008, ref.getEmbeddedTable()));
+				}
+				insert.append(ref.getEmbeddedTable(), embedDoc);
+			}
+		}
+		return insert;
+	}
+
+	public BasicDBObject getUpdate(DB db, LinkedHashMap<String, DBObject> embeddedDocuments) throws TranslatorException {
+		BasicDBObject update = new BasicDBObject();
+
+		String embeddedDocumentName = null;
+		if (this.pushKey != null) {
+			embeddedDocumentName = this.pushKey.getEmbeddedTable();
+		}
+
+		for (String key:this.columnValues.keySet()) {
+			Object obj = this.columnValues.get(key);
+			if (obj instanceof MutableDBRef) {
+				MutableDBRef ref = ((MutableDBRef)obj);
+
+				if (ref.getId() != null) {
+					if (this.pushKey != null) {
+						// do not allow updating the main document reference where this embedded document is embedded.
+						if (ref.getParentTable().equals(this.pushKey.getParentTable())) {
+							throw new TranslatorException(MongoDBPlugin.Util.gs(MongoDBPlugin.Event.TEIID18007, ref.getParentTable(), embeddedDocumentName));
+						}
+					}
+
+					update.append(key, ref.getDBRef(db, true));
+
+					// also update the embedded document
+					if (this.pullKeys != null) {
+						for (MutableDBRef pullRef: this.pullKeys) {
+							if (ref.getParentTable().equals(pullRef.getEmbeddedTable())) {
+								DBObject embedDoc = embeddedDocuments.get(pullRef.getEmbeddedTable());
+								if (embedDoc == null) {
+									throw new TranslatorException(MongoDBPlugin.Util.gs(MongoDBPlugin.Event.TEIID18008, ref.getEmbeddedTable()));
+								}
+								update.append(pullRef.getEmbeddedTable(), embedDoc);
+							}
+						}
+					}
+				}
+			}
+			else {
+				if (this.pushKey != null && this.pushKey.getAssosiation() == Assosiation.MANY) {
+					update.append(embeddedDocumentName+".$."+key, obj); //$NON-NLS-1$
+				}
+				else {
+					update.append(((embeddedDocumentName == null)?key:embeddedDocumentName+"."+key), obj); //$NON-NLS-1$
+				}
+			}
+		}
+		return update;
+	}
+}

--- a/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MutableDBRef.java
+++ b/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MutableDBRef.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.mongodb;
+
+import com.mongodb.DB;
+import com.mongodb.DBRef;
+
+public class MutableDBRef {
+	enum Assosiation {ONE, MANY};
+
+	private String parentTable;
+	private Object id;
+	private String referenceColumnName;
+	private String columnName;
+
+	private String embeddedTable;
+	private Assosiation assosiation;
+
+	public DBRef getDBRef(DB db, boolean push) {
+		return new DBRef(db, push?this.parentTable:this.embeddedTable, this.id);
+	}
+
+	public String getParentTable() {
+		return this.parentTable;
+	}
+
+	public void setParentTable(String parentTable) {
+		this.parentTable = parentTable;
+	}
+
+	public Object getId() {
+		return this.id;
+	}
+
+	public void setId(Object id) {
+		this.id = id;
+	}
+
+	public String getReferenceColumnName() {
+		return this.referenceColumnName;
+	}
+
+	public void setReferenceColumnName(String columnName) {
+		this.referenceColumnName = columnName;
+	}
+
+	public String getEmbeddedTable() {
+		return this.embeddedTable;
+	}
+
+	public void setEmbeddedTable(String embeddedTable) {
+		this.embeddedTable = embeddedTable;
+	}
+
+	public Assosiation getAssosiation() {
+		return this.assosiation;
+	}
+
+	public void setAssosiation(Assosiation assosiation) {
+		this.assosiation = assosiation;
+	}
+
+	public String getColumnName() {
+		return this.columnName;
+	}
+
+	public void setColumnName(String columnName) {
+		this.columnName = columnName;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("ParentTable:").append(this.parentTable); //$NON-NLS-1$
+		sb.append(" id:").append(this.id); //$NON-NLS-1$
+		sb.append(" EmbeddedTable:").append(this.embeddedTable); //$NON-NLS-1$
+		return sb.toString();
+	}
+}

--- a/connectors/translator-mongodb/src/main/resources/META-INF/services/org.teiid.translator.ExecutionFactory
+++ b/connectors/translator-mongodb/src/main/resources/META-INF/services/org.teiid.translator.ExecutionFactory
@@ -1,0 +1,1 @@
+org.teiid.translator.mongodb.MongoDBExecutionFactory

--- a/connectors/translator-mongodb/src/main/resources/org/teiid/translator/mongodb/i18n.properties
+++ b/connectors/translator-mongodb/src/main/resources/org/teiid/translator/mongodb/i18n.properties
@@ -1,0 +1,32 @@
+#
+# JBoss, Home of Professional Open Source.
+# See the COPYRIGHT.txt file distributed with this work for information
+# regarding copyright ownership.  Some portions may be licensed
+# to Red Hat, Inc. under one or more contributor license agreements.
+# 
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# 
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+# 
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA.
+#
+TEIID18001=expressions not allowed in insert statement
+TEIID18002=expressions not allowed in update statement
+TEIID18003=Aggregate function can only contain column references, complex expressions are not allowed.
+TEIID18004=In "group by" clause only column references are allowed; complex expressions are not allowed.
+TEIID18005=Unknown aggregate function {0}
+TEIID18006=Failed to find parent document {0}, with key {1}, to embed document for {3}
+TEIID18007=Can not update the root document {0} where the this document {1} is embedded
+TEIID18008=Embeddable document {0} is not supplied for update or null.
+TEIID18009=Update operation failed to update all the collections that embed this collection
+TEIID18010=Failed to delete row(s) from {0} as there are referenced rows in {1}.  
+TEIID18011=Missing native-query extension metadata.

--- a/connectors/translator-mongodb/src/test/java/org/teiid/translator/mongodb/TestMongoDBQueryExecution.java
+++ b/connectors/translator-mongodb/src/test/java/org/teiid/translator/mongodb/TestMongoDBQueryExecution.java
@@ -1,0 +1,217 @@
+package org.teiid.translator.mongodb;
+
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.teiid.cdk.api.TranslationUtility;
+import org.teiid.core.util.ObjectConverterUtil;
+import org.teiid.core.util.UnitTestUtil;
+import org.teiid.language.Command;
+import org.teiid.language.QueryExpression;
+import org.teiid.mongodb.MongoDBConnection;
+import org.teiid.query.metadata.TransformationMetadata;
+import org.teiid.query.unittest.RealMetadataFactory;
+import org.teiid.translator.ExecutionContext;
+import org.teiid.translator.ResultSetExecution;
+import org.teiid.translator.TranslatorException;
+
+import com.mongodb.AggregationOutput;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.QueryBuilder;
+
+@SuppressWarnings("nls")
+public class TestMongoDBQueryExecution {
+    private MongoDBExecutionFactory translator;
+    private TranslationUtility utility;
+
+    @Before
+    public void setUp() throws Exception {
+    	this.translator = new MongoDBExecutionFactory();
+    	this.translator.start();
+
+    	TransformationMetadata metadata = RealMetadataFactory.fromDDL(ObjectConverterUtil.convertFileToString(UnitTestUtil.getTestDataFile("northwind.ddl")), "sakila", "northwind");
+    	this.utility = new TranslationUtility(metadata);
+    }
+
+	private DBCollection helpExecute(String query, String[] expectedCollection, int expectedParameters) throws TranslatorException {
+		Command cmd = this.utility.parseCommand(query);
+		ExecutionContext context = Mockito.mock(ExecutionContext.class);
+		MongoDBConnection connection = Mockito.mock(MongoDBConnection.class);
+		DB db = Mockito.mock(DB.class);
+
+		DBCollection dbCollection = Mockito.mock(DBCollection.class);
+		for(String collection:expectedCollection) {
+			Mockito.stub(db.getCollection(collection)).toReturn(dbCollection);
+		}
+
+		AggregationOutput output = Mockito.mock(AggregationOutput.class);
+		Mockito.stub(output.results()).toReturn(new ArrayList<DBObject>());
+
+		ArrayList<DBObject> params = new ArrayList<DBObject>();
+		for (int i = 0; i < expectedParameters; i++) {
+			params.add(Mockito.any(DBObject.class));
+		}
+
+		Mockito.stub(dbCollection.aggregate(Mockito.any(DBObject.class), params.toArray(new DBObject[params.size()]))).toReturn(output);
+
+		Mockito.stub(db.collectionExists(Mockito.anyString())).toReturn(true);
+		Mockito.stub(connection.getDatabase()).toReturn(db);
+
+		Mockito.stub(db.getCollectionFromString(Mockito.anyString())).toReturn(dbCollection);
+
+		ResultSetExecution execution = this.translator.createResultSetExecution((QueryExpression)cmd, context, this.utility.createRuntimeMetadata(), connection);
+		execution.execute();
+		return dbCollection;
+	}
+
+	@Test
+	public void testSimpleSelectNoAssosiations() throws Exception {
+		String query = "SELECT * FROM Customers";
+
+		DBCollection dbCollection = helpExecute(query, new String[]{"Customers"}, 0);
+
+	    BasicDBObject result = new BasicDBObject();
+	    result.append( "_m0","$_id");
+	    result.append( "_m1","$CompanyName");
+	    result.append( "_m2","$ContactName");
+	    result.append( "_m3","$ContactTitle");
+	    result.append( "_m4","$Address");
+	    result.append( "_m5","$City");
+	    result.append( "_m6","$Region");
+	    result.append( "_m7","$PostalCode");
+	    result.append( "_m8","$Country");
+	    result.append( "_m9","$Phone");
+	    result.append( "_m10","$Fax");
+
+		Mockito.verify(dbCollection).aggregate(new BasicDBObject("$project", result));
+	}
+
+	@Test
+	public void testSimpleWhere() throws Exception {
+		String query = "SELECT CompanyName, ContactTitle FROM Customers WHERE Country='USA'";
+
+		DBCollection dbCollection = helpExecute(query, new String[]{"Customers"}, 1);
+
+	    BasicDBObject result = new BasicDBObject();
+	    result.append( "_m0","$CompanyName");
+	    result.append( "_m1","$ContactTitle");
+
+		Mockito.verify(dbCollection).aggregate(
+						new BasicDBObject("$match", new BasicDBObject("Country", "USA")),
+						new BasicDBObject("$project", result));
+	}
+
+	@Test
+	public void testSelectEmbeddable() throws Exception {
+		String query = "SELECT CategoryName FROM Categories";
+
+		DBCollection dbCollection = helpExecute(query, new String[]{"Categories"}, 0);
+
+	    BasicDBObject result = new BasicDBObject();
+	    result.append( "_m0","$CategoryName");
+
+		Mockito.verify(dbCollection).aggregate(
+						new BasicDBObject("$project", result));
+	}
+
+	@Test
+	public void testSelectEmbedIn() throws Exception {
+		String query = "SELECT UnitPrice FROM OrderDetails";
+
+		DBCollection dbCollection = helpExecute(query, new String[]{"Orders"}, 1);
+
+	    BasicDBObject result = new BasicDBObject();
+	    result.append( "_m0","$OrderDetails.UnitPrice");
+
+		Mockito.verify(dbCollection).aggregate(
+						new BasicDBObject("$unwind","$OrderDetails"),
+						new BasicDBObject("$project", result));
+	}
+
+	@Test
+	public void testSelectEmbedInWithWhere() throws Exception {
+		String query = "SELECT * FROM OrderDetails WHERE OrderId = 10248";
+
+		DBCollection dbCollection = helpExecute(query, new String[]{"Orders"}, 2);
+
+	    BasicDBObject result = new BasicDBObject();
+	    result.append( "_m0","$OrderDetails._id");
+	    result.append( "_m1","$OrderDetails.OrderID");
+	    result.append( "_m2","$OrderDetails.ProductID");
+	    result.append( "_m3","$OrderDetails.UnitPrice");
+	    result.append( "_m4","$OrderDetails.Quantity");
+	    result.append( "_m5","$OrderDetails.Discount");
+
+
+		Mockito.verify(dbCollection).aggregate(
+				new BasicDBObject("$match", new BasicDBObject("OrderDetails.OrderID.$id", 10248)),
+						new BasicDBObject("$unwind","$OrderDetails"),
+						new BasicDBObject("$project", result));
+	}
+
+	@Test
+	public void testTwoTableInnerJoin() throws Exception {
+		String query = "SELECT o.CustomerID, od.ProductID FROM Orders o JOIN OrderDetails od ON o.OrderID=od.OrderID";
+
+		DBCollection dbCollection = helpExecute(query, new String[]{"Orders"}, 1);
+
+	    BasicDBObject result = new BasicDBObject();
+	    result.append( "_m0","$CustomerID");
+	    result.append( "_m1","$OrderDetails.ProductID");
+
+		Mockito.verify(dbCollection).aggregate(
+						//new BasicDBObject("$match",new BasicDBObject("_id", "OrderDetails.OrderID")),
+						new BasicDBObject("$unwind","$OrderDetails"),
+						new BasicDBObject("$project", result));
+	}
+
+	@Test
+	public void testThreeTableInnerJoin() throws Exception {
+		String query = "SELECT o.CustomerID, od.ProductID, s.CompanyName FROM Orders o JOIN OrderDetails od ON o.OrderID=od.OrderID JOIN Shippers s ON o.ShipVia = s.ShipperID";
+
+		DBCollection dbCollection = helpExecute(query, new String[]{"Orders"}, 2);
+
+	    BasicDBObject result = new BasicDBObject();
+	    result.append( "_m0","$CustomerID");
+	    result.append( "_m1","$OrderDetails.ProductID");
+	    result.append( "_m2","$Shippers.CompanyName");
+
+	    //BasicDBList matchList = new BasicDBList();
+	    //matchList.add(new BasicDBObject("ShipVia.$id", "Shippers._id"));
+	    //matchList.add(new BasicDBObject("_id", "OrderDetails.OrderID"));
+
+	    Mockito.verify(dbCollection).aggregate(
+						//new BasicDBObject("$match",new BasicDBObject("$and", matchList)),
+						new BasicDBObject("$unwind","$OrderDetails"),
+						new BasicDBObject("$unwind","$Shippers"),
+						new BasicDBObject("$project", result));
+	}
+
+	@Test
+	public void testLeftOuterJoin() throws Exception {
+		String query = "SELECT Orders.CustomerID, OrderDetails.ProductID FROM Orders " +
+				"LEFT OUTER JOIN OrderDetails ON Orders.OrderID = OrderDetails.OrderID " +
+				"WHERE OrderDetails.OrderID IS NOT NULL";
+
+		DBCollection dbCollection = helpExecute(query, new String[]{"Orders"}, 2);
+
+	    BasicDBObject result = new BasicDBObject();
+	    result.append( "_m0","$CustomerID");
+	    result.append( "_m1","$OrderDetails.ProductID");
+
+	   // BasicDBList matchList = new BasicDBList();
+	    //matchList.add(new BasicDBObject("ShipVia.$id", "Shippers._id"));
+	   // matchList.add(new BasicDBObject("_id", "OrderDetails.OrderID"));
+
+	    DBObject match = QueryBuilder.start("OrderDetails.OrderID").notEquals(null).get();
+	    Mockito.verify(dbCollection).aggregate(
+						new BasicDBObject("$match",match),
+						new BasicDBObject("$unwind","$OrderDetails"),
+						new BasicDBObject("$project", result));
+	}
+}

--- a/connectors/translator-mongodb/src/test/java/org/teiid/translator/mongodb/TestMongoDBSelectVisitor.java
+++ b/connectors/translator-mongodb/src/test/java/org/teiid/translator/mongodb/TestMongoDBSelectVisitor.java
@@ -1,0 +1,406 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.mongodb;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.teiid.cdk.api.TranslationUtility;
+import org.teiid.core.util.ObjectConverterUtil;
+import org.teiid.core.util.UnitTestUtil;
+import org.teiid.language.Select;
+import org.teiid.query.metadata.TransformationMetadata;
+import org.teiid.query.unittest.RealMetadataFactory;
+
+import com.mongodb.BasicDBObject;
+
+@SuppressWarnings("nls")
+public class TestMongoDBSelectVisitor {
+    private MongoDBExecutionFactory translator;
+    private TranslationUtility utility;
+
+    @Before
+    public void setUp() throws Exception {
+    	this.translator = new MongoDBExecutionFactory();
+    	this.translator.start();
+
+    	TransformationMetadata metadata = RealMetadataFactory.fromDDL(ObjectConverterUtil.convertFileToString(UnitTestUtil.getTestDataFile("northwind.ddl")), "sakila", "northwind");
+    	this.utility = new TranslationUtility(metadata);
+
+    }
+
+    private void helpExecute(String query, String collection, String project, String match) throws Exception {
+    	helpExecute(query, collection, project, match, null, null);
+    }
+    private void helpExecute(String query, String collection, String project, String match, String groupby, String having) throws Exception {
+    	Select cmd = (Select)this.utility.parseCommand(query);
+    	MongoDBSelectVisitor visitor = new MongoDBSelectVisitor(this.translator, this.utility.createRuntimeMetadata());
+    	visitor.visitNode(cmd);
+    	if (!visitor.exceptions.isEmpty()) {
+    		throw visitor.exceptions.get(0);
+    	}
+
+    	assertEquals(collection, visitor.collectionName);
+    	if (project != null) {
+    		assertEquals("project wrong", project, visitor.project.toString());
+    	}
+
+    	if (match != null) {
+    		assertEquals("match wrong", match, visitor.match.toString());
+    	}
+
+    	if (groupby != null) {
+    		assertEquals("groupby wrong", groupby, visitor.group.toString());
+    	}
+
+    	if (having != null) {
+    		assertEquals("having wrong", having, visitor.having.toString());
+    	}
+    }
+
+    @Test
+    public void testSelectStar() throws Exception {
+		helpExecute(
+				"select * from customers",
+				"Customers",
+				"{ \"_m0\" : \"$_id\" , \"_m1\" : \"$CompanyName\" , \"_m2\" : \"$ContactName\" , \"_m3\" : \"$ContactTitle\" , \"_m4\" : \"$Address\" , \"_m5\" : \"$City\" , \"_m6\" : \"$Region\" , \"_m7\" : \"$PostalCode\" , \"_m8\" : \"$Country\" , \"_m9\" : \"$Phone\" , \"_m10\" : \"$Fax\"}",
+				null);
+    }
+
+    @Test
+    public void testSelectColum() throws Exception {
+		helpExecute("select CompanyName, ContactName from customers",
+				"Customers",
+				"{ \"_m0\" : \"$CompanyName\" , \"_m1\" : \"$ContactName\"}",
+				null);
+    }
+
+    @Test
+    public void testWhereEQ() throws Exception {
+		helpExecute(
+				"SELECT CompanyName, ContactName FROM customers WHERE CompanyName = 'A'",
+				"Customers",
+				"{ \"_m0\" : \"$CompanyName\" , \"_m1\" : \"$ContactName\"}",
+				"{ \"CompanyName\" : \"A\"}");
+    }
+
+    @Test
+    public void testAND() throws Exception {
+		helpExecute(
+				"SELECT CompanyName, ContactName FROM customers WHERE CompanyName = 'A' AND ContactName = 'B'",
+				"Customers",
+				"{ \"_m0\" : \"$CompanyName\" , \"_m1\" : \"$ContactName\"}",
+				"{ \"$and\" : [ { \"CompanyName\" : \"A\"} , { \"ContactName\" : \"B\"}]}");
+    }
+
+    @Test
+    public void testOR() throws Exception {
+		helpExecute(
+				"SELECT CompanyName, ContactName FROM customers WHERE CompanyName = 'A' OR ContactName = 'B'",
+				"Customers",
+				"{ \"_m0\" : \"$CompanyName\" , \"_m1\" : \"$ContactName\"}",
+				"{ \"$or\" : [ { \"CompanyName\" : \"A\"} , { \"ContactName\" : \"B\"}]}");
+    }
+
+
+    @Test
+    public void testComplexAndOr() throws Exception {
+		helpExecute(
+				"SELECT CompanyName, ContactName FROM customers WHERE (CompanyName = 'A' AND ContactName = 'B') OR (CompanyName = 'B' AND ContactName = 'A')",
+				"Customers",
+				"{ \"_m0\" : \"$CompanyName\" , \"_m1\" : \"$ContactName\"}",
+				"{ \"$or\" : [ { \"$and\" : [ { \"CompanyName\" : \"A\"} , { \"ContactName\" : \"B\"}]} , { \"$and\" : [ { \"CompanyName\" : \"B\"} , { \"ContactName\" : \"A\"}]}]}");
+    }
+
+    @Test
+    public void testComplexOrAnd() throws Exception {
+		helpExecute(
+				"SELECT CompanyName, ContactName FROM customers WHERE (CompanyName = 'A' OR ContactName = 'B') AND (CompanyName = 'B' OR ContactName = 'A')",
+				"Customers",
+				"{ \"_m0\" : \"$CompanyName\" , \"_m1\" : \"$ContactName\"}",
+				"{ \"$and\" : [ { \"$or\" : [ { \"CompanyName\" : \"A\"} , { \"ContactName\" : \"B\"}]} , { \"$or\" : [ { \"CompanyName\" : \"B\"} , { \"ContactName\" : \"A\"}]}]}");
+    }
+
+    @Test
+    public void testOrRewriteToIn() throws Exception {
+		helpExecute(
+				"SELECT CompanyName, ContactName FROM customers WHERE CompanyName = 'A' OR CompanyName = 'B'",
+				"Customers",
+				"{ \"_m0\" : \"$CompanyName\" , \"_m1\" : \"$ContactName\"}",
+				"{ \"CompanyName\" : { \"$in\" : [ \"B\" , \"A\"]}}");
+    }
+
+    @Test
+    public void testIn() throws Exception {
+		helpExecute(
+				"SELECT CompanyName, ContactName FROM customers WHERE CompanyName IN('A', 'B')",
+				"Customers",
+				"{ \"_m0\" : \"$CompanyName\" , \"_m1\" : \"$ContactName\"}",
+				"{ \"CompanyName\" : { \"$in\" : [ \"A\" , \"B\"]}}");
+    }
+
+    @Test
+    public void testNotIn() throws Exception {
+		helpExecute(
+				"SELECT CompanyName, ContactName FROM customers WHERE CompanyName NOT IN ('A', 'B')",
+				"Customers",
+				"{ \"_m0\" : \"$CompanyName\" , \"_m1\" : \"$ContactName\"}",
+				"{ \"CompanyName\" : { \"$nin\" : [ \"A\" , \"B\"]}}");
+    }
+
+    @Test
+    public void testIsNull() throws Exception {
+		helpExecute(
+				"SELECT CompanyName, ContactName FROM Customers WHERE ContactName IS NULL",
+				"Customers",
+				"{ \"_m0\" : \"$CompanyName\" , \"_m1\" : \"$ContactName\"}",
+				"{ \"ContactName\" :  null }");
+    }
+
+    @Test
+    public void testIsNotNull() throws Exception {
+		helpExecute(
+				"SELECT CompanyName, ContactName FROM Customers WHERE ContactName IS NOT NULL",
+				"Customers",
+				"{ \"_m0\" : \"$CompanyName\" , \"_m1\" : \"$ContactName\"}",
+				"{ \"ContactName\" : { \"$ne\" :  null }}");
+    }
+
+    @Test
+    public void testGtLt() throws Exception {
+		helpExecute(
+				"SELECT age,status FROM users WHERE age > 25 AND age <= 50",
+				"users", "{ \"_m0\" : \"$age\" , \"_m1\" : \"$status\"}",
+				"{ \"$and\" : [ { \"age\" : { \"$gt\" : 25}} , { \"age\" : { \"$lte\" : 50}}]}");
+    }
+
+    @Test
+    public void testLike() throws Exception {
+		helpExecute(
+				"SELECT user_id, age, status FROM users WHERE user_id like '%bc%'",
+				"users",
+				"{ \"_m0\" : \"$user_id\" , \"_m1\" : \"$age\" , \"_m2\" : \"$status\"}",
+				"{ \"user_id.$id\" : \"/bc/\"}");
+    }
+
+    @Test
+    public void testLike2() throws Exception {
+		helpExecute(
+				"SELECT user_id, age, status FROM users WHERE user_id like 'bc%'",
+				"users",
+				"{ \"_m0\" : \"$user_id\" , \"_m1\" : \"$age\" , \"_m2\" : \"$status\"}",
+				"{ \"user_id.$id\" : \"/^bc/\"}");
+    }
+
+    @Test
+    public void testLike3() throws Exception {
+		helpExecute(
+				"SELECT user_id, age, status FROM users WHERE user_id like 'b%c'",
+				"users",
+				"{ \"_m0\" : \"$user_id\" , \"_m1\" : \"$age\" , \"_m2\" : \"$status\"}",
+				"{ \"user_id.$id\" : \"/^b.*c$/\"}");
+    }
+
+    @Test
+    public void testLike4() throws Exception {
+		helpExecute(
+				"SELECT user_id, age, status FROM users WHERE user_id NOT LIKE 'b%c'",
+				"users",
+				"{ \"_m0\" : \"$user_id\" , \"_m1\" : \"$age\" , \"_m2\" : \"$status\"}",
+				"{ \"user_id.$id\" : { \"$not\" : \"/^b.*c$/\"}}");
+    }
+
+    @Test
+    public void testLimit() throws Exception {
+    	String query = "SELECT user_id, age, status FROM users LIMIT 2,5";
+    	Select cmd = (Select)this.utility.parseCommand(query);
+    	MongoDBSelectVisitor visitor = new MongoDBSelectVisitor(this.translator, this.utility.createRuntimeMetadata());
+    	visitor.visitNode(cmd);
+    	assertEquals(new Integer(5), visitor.limit);
+    	assertEquals(new Integer(2), visitor.skip);
+    }
+
+    @Test
+    public void testOrderBy() throws Exception {
+    	String query = "SELECT user_id, age, status FROM users ORDER BY age, status DESC";
+    	Select cmd = (Select)this.utility.parseCommand(query);
+    	MongoDBSelectVisitor visitor = new MongoDBSelectVisitor(this.translator, this.utility.createRuntimeMetadata());
+    	visitor.visitNode(cmd);
+    	BasicDBObject expected = new BasicDBObject("_m1", 1);
+    	expected.put("_m2", -1);
+    	System.out.println(visitor.project.toString());
+    	assertEquals(expected, visitor.sort);
+    }
+
+    @Test
+    public void testCountStar() throws Exception {
+    	String query = "SELECT COUNT(*) AS allusers FROM users";
+		helpExecute(query, "users", "{ \"allusers\" : 1}", null,
+				"{ \"_id\" :  null  , \"allusers\" : { \"$sum\" : 1}}", null);
+    }
+
+    @Test
+    public void testCountStarWithoutAlias() throws Exception {
+    	String query = "SELECT COUNT(*) FROM users";
+		helpExecute(query, "users", "{ \"_m0\" : 1}", null,
+				"{ \"_m0\" : { \"$sum\" : 1} , \"_id\" :  null }", null);
+    }
+
+    @Test
+    public void testCountStarWithDistinct() throws Exception {
+    	String query = "SELECT DISTINCT COUNT(*) FROM users";
+		helpExecute(query, "users", "{ \"_m0\" : 1}", null,
+				"{ \"_m0\" : { \"$sum\" : 1} , \"_id\" :  null }", null);
+    }
+    @Test
+    public void testDistinct() throws Exception {
+    	String query = "SELECT DISTINCT user_id, age FROM users";
+		helpExecute(query, "users",
+				"{ \"_m0\" : \"$_id._m0\" , \"_m1\" : \"$_id._m1\"}", //project
+				null, 												  // match
+				"{ \"_id\" : { \"_m0\" : \"$user_id\" , \"_m1\" : \"$age\"}}", //group by
+				null); 												  // having
+    }
+
+    @Test
+    public void testDistinctEquivalent() throws Exception {
+    	String query = "SELECT user_id, age age FROM users group by user_id, age";
+
+		helpExecute(
+				query,
+				"users",
+				"{ \"_m0\" : \"$_id.user_id\" , \"age\" : \"$_id.age\"}",
+				null,
+				"{ \"_id\" : { \"user_id\" : \"$user_id\" , \"age\" : \"$age\"}}",
+				null);
+    }
+
+    @Test
+    public void testSum() throws Exception {
+    	String query = "SELECT SUM(age) as total FROM users";
+		helpExecute(query, "users", "{ \"total\" : 1}", null,
+				"{ \"total\" : { \"$sum\" : \"$age\"} , \"_id\" :  null }",
+				null);
+    }
+
+    @Test
+    public void testSumWithGroupBy() throws Exception {
+    	String query = "SELECT SUM(age) as total FROM users GROUP BY user_id";
+		helpExecute(
+				query,
+				"users",
+				"{ \"total\" : 1}",
+				null,
+				"{ \"total\" : { \"$sum\" : \"$age\"} , \"_id\" : \"$user_id\"}",
+				null);
+    }
+
+    @Test
+    public void testSumWithGroupBy2() throws Exception {
+    	String query = "SELECT user_id, status, SUM(age) as total FROM users GROUP BY user_id, status";
+		helpExecute(
+				query,
+				"users",
+				"{ \"_m0\" : \"$_id.user_id\" , \"_m1\" : \"$_id.status\" , \"total\" : 1}",
+				null,
+				"{ \"total\" : { \"$sum\" : \"$age\"} , \"_id\" : { \"user_id\" : \"$user_id\" , \"status\" : \"$status\"}}",
+				null);
+    }
+
+    @Test
+    public void testAggregateWithHaving() throws Exception {
+    	String query = "SELECT SUM(age) as total FROM users GROUP BY user_id HAVING SUM(age) > 250";
+		helpExecute(
+				query,
+				"users",
+				"{ \"total\" : 1}",
+				null,
+				"{ \"total\" : { \"$sum\" : \"$age\"} , \"_id\" : \"$user_id\"}",
+				"{ \"total\" : { \"$gt\" : 250}}");
+    }
+
+    @Test
+    public void testAggregateWithHaving1() throws Exception {
+    	String query = "SELECT age FROM users GROUP BY user_id HAVING SUM(age) > 250";
+		helpExecute(query, "users", "{ \"_m0\" : \"$age\" , \"_m1\" : 1}",
+				null,
+				"{ \"_m1\" : { \"$sum\" : \"$age\"} , \"_id\" : \"$user_id\"}",
+				"{ \"_m1\" : { \"$gt\" : 250}}");
+    }
+
+    @Test
+    public void testAggregateWithHavingAndWhere() throws Exception {
+    	String query = "SELECT SUM(age) as total FROM users WHERE age > 45 GROUP BY user_id HAVING SUM(age) > 250";
+		helpExecute(
+				query,
+				"users",
+				"{ \"total\" : 1}",
+				"{ \"age\" : { \"$gt\" : 45}}",
+				"{ \"total\" : { \"$sum\" : \"$age\"} , \"_id\" : \"$user_id\"}",
+				"{ \"total\" : { \"$gt\" : 250}}");
+    }
+
+    @Test
+    public void testPlusOperatorWithAlias() throws Exception {
+    	String query = "SELECT (age+age) as total FROM users";
+    	helpExecute(query, "users", "{ \"total\" : { \"$add\" : [ \"$age\" , \"$age\"]}}", null, null, null);
+    }
+
+    @Test
+    public void testPlusOperatorWithOutAlias() throws Exception {
+    	String query = "SELECT (age+age) FROM users";
+    	helpExecute(query, "users", "{ \"_m0\" : { \"$add\" : [ \"$age\" , \"$age\"]}}", null, null, null);
+    }
+
+    //TODO: fix this
+    public void testPlusOperatorInWhere() throws Exception {
+    	String query = "SELECT age FROM users WHERE age*2 > 2.5";
+    	helpExecute(query, "users", "{ \"_m0\" : \"$age\"}", "{ \"$divide\" : [ \"$age\" , 2]}");
+    }
+
+    @Test
+    public void testPlusOperatorInWhere2() throws Exception {
+    	String query = "SELECT age FROM users WHERE age/2 > age*3";
+		helpExecute(
+				query,
+				"users",
+				"{ \"_m0\" : { \"$divide\" : [ \"$age\" , 2]} , \"_m1\" : { \"$multiply\" : [ \"$age\" , 3]} , \"_m2\" : \"$age\"}",
+				"{ \"_m0\" : { \"$gt\" : \"_m1\"}}");
+    }
+
+    @Test
+    public void testFunction() throws Exception {
+    	String query = "SELECT concat(user_id, user_id) FROM users";
+		helpExecute(query, "users",
+				"{ \"_m0\" : { \"$concat\" : [ \"$user_id\" , \"$user_id\"]}}",
+				null);
+    }
+
+    @Test
+    public void testWhereReference() throws Exception {
+    	String query = "SELECT age FROM users WHERE user_id = 'bob'";
+		helpExecute(query, "users",
+				"{ \"_m0\" : \"$age\"}",
+				"{ \"user_id.$id\" : \"bob\"}");
+    }
+}

--- a/connectors/translator-mongodb/src/test/java/org/teiid/translator/mongodb/TestMongoDBUpdateExecution.java
+++ b/connectors/translator-mongodb/src/test/java/org/teiid/translator/mongodb/TestMongoDBUpdateExecution.java
@@ -1,0 +1,231 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.mongodb;
+
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.teiid.cdk.api.TranslationUtility;
+import org.teiid.core.util.ObjectConverterUtil;
+import org.teiid.core.util.UnitTestUtil;
+import org.teiid.language.Command;
+import org.teiid.mongodb.MongoDBConnection;
+import org.teiid.query.metadata.TransformationMetadata;
+import org.teiid.query.unittest.RealMetadataFactory;
+import org.teiid.translator.ExecutionContext;
+import org.teiid.translator.TranslatorException;
+import org.teiid.translator.UpdateExecution;
+
+import com.mongodb.AggregationOutput;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.DBRef;
+import com.mongodb.WriteConcern;
+import com.mongodb.WriteResult;
+
+@SuppressWarnings("nls")
+public class TestMongoDBUpdateExecution {
+    private MongoDBExecutionFactory translator;
+    private TranslationUtility utility;
+
+    @Before
+    public void setUp() throws Exception {
+    	this.translator = new MongoDBExecutionFactory();
+    	this.translator.start();
+
+    	TransformationMetadata metadata = RealMetadataFactory.fromDDL(ObjectConverterUtil.convertFileToString(UnitTestUtil.getTestDataFile("northwind.ddl")), "sakila", "northwind");
+    	this.utility = new TranslationUtility(metadata);
+    }
+
+	private DBCollection helpExecute(String query, String[] expectedCollection, DBObject match) throws TranslatorException {
+		Command cmd = this.utility.parseCommand(query);
+		ExecutionContext context = Mockito.mock(ExecutionContext.class);
+		MongoDBConnection connection = Mockito.mock(MongoDBConnection.class);
+		DB db = Mockito.mock(DB.class);
+		DBCollection dbCollection = Mockito.mock(DBCollection.class);
+		for(String collection:expectedCollection) {
+			Mockito.stub(db.getCollection(collection)).toReturn(dbCollection);
+		}
+		Mockito.stub(db.collectionExists(Mockito.anyString())).toReturn(true);
+		Mockito.stub(connection.getDatabase()).toReturn(db);
+
+		Mockito.stub(db.getCollectionFromString(Mockito.anyString())).toReturn(dbCollection);
+		Mockito.stub(dbCollection.findOne(Mockito.any())).toReturn(match);
+
+		UpdateExecution execution = this.translator.createUpdateExecution(cmd, context, this.utility.createRuntimeMetadata(), connection);
+		execution.execute();
+		return dbCollection;
+	}
+
+	@Test
+	public void testSimpleInsertNoAssosiations() throws Exception {
+		String query = "insert into Customers (CustomerID,CompanyName,ContactName,"
+				+ "ContactTitle,Address,City,Region,"
+				+ "PostalCode,Country,Phone,Fax) VALUES ('11', 'jboss', 'teiid', 'Mr.Lizard', "
+				+ "'jboss.org', 'internet', 'all', '1111', 'US', '555-1212', '555-1212')";
+
+		DBCollection dbCollection = helpExecute(query, new String[]{"Customers"}, null);
+
+	    BasicDBObject result = new BasicDBObject();
+		result.append("_id", "11");
+		result.append("CompanyName", "jboss");
+		result.append("ContactName" , "teiid");
+		result.append("ContactTitle","Mr.Lizard");
+		result.append("Address","jboss.org");
+		result.append("City","internet");
+		result.append("Region","all");
+		result.append("PostalCode","1111");
+		result.append( "Country","US");
+		result.append("Phone","555-1212");
+		result.append("Fax","555-1212");
+		Mockito.verify(dbCollection).insert(result, WriteConcern.ACKNOWLEDGED);
+		Mockito.verify(dbCollection, Mockito.never()).update(new BasicDBObject(), result, false, true, WriteConcern.ACKNOWLEDGED);
+	}
+
+	@Test
+	public void testEmbeddableInsert() throws Exception {
+		String query = "INSERT INTO Categories (CategoryID, CategoryName, Description, Picture) " +
+				"VALUES (12, 'mongo', 'mongo with sql', null)";
+
+		DBCollection dbCollection = helpExecute(query, new String[]{"Categories"}, null);
+	    BasicDBObject result = new BasicDBObject();
+		result.append("_id", 12);
+		result.append("CategoryName", "mongo");
+		result.append("Description" , "mongo with sql");
+		result.append("Picture",null);
+		Mockito.verify(dbCollection).insert(result, WriteConcern.ACKNOWLEDGED);
+		Mockito.verify(dbCollection, Mockito.never()).update(new BasicDBObject(), result, false, true, WriteConcern.ACKNOWLEDGED);
+	}
+
+	@Test
+	public void testEmbedInInsert() throws Exception {
+		// tests one-to-many situation
+		String query = "INSERT INTO OrderDetails (odID, OrderID, ProductID, UnitPrice, Quantity, Discount) " +
+				"VALUES (12, 14, 15, 34.50, 10, 12)";
+
+		BasicDBObject match = new BasicDBObject("OrderID", 14);
+		DBCollection dbCollection = helpExecute(query, new String[]{"Orders"}, match);
+
+		BasicDBObject details = new BasicDBObject();
+		details.append("OrderID", new DBRef(null,"Orders", 14));
+		details.append("ProductID", new DBRef(null,"Products", 15));
+		details.append("_id", 12);
+		details.append("UnitPrice", 34.50);
+		details.append("Quantity", 10);
+		details.append("Discount", 12);
+
+		details = new BasicDBObject("OrderDetails", details);
+		Mockito.verify(dbCollection, Mockito.never()).insert(details, WriteConcern.ACKNOWLEDGED);
+		Mockito.verify(dbCollection).update(match, new BasicDBObject("$push", details), false, true, WriteConcern.ACKNOWLEDGED);
+	}
+
+	@Test
+	public void testSimpleUpdate() throws Exception {
+		String query = "UPDATE Customers SET CompanyName='JBOSS', ContactName='TEIID' WHERE CustomerID = '11'";
+
+		BasicDBObject match = new BasicDBObject("_id", "11");
+		DBCollection dbCollection = helpExecute(query, new String[]{"Customers"}, match);
+
+		BasicDBObject details = new BasicDBObject();
+		details.append("CompanyName", "JBOSS");
+		details.append("ContactName", "TEIID");
+
+		details = new BasicDBObject("$set", details);
+
+		Mockito.verify(dbCollection, Mockito.never()).insert(new BasicDBObject(), WriteConcern.ACKNOWLEDGED);
+		Mockito.verify(dbCollection).update(match, details, false, true, WriteConcern.ACKNOWLEDGED);
+	}
+
+	private DBCollection helpUpdate(String query, String[] expectedCollection, DBObject match, ArrayList<DBObject> results) throws TranslatorException {
+		Command cmd = this.utility.parseCommand(query);
+		ExecutionContext context = Mockito.mock(ExecutionContext.class);
+		MongoDBConnection connection = Mockito.mock(MongoDBConnection.class);
+		DB db = Mockito.mock(DB.class);
+		DBCollection dbCollection = Mockito.mock(DBCollection.class);
+		for(String collection:expectedCollection) {
+			Mockito.stub(db.getCollection(collection)).toReturn(dbCollection);
+		}
+		Mockito.stub(db.collectionExists(Mockito.anyString())).toReturn(true);
+		Mockito.stub(connection.getDatabase()).toReturn(db);
+
+		Mockito.stub(db.getCollectionFromString(Mockito.anyString())).toReturn(dbCollection);
+		Mockito.stub(dbCollection.findOne(Mockito.any())).toReturn(match);
+		Mockito.stub(dbCollection.update(Mockito.any(BasicDBObject.class),
+				Mockito.any(BasicDBObject.class),
+				Mockito.eq(false),
+				Mockito.eq(true),
+				Mockito.any(WriteConcern.class))).toReturn(Mockito.mock(WriteResult.class));;
+
+		if (results != null) {
+			AggregationOutput out = Mockito.mock(AggregationOutput.class);
+			Mockito.stub(out.results()).toReturn(results);
+
+			for (DBObject obj:results) {
+				match = new BasicDBObject("_id", obj.get("_id"));
+				Mockito.stub(dbCollection.aggregate(new BasicDBObject("$match", match))).toReturn(out);
+			}
+		}
+
+		UpdateExecution execution = this.translator.createUpdateExecution(cmd, context, this.utility.createRuntimeMetadata(), connection);
+		execution.execute();
+		return dbCollection;
+	}
+
+	@Test
+	public void testUpdateEmbeddable() throws Exception {
+		// check to make sure about multiple updates
+		String query = "UPDATE Categories SET CategoryName='JBOSS' WHERE CategoryID = 11";
+
+		BasicDBObject match = new BasicDBObject("_id", 11);
+		BasicDBObject details = new BasicDBObject();
+		details.append("CategoryName", "JBOSS");
+		details = new BasicDBObject("$set", details);
+
+		ArrayList<DBObject> results = new ArrayList<DBObject>();
+		results.add(new BasicDBObject("_id", 11).append("key", "value"));
+
+		DBCollection dbCollection = helpUpdate(query, new String[]{"Categories", "Products"}, match, results);
+
+		Mockito.verify(dbCollection, Mockito.never()).insert(new BasicDBObject(), WriteConcern.ACKNOWLEDGED);
+		Mockito.verify(dbCollection).update(match, details, false, true, WriteConcern.ACKNOWLEDGED);
+
+		Mockito.verify(dbCollection).update(
+				new BasicDBObject("CategoryID.$id", 11), new BasicDBObject("$set", new BasicDBObject("Categories", new BasicDBObject("_id", 11).append("key","value"))),
+				false, true, WriteConcern.ACKNOWLEDGED);
+	}
+
+	@Test
+	public void testUpdateEmbedIn() throws Exception {
+		String query = "UPDATE OrderDetails SET UnitPrice = 12.50 WHERE ProductID = 14";
+
+		DBCollection dbCollection = helpUpdate(query, new String[]{"Orders"}, null, null);
+
+		Mockito.verify(dbCollection, Mockito.never()).insert(new BasicDBObject(), WriteConcern.ACKNOWLEDGED);
+		Mockito.verify(dbCollection, Mockito.times(1)).update(
+				new BasicDBObject("OrderDetails.ProductID.$id", 14), new BasicDBObject("$set", new BasicDBObject("OrderDetails.$.UnitPrice", 12.5)),
+				false, true, WriteConcern.ACKNOWLEDGED);
+	}
+}

--- a/connectors/translator-mongodb/src/test/java/org/teiid/translator/mongodb/TestMongoDBUpdateVisitor.java
+++ b/connectors/translator-mongodb/src/test/java/org/teiid/translator/mongodb/TestMongoDBUpdateVisitor.java
@@ -1,0 +1,208 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.mongodb;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.LinkedHashMap;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.teiid.cdk.api.TranslationUtility;
+import org.teiid.core.util.ObjectConverterUtil;
+import org.teiid.core.util.UnitTestUtil;
+import org.teiid.language.Command;
+import org.teiid.language.Delete;
+import org.teiid.language.Insert;
+import org.teiid.language.Update;
+import org.teiid.query.metadata.TransformationMetadata;
+import org.teiid.query.unittest.RealMetadataFactory;
+import org.teiid.translator.TranslatorException;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+
+@SuppressWarnings("nls")
+public class TestMongoDBUpdateVisitor {
+
+    private MongoDBExecutionFactory translator;
+    private TranslationUtility utility;
+    private LinkedHashMap<String, DBObject> docs;
+
+    @Before
+    public void setUp() throws Exception {
+    	this.translator = new MongoDBExecutionFactory();
+    	this.translator.start();
+
+    	TransformationMetadata metadata = RealMetadataFactory.fromDDL(ObjectConverterUtil.convertFileToString(UnitTestUtil.getTestDataFile("northwind.ddl")), "sakila", "northwind");
+    	this.utility = new TranslationUtility(metadata);
+
+    }
+
+    private void helpExecute(String query, String collection, String expected, String match, String pushKey, String pullKeys) throws Exception {
+    	Command cmd = this.utility.parseCommand(query);
+    	MongoDBUpdateVisitor visitor = new MongoDBUpdateVisitor(this.translator, this.utility.createRuntimeMetadata());
+    	visitor.visitNode(cmd);
+    	if (!visitor.exceptions.isEmpty()) {
+    		throw visitor.exceptions.get(0);
+    	}
+
+    	assertEquals(collection, visitor.collectionName);
+
+    	if (cmd instanceof Insert) {
+    		assertEquals("wrong insert", expected, visitor.getInsert(null, this.docs).toString());
+    	}
+    	else if (cmd instanceof Update) {
+    		assertEquals("wrong update", expected, visitor.getUpdate(null, this.docs).toString());
+    	}
+    	else if (cmd instanceof Delete) {
+    	}
+
+    	if (visitor.match != null) {
+    		assertEquals("match wrong", match, visitor.match.toString());
+    	}
+
+    	if (visitor.pushKey != null) {
+    		assertEquals("Wrong PushKey", pushKey, visitor.pushKey.toString());
+    	}
+
+    	if (visitor.pullKeys != null && !visitor.pullKeys.isEmpty()) {
+    		assertEquals("Wrong PullKeys", visitor.pullKeys.toString(), pullKeys);
+    	}
+    	this.docs = null;
+    }
+
+	@Test
+	public void testInsert() throws Exception {
+		helpExecute("insert into users (id, user_id, age, status) values (1, 'johndoe', 34, 'A')", "users",
+				"{ \"user_id\" : { \"$ref\" : \"Customers\" , \"$id\" : \"johndoe\"} , \"id\" : 1 , \"age\" : 34 , \"status\" : \"A\"}",
+				null, null, null);
+	}
+
+	@Test
+	public void testInsertWithFKWithEmbeddable() throws Exception {
+		this.docs = new LinkedHashMap<String, DBObject>();
+		this.docs.put("Categories", new BasicDBObject("categoryK", "categoryV"));
+		this.docs.put("Suppliers", new BasicDBObject("SuppliersK", "SuppliersV"));
+		helpExecute("insert into Products (ProductID, ProductName, SupplierID, CategoryID, QuantityPerUnit, UnitPrice, UnitsInStock, UnitsOnOrder, ReorderLevel, Discontinued) " +
+				"values (1, 'hammer', 34, 24, 12, 12.50, 3, 4, 2, 1)",
+				"Products",
+				"{ \"CategoryID\" : { \"$ref\" : \"Categories\" , \"$id\" : 24} , \"SupplierID\" : { \"$ref\" : \"Suppliers\" , \"$id\" : 34} , \"_id\" : 1 , \"ProductName\" : \"hammer\" , \"QuantityPerUnit\" : \"12\" , \"UnitPrice\" : 12.5 , \"UnitsInStock\" : 3 , \"UnitsOnOrder\" : 4 , \"ReorderLevel\" : 2 , \"Discontinued\" : 1 , \"Categories\" : { \"categoryK\" : \"categoryV\"} , \"Suppliers\" : { \"SuppliersK\" : \"SuppliersV\"}}",
+				null, null,
+				"[ParentTable:Products id:24 EmbeddedTable:Categories, ParentTable:Products id:34 EmbeddedTable:Suppliers]");
+	}
+
+
+	@Test
+	public void testEmbeddedInsert() throws Exception {
+		helpExecute("insert into OrderDetails (odID, OrderID, ProductID, UnitPrice, Quantity, Discount) " +
+				"values (1, 2, 3, 1.50, 12, 1.0)",
+				"Orders",
+				"{ \"OrderID\" : { \"$ref\" : \"Orders\" , \"$id\" : 2} , \"ProductID\" : { \"$ref\" : \"Products\" , \"$id\" : 3} , \"_id\" : 1 , \"UnitPrice\" : 1.5 , \"Quantity\" : 12 , \"Discount\" : 1.0}",
+				null,
+				"ParentTable:Orders id:2 EmbeddedTable:OrderDetails", null);
+	}
+
+	@Test
+	public void testUpdate() throws Exception {
+		helpExecute("update users set age = 48",  "users", "{ \"age\" : 48}", null, null, null);
+	}
+
+	@Test
+	public void testUpdateFK() throws Exception {
+		helpExecute(
+				"update users set user_id = 'billybob'",
+				"users",
+				"{ \"user_id\" : { \"$ref\" : \"Customers\" , \"$id\" : \"billybob\"}}",
+				null, null, null);
+	}
+
+	@Test
+	public void testUpdateWithWhere() throws Exception {
+		helpExecute(
+				"update users set user_id = 'billybob' WHERE age > 50",
+				"users",
+				"{ \"user_id\" : { \"$ref\" : \"Customers\" , \"$id\" : \"billybob\"}}",
+				"{ \"age\" : { \"$gt\" : 50}}", null, null);
+	}
+
+	@Test
+	public void testDeleteWithWhere() throws Exception {
+		helpExecute("delete from users WHERE age > 50", "users", null,
+				"{ \"age\" : { \"$gt\" : 50}}", null, null);
+	}
+
+	@Test
+	public void testUpdateEmbedddedInSimpleUpdate() throws Exception {
+		helpExecute("UPDATE OrderDetails SET UnitPrice = 14.50", "Orders",
+				"{ \"OrderDetails.$.UnitPrice\" : 14.5}", null,
+				"ParentTable:Orders id:null EmbeddedTable:OrderDetails", null);
+	}
+
+	@Test
+	public void testUpdateEmbedddedInReferenceUpdate() throws Exception {
+		helpExecute("UPDATE OrderDetails SET ProductID = 4", "Orders",
+				"{ \"ProductID\" : { \"$ref\" : \"Products\" , \"$id\" : 4}}",
+				null, "ParentTable:Orders id:null EmbeddedTable:OrderDetails",
+				null);
+	}
+
+	@Test
+	public void testUpdateEmbedddedInReferenceUpdateWhere() throws Exception {
+		helpExecute("UPDATE OrderDetails SET ProductID = 4 WHERE ProductID = 3",
+				"Orders",
+				"{ \"ProductID\" : { \"$ref\" : \"Products\" , \"$id\" : 4}}", "{ \"OrderDetails.ProductID.$id\" : 3}",
+				"ParentTable:Orders id:null EmbeddedTable:OrderDetails",
+				null);
+	}
+
+	@Test(expected=TranslatorException.class)
+	public void testUpdateEmbedddedInParentUpdate() throws Exception {
+		this.docs = new LinkedHashMap<String, DBObject>();
+		this.docs.put("Products", new BasicDBObject("key", "value"));
+		helpExecute("UPDATE OrderDetails SET OrderID = 4",  "Orders", "{ \"Products.ProductID\" : { \"$ref\" : \"Products\" , \"$id\" : 4} , \"Products\" : { \"key\" : \"value\"}}", null, "ParentTable:Orders id:null EmbeddedTable:OrderDetails", null);
+	}
+
+	@Test
+	public void testUpdateParentTableWithEmbeddable() throws Exception {
+		this.docs = new LinkedHashMap<String, DBObject>();
+		this.docs.put("Categories", new BasicDBObject("categoryK", "categoryV"));
+
+		helpExecute("UPDATE Products SET CategoryID = 4",  "Products",
+				"{ \"CategoryID\" : { \"$ref\" : \"Categories\" , \"$id\" : 4} , \"Categories\" : { \"categoryK\" : \"categoryV\"}}",
+				null,
+				null,
+				"[ParentTable:Products id:4 EmbeddedTable:Categories, ParentTable:Products id:null EmbeddedTable:Suppliers]");
+	}
+
+
+	@Test
+	public void testUpdateEmbeddableTable() throws Exception {
+		this.docs = new LinkedHashMap<String, DBObject>();
+
+		helpExecute("UPDATE Categories SET Description = 'change' WHERE CategoryID = 1",  "Categories",
+				"{ \"Description\" : \"change\"}",
+				"{ \"_id\" : 1}",
+				null,
+				"");
+	}
+}

--- a/connectors/translator-mongodb/src/test/resources/northwind.ddl
+++ b/connectors/translator-mongodb/src/test/resources/northwind.ddl
@@ -1,0 +1,125 @@
+CREATE FOREIGN TABLE  Categories (
+  CategoryID integer NOT NULL auto_increment OPTIONS (NAMEINSOURCE '_id'),
+  CategoryName varchar(15),
+  Description varchar(4000),
+  Picture varchar(40),
+  PRIMARY KEY  (CategoryID),
+  UNIQUE (CategoryName)
+) OPTIONS(UPDATABLE 'TRUE', EMBEDDABLE 'TRUE');
+
+CREATE FOREIGN TABLE Suppliers (
+  SupplierID integer NOT NULL auto_increment OPTIONS (NAMEINSOURCE '_id'),
+  CompanyName varchar(40),
+  ContactName varchar(30),
+  ContactTitle varchar(30),
+  Address varchar(60),
+  City varchar(15),
+  Region varchar(15),
+  PostalCode varchar(10),
+  Country varchar(15),
+  Phone varchar(24),
+  Fax varchar(24),
+  HomePage varchar(4000),
+  PRIMARY KEY  (SupplierID)
+)OPTIONS(UPDATABLE 'TRUE', EMBEDDABLE 'TRUE');
+
+CREATE FOREIGN TABLE Shippers (
+  ShipperID integer NOT NULL auto_increment OPTIONS (NAMEINSOURCE '_id'),
+  CompanyName varchar(40),
+  Phone varchar(24),
+  PRIMARY KEY (ShipperID)
+)OPTIONS(UPDATABLE 'TRUE', EMBEDDABLE 'TRUE');
+
+CREATE FOREIGN TABLE Customers (
+  CustomerID varchar(5) NOT NULL default '' OPTIONS (NAMEINSOURCE '_id'),
+  CompanyName varchar(40),
+  ContactName varchar(30),
+  ContactTitle varchar(30),
+  Address varchar(60),
+  City varchar(15),
+  Region varchar(15),
+  PostalCode varchar(10),
+  Country varchar(15),
+  Phone varchar(24),
+  Fax varchar(24),
+  PRIMARY KEY  (CustomerID)
+)OPTIONS(UPDATABLE 'TRUE');
+
+CREATE FOREIGN TABLE Employees (
+  EmployeeID integer NOT NULL auto_increment OPTIONS (NAMEINSOURCE '_id'),
+  LastName varchar(20),
+  FirstName varchar(10),
+  Title varchar(30),
+  TitleOfCourtesy varchar(25),
+  BirthDate date,
+  HireDate date,
+  Address varchar(60),
+  City varchar(15),
+  Region varchar(15),
+  PostalCode varchar(10),
+  Country varchar(15),
+  HomePhone varchar(24),
+  Extension varchar(4),
+  Photo varchar(40),
+  Notes varchar(4000),
+  ReportsTo integer,
+  PRIMARY KEY  (EmployeeID)
+) OPTIONS(UPDATABLE 'TRUE');
+
+CREATE FOREIGN TABLE Products (
+  ProductID integer NOT NULL auto_increment OPTIONS (NAMEINSOURCE '_id'),
+  ProductName varchar(40),
+  SupplierID integer NOT NULL,
+  CategoryID integer NOT NULL,
+  QuantityPerUnit varchar(20),
+  UnitPrice float default '0',
+  UnitsInStock integer default '0',
+  UnitsOnOrder integer default '0',
+  ReorderLevel integer default '0',
+  Discontinued integer default '0',
+  PRIMARY KEY  (ProductID),
+  FOREIGN KEY (CategoryID) REFERENCES Categories (CategoryID),
+  FOREIGN KEY (SupplierID) REFERENCES Suppliers (SupplierID)
+) OPTIONS(UPDATABLE 'TRUE');
+
+CREATE FOREIGN TABLE Orders (
+  OrderID integer NOT NULL auto_increment OPTIONS (NAMEINSOURCE '_id'),
+  CustomerID varchar(5),
+  EmployeeID integer,
+  OrderDate date,
+  RequiredDate date,
+  ShippedDate date,
+  ShipVia integer,
+  Freight float default '0',
+  ShipName varchar(40),
+  ShipAddress varchar(60),
+  ShipCity varchar(15),
+  ShipRegion varchar(15),
+  ShipPostalCode varchar(10),
+  ShipCountry varchar(15),
+  PRIMARY KEY  (OrderID),
+  FOREIGN KEY (CustomerID) REFERENCES Customers (CustomerID),
+  FOREIGN KEY (EmployeeID) REFERENCES Employees (EmployeeID),
+  FOREIGN KEY (ShipVia) REFERENCES Shippers (ShipperID)
+) OPTIONS(UPDATABLE 'TRUE');
+
+CREATE FOREIGN TABLE OrderDetails (
+  odID integer OPTIONS (NAMEINSOURCE '_id'),
+  OrderID integer NOT NULL,
+  ProductID integer NOT NULL,
+  UnitPrice float default '0',
+  Quantity integer default '1',
+  Discount float default '0',
+  FOREIGN KEY (OrderID) REFERENCES Orders (OrderID),
+  FOREIGN KEY (ProductID) REFERENCES Products (ProductID),
+  PRIMARY KEY (OrderID,ProductID)
+) OPTIONS (EMBEDIN 'Orders', UPDATABLE 'TRUE');
+
+CREATE FOREIGN TABLE users (
+    id integer NOT NULL AUTO_INCREMENT,
+    user_id varchar(30),
+    age integer,
+    status varchar(1),
+    PRIMARY KEY (id),
+    FOREIGN KEY (user_id) REFERENCES Customers (CustomerID)
+);


### PR DESCRIPTION
Support to access MongoDB using Teiid 

This feature adds the support to integrate MongoDB as one of the supported sources in the Teiid. This commit consists of a connector module and translator module. The translator DOES NOT have capability to provide metadata to Teiid based on already existing MongoDB.  The translator can convert SELECT, INSERT, UPDATE and DELETE calls appropriately the MongoDB specific dialect. There are extended metadata features available, that can let users build a single complex document in MongoDB based on multiple individual tables in the VDB Schema defined for MongoDB. Supports creation of indexes on MongoDB. Supports aggregation and functions exposed by the MongoDB. The binary kits will have this translator preloaded.
