### PR TITLE
TEIID-2664: Making TeiidProviderProducer client map, concurrent and boun...

### DIFF
--- a/jboss-integration/src/main/java/org/teiid/jboss/TransportService.java
+++ b/jboss-integration/src/main/java/org/teiid/jboss/TransportService.java
@@ -212,7 +212,8 @@ public class TransportService implements Service<ClientServiceRegistry>, ClientS
     			
 		DQP dqpProxy = proxyService(DQP.class, getDQP(), LogConstants.CTX_DQP);
     	this.csr.registerClientService(ILogon.class, logon, LogConstants.CTX_SECURITY);
-    	this.csr.registerClientService(DQP.class, dqpProxy, LogConstants.CTX_DQP);
+    	this.csr.registerClientService(DQP.class, dqpProxy, LogConstants.CTX_DQP);    	
+	 	this.csr.registerClientService(VDBRepository.class, getVdbRepository(), LogConstants.CTX_DQP);    	
 	}
 
 	@Override
@@ -245,6 +246,7 @@ public class TransportService implements Service<ClientServiceRegistry>, ClientS
 
 		return iface.cast(Proxy.newProxyInstance(this.getClass().getClassLoader(), new Class[] {iface}, new LogManager.LoggingProxy(instance, context, MessageLevel.TRACE) {
 
+			@Override
 			public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
 				Throwable exception = null;
 				try {

--- a/odata/src/main/java/org/teiid/odata/LocalClient.java
+++ b/odata/src/main/java/org/teiid/odata/LocalClient.java
@@ -76,7 +76,7 @@ public class LocalClient implements Client {
 	private static final String BATCH_SIZE = "batch-size"; //$NON-NLS-1$
 	private static final String SKIPTOKEN_TIME = "skiptoken-cache-time"; //$NON-NLS-1$
 
-	private MetadataStore metadataStore;
+	private volatile MetadataStore metadataStore;
 	private String vdbName;
 	private int vdbVersion;
 	private int batchSize;
@@ -84,7 +84,6 @@ public class LocalClient implements Client {
 	private String transportName;
 	private String connectionString;
 	private EdmDataServices edmMetaData;
-	private long lastLookup = -1L;
 	private TeiidDriver driver = TeiidDriver.getInstance();
 
 	public LocalClient(String vdbName, int vdbVersion, Properties props) {
@@ -114,7 +113,7 @@ public class LocalClient implements Client {
 		this.driver = driver;
 	}
 
-	private ConnectionImpl getConnection() throws SQLException {
+	ConnectionImpl getConnection() throws SQLException {
 		return driver.connect(this.connectionString, null);
 	}
 
@@ -180,10 +179,8 @@ public class LocalClient implements Client {
 
 	@Override
 	public MetadataStore getMetadataStore() {
-		MetadataStore store = null;
 		ConnectionImpl connection = null;
-		long currentTime = System.currentTimeMillis();
-		if (this.metadataStore == null || this.lastLookup == -1 || currentTime-this.lastLookup > this.cacheTime) {
+		if (this.metadataStore == null) {
 			try {
 				connection = getConnection();
 				LocalServerConnection lsc = (LocalServerConnection)connection.getServerConnection();
@@ -191,7 +188,7 @@ public class LocalClient implements Client {
 				if (vdb == null) {
 					throw new NotFoundException(ODataPlugin.Util.gs(ODataPlugin.Event.TEIID16001, this.vdbName, this.vdbVersion));
 				}
-				store = vdb.getAttachment(TransformationMetadata.class).getMetadataStore();
+				this.metadataStore = vdb.getAttachment(TransformationMetadata.class).getMetadataStore();
 			} catch (SQLException e) {
 				throw new TeiidRuntimeException(RuntimePlugin.Event.TEIID40067, e);
 			} finally {
@@ -203,13 +200,6 @@ public class LocalClient implements Client {
 					}
 				}
 			}
-		}
-
-		// this is check if the vdb has reloaded between calls. Hopefully the above look up is not expensive and by doing
-		// object id match we can figure out there has been change in vdb load
-		if (this.metadataStore == null || this.metadataStore != store) {
-			this.metadataStore = store;
-			this.edmMetaData = null;
 		}
 		return this.metadataStore;
 	}

--- a/odata/src/main/java/org/teiid/odata/ODataPlugin.java
+++ b/odata/src/main/java/org/teiid/odata/ODataPlugin.java
@@ -53,5 +53,6 @@ public class ODataPlugin {
     	TEIID16011, 
     	TEIID16012,
     	TEIID16013,
+    	TEIID16014
     }
 }

--- a/odata/src/main/resources/org/teiid/odata/i18n.properties
+++ b/odata/src/main/resources/org/teiid/odata/i18n.properties
@@ -33,3 +33,4 @@ TEIID16010=Bad expression provided; or not supported
 TEIID16011=EntitySet "{0}" is not found; Check the spelling, use modelName.tableName; The table that representing the Entity type must either have a PRIMARY KEY or UNIQUE key(s)
 TEIID16012=Could not produce a sucessful OData response.  Returning status {0} with message {1}.
 TEIID16013=Error occured producing OData result.
+TEIID16014=Failed to register the VDB listener

--- a/runtime/src/main/java/org/teiid/runtime/EmbeddedServer.java
+++ b/runtime/src/main/java/org/teiid/runtime/EmbeddedServer.java
@@ -359,6 +359,15 @@ public class EmbeddedServer extends AbstractVDBDeployer implements EventDistribu
 						protected ClientServiceRegistry getClientServiceRegistry(String name) {
 							return services;
 						}
+						
+						@Override
+						public void addListener(VDBLifeCycleListener listener) {
+							EmbeddedServer.this.repo.addListener(listener);
+						}
+						@Override
+						public void removeListener(VDBLifeCycleListener listener) {
+							EmbeddedServer.this.repo.removeListener(listener);
+						}						
 					};
 				} catch (CommunicationException e) {
 					throw TeiidSQLException.create(e);

--- a/runtime/src/main/java/org/teiid/transport/LocalServerConnection.java
+++ b/runtime/src/main/java/org/teiid/transport/LocalServerConnection.java
@@ -38,9 +38,12 @@ import org.teiid.client.security.ILogon;
 import org.teiid.client.security.LogonException;
 import org.teiid.client.security.LogonResult;
 import org.teiid.client.util.ExceptionUtil;
+import org.teiid.core.ComponentNotFoundException;
 import org.teiid.core.TeiidComponentException;
 import org.teiid.core.TeiidRuntimeException;
 import org.teiid.core.util.PropertiesUtils;
+import org.teiid.deployers.VDBLifeCycleListener;
+import org.teiid.deployers.VDBRepository;
 import org.teiid.dqp.internal.process.DQPWorkContext;
 import org.teiid.jdbc.EmbeddedProfile;
 import org.teiid.net.CommunicationException;
@@ -205,5 +208,27 @@ public class LocalServerConnection implements ServerConnection {
 	@Override
 	public boolean isLocal() {
 		return true;
+	}
+	
+	public void addListener(VDBLifeCycleListener listener) {
+		try {
+			VDBRepository repo = csr.getClientService(VDBRepository.class);
+			if (repo != null) {
+				repo.addListener(listener);
+			}
+		} catch (ComponentNotFoundException e) {
+			throw new TeiidRuntimeException(RuntimePlugin.Event.TEIID40067, e);
+		}
+	}
+	
+	public void removeListener(VDBLifeCycleListener listener) {
+		try {
+			VDBRepository repo = csr.getClientService(VDBRepository.class);
+			if (repo != null) {
+				repo.removeListener(listener);
+			}
+		} catch (ComponentNotFoundException e) {
+			throw new TeiidRuntimeException(RuntimePlugin.Event.TEIID40067, e);
+		}
 	}
 }


### PR DESCRIPTION
...ded map. Also registered the TeiidProviderProducer as VDB Lifecycle listener so that this map can be cleaned up when the vdb undeploys, also made the entries in the map as soft-references such that incase of low memory the connection objects can be reclaimed
