### PR TITLE
TEIID-2532 - fixed the connection factory as to when it obtains the cache

### DIFF
--- a/connectors/connector-infinispan/src/main/rar/META-INF/MANIFEST.MF
+++ b/connectors/connector-infinispan/src/main/rar/META-INF/MANIFEST.MF
@@ -1,1 +1,1 @@
-Dependencies: org.jboss.teiid.common-core,org.jboss.teiid.api,javax.api,org.jboss.teiid.translator.object,org.infinispan,org.infinispan.client.hotrod,org.infinispan.cachestore.remote,org.jboss.as.clustering.infinispan,org.jboss.modules	
+Dependencies: org.jboss.teiid.common-core,org.jboss.teiid.api,javax.api,org.jboss.teiid.translator.object,org.infinispan export,org.infinispan.client.hotrod,org.infinispan.cachestore.remote,org.jboss.as.clustering.infinispan,org.jboss.modules	

--- a/connectors/connector-infinispan/src/test/java/org/teiid/resource/adapter/infinispan/RemoteInfinispanTestHelper.java
+++ b/connectors/connector-infinispan/src/test/java/org/teiid/resource/adapter/infinispan/RemoteInfinispanTestHelper.java
@@ -97,12 +97,24 @@ public class RemoteInfinispanTestHelper {
     public static synchronized void releaseServer() {
         --count;
         if (count <= 0) {
+            
+            try {
+            	if (CACHEMANAGER != null) {
+            		CACHEMANAGER.stop();
+            	}
+            } finally {
+            	CACHEMANAGER = null;
+            }
+            
             try {
                 // System.out.println("Stopping HotRot Server at " + hostAddress() + ":" + hostPort());
-                server.stop();
+                if (server != null) {
+                	server.stop();
+                }
             } finally {
                 server = null;
             }
+
         }
     }
 }

--- a/connectors/connector-infinispan/src/test/java/org/teiid/resource/adapter/infinispan/TestInfinispanConfigFileLocalCache.java
+++ b/connectors/connector-infinispan/src/test/java/org/teiid/resource/adapter/infinispan/TestInfinispanConfigFileLocalCache.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.*;
 
 import java.util.Map;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.teiid.translator.object.ObjectConnection;
@@ -33,7 +34,7 @@ import org.teiid.translator.object.ObjectConnection;
 public class TestInfinispanConfigFileLocalCache {
     
     private static InfinispanManagedConnectionFactory factory = null;
-		
+    
 	@BeforeClass
     public static void beforeEachClass() throws Exception {  
  		
@@ -42,11 +43,12 @@ public class TestInfinispanConfigFileLocalCache {
 		factory.setConfigurationFileNameForLocalCache("./src/test/resources/infinispan_persistent_config.xml");
 		factory.setCacheTypeMap(RemoteInfinispanTestHelper.CACHE_NAME + ":" + "java.lang.Long;longValue");
 		
-		// initialize container and cache
-		factory.createCacheContainer();
-		factory.getCache(RemoteInfinispanTestHelper.CACHE_NAME).put("1", new Long(12345678));
-
 	}
+	
+    @AfterClass
+    public static void closeConnection() throws Exception {
+        RemoteInfinispanTestHelper.releaseServer();
+    }
 	
     @Test
     public void testConnection() throws Exception {


### PR DESCRIPTION
fixed the connection factory to not obtain the connection at startup, but to get it when the first connection is called.  Also, missed this checkin, but the MANIFEST.MF needed 'export' added for org.infinispan
