### PR TITLE
TEIID-2638 fix CLI scripts to map the caches to the teiid-cache container

### DIFF
--- a/build/kits/jboss-as7/bin/scripts/teiid-domain-mode-install.cli
+++ b/build/kits/jboss-as7/bin/scripts/teiid-domain-mode-install.cli
@@ -28,7 +28,7 @@ connect
 /profile=ha/subsystem=security/security-domain=teiid-security/authentication=classic:add(login-modules=[{"code"=>"org.jboss.security.auth.spi.UsersRolesLoginModule", "flag"=>"required", "module-options"=>[("usersProperties"=>"${jboss.domain.config.dir}/teiid-security-users.properties"), ("rolesProperties"=>"${jboss.domain.config.dir}/teiid-security-roles.properties")]}]) 
 /profile=ha/subsystem=threads/bounded-queue-thread-pool=teiid-async:add(max-threads=4, queue-length=100)
 
-/profile=ha/subsystem=teiid:add(async-thread-pool=teiid-async, distributed-cache-jgroups-stack=udp, resultset-cache-infinispan-container=resultset-repl, preparedplan-cache-infinispan-container=preparedplan, policy-decider-module=org.jboss.teiid)
+/profile=ha/subsystem=teiid:add(async-thread-pool=teiid-async, distributed-cache-jgroups-stack=udp, resultset-cache-infinispan-container=teiid-cache, preparedplan-cache-infinispan-container=teiid-cache, policy-decider-module=org.jboss.teiid)
 /profile=ha/subsystem=teiid/transport=embedded:add()
 /profile=ha/subsystem=teiid/transport=odata:add(authentication-security-domain=teiid-security)
 /profile=ha/subsystem=teiid/transport=jdbc:add(protocol=teiid, socket-binding=teiid-jdbc, authentication-security-domain=teiid-security)

--- a/build/kits/jboss-as7/bin/scripts/teiid-standalone-mode-install.cli
+++ b/build/kits/jboss-as7/bin/scripts/teiid-standalone-mode-install.cli
@@ -25,7 +25,7 @@ connect
 /subsystem=security/security-domain=teiid-security/authentication=classic:add(login-modules=[{"code"=>"org.jboss.security.auth.spi.UsersRolesLoginModule", "flag"=>"required", "module-options"=>[("usersProperties"=>"${jboss.server.config.dir}/teiid-security-users.properties"), ("rolesProperties"=>"${jboss.server.config.dir}/teiid-security-roles.properties")]}]) 
 /subsystem=threads/bounded-queue-thread-pool=teiid-async:add(max-threads=4, queue-length=100)
 
-/subsystem=teiid:add(async-thread-pool=teiid-async, resultset-cache-infinispan-container=resultset, preparedplan-cache-infinispan-container=preparedplan, policy-decider-module=org.jboss.teiid)
+/subsystem=teiid:add(async-thread-pool=teiid-async, resultset-cache-infinispan-container=teiid-cache, preparedplan-cache-infinispan-container=teiid-cache, policy-decider-module=org.jboss.teiid)
 /subsystem=teiid/transport=embedded:add()
 /subsystem=teiid/transport=odata:add(authentication-security-domain=teiid-security)
 /subsystem=teiid/transport=jdbc:add(protocol=teiid, socket-binding=teiid-jdbc, authentication-security-domain=teiid-security)


### PR DESCRIPTION
TEIID-2638 fix CLI scripts to map the caches to the teiid-cache container
