### PR TITLE
Productization change to change the xom.jar dependency

### DIFF
--- a/build/assembly/jboss-as7/dist.xml
+++ b/build/assembly/jboss-as7/dist.xml
@@ -146,7 +146,8 @@
                         <exclude>javax.transaction:jta</exclude>
                         <exclude>org.jboss.teiid:teiid-common-core</exclude>
                         <exclude>org.jboss.teiid:teiid-api</exclude>
-                        <exclude>org.jboss.teiid:teiid-client</exclude>                        
+                        <exclude>org.jboss.teiid:teiid-client</exclude>     
+                        <exclude>xom:xom</exclude>                    
                     </excludes>
                     <useProjectArtifact>true</useProjectArtifact>
                     <unpack>false</unpack>

--- a/build/kits/jboss-as7/modules/system/layers/base/org/jboss/teiid/main/module.xml
+++ b/build/kits/jboss-as7/modules/system/layers/base/org/jboss/teiid/main/module.xml
@@ -7,7 +7,6 @@
         <resource-root path="teiid-runtime-${project.version}.jar" />
         <resource-root path="teiid-engine-${project.version}.jar" />
         <resource-root path="saxonhe-9.2.1.5.jar" />
-        <resource-root path="xom-1.2.jar" />
         <resource-root path="nux-1.6.jar" />
         
         <resource-root path="deployments" />
@@ -23,7 +22,7 @@
         <module name="org.jboss.teiid.admin" />
         <module name="org.jboss.logging" />
         <module name="org.jboss.as.controller"/>
-        <module name="org.jboss.modules"/>
+        <module name="org.jboss.modules"/>      
         <module name="org.jboss.msc" />
         <module name="org.jboss.netty"/>
         <module name="org.jboss.staxmapper" />
@@ -47,6 +46,8 @@
         <module name="org.jboss.ironjacamar.api"/>
         <module name="org.jboss.ironjacamar.impl"/>
         <module name="org.jgroups"/>
+        <module name="nu.xom" />
+        <module name="org.jaxen" />        
     </dependencies>
 
 </module>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -105,12 +105,23 @@
             <artifactId>nux</artifactId>
             <version>1.6</version>
         </dependency>
+         
 
         <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <version>1.2</version>
+          <groupId>xom</groupId>
+          <artifactId>xom</artifactId>
+          <version>1.2.5</version>
+          <scope>provided</scope>
         </dependency>
+
+        <dependency>
+          <groupId>jaxen</groupId>
+          <artifactId>jaxen</artifactId>
+          <version>1.1.4</version>
+          <scope>provided</scope>          
+        </dependency>
+
+
 	</dependencies>
 
 </project>

--- a/test-integration/common/pom.xml
+++ b/test-integration/common/pom.xml
@@ -44,6 +44,20 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+          <groupId>xom</groupId>
+          <artifactId>xom</artifactId>
+          <version>1.2.5</version>
+          <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>jaxen</groupId>
+          <artifactId>jaxen</artifactId>
+          <version>1.1.4</version>
+          <scope>provided</scope>          
+        </dependency>        
 	</dependencies>
     
     <profiles>


### PR DESCRIPTION
Productization change to change the xom.jar dependency which now will rely on modules for xom and jaxen.

Note, due to time constraints, the embedded kit was not evaluated at this time for any dependency changes since it is not being productized in EDS 6.
