### PR TITLE
TEIID-2480 fixing the domain script

### DIFF
--- a/build/kits/jboss-as7/bin/scripts/teiid-domain-mode-install.cli
+++ b/build/kits/jboss-as7/bin/scripts/teiid-domain-mode-install.cli
@@ -26,7 +26,7 @@ connect
 
 /profile=ha/subsystem=security/security-domain=teiid-security:add(cache-type=default)
 /profile=ha/subsystem=security/security-domain=teiid-security/authentication=classic:add(login-modules=[{"code"=>"org.jboss.security.auth.spi.UsersRolesLoginModule", "flag"=>"required", "module-options"=>[("usersProperties"=>"${jboss.domain.config.dir}/teiid-security-users.properties"), ("rolesProperties"=>"${jboss.domain.config.dir}/teiid-security-roles.properties")]}]) 
-/profile=ha/subsystem=threads/bounded-queue-thread-pool=teiid-async:add(name=teiid-async, max-threads=4, queue-length=100)
+/profile=ha/subsystem=threads/bounded-queue-thread-pool=teiid-async:add(max-threads=4, queue-length=100)
 
 /profile=ha/subsystem=teiid:add(async-thread-pool=teiid-async, distributed-cache-jgroups-stack=udp, resultset-cache-infinispan-container=teiid-cache, preparedplan-cache-infinispan-container=teiid-cache, policy-decider-module=org.jboss.teiid)
 /profile=ha/subsystem=teiid/transport=embedded:add()
@@ -78,8 +78,5 @@ connect
 /profile=ha/subsystem=resource-adapters/resource-adapter=ldap:add(module=org.jboss.teiid.resource-adapter.ldap)
 /profile=ha/subsystem=resource-adapters/resource-adapter=salesforce:add(module=org.jboss.teiid.resource-adapter.salesforce)
 /profile=ha/subsystem=resource-adapters/resource-adapter=webservice:add(module=org.jboss.teiid.resource-adapter.webservice)
-
-deploy --server-groups=main-server-group ../modules/org/jboss/teiid/main/deployments/teiid-odata-${project.version}.war
-
 
 /server-group=main-server-group:restart-servers  


### PR DESCRIPTION
fixing the domain script, removed unsupported use of name={value} when adding teiid-async and removed the deployment of the odata war, because its being deployed by AS
