### PR TITLE
TEIID-2670: The connection-type has never been added to the vdb.xml sche...

### DIFF
--- a/admin/src/main/java/org/teiid/adminapi/impl/VDBMetadataParser.java
+++ b/admin/src/main/java/org/teiid/adminapi/impl/VDBMetadataParser.java
@@ -104,6 +104,9 @@ public class VDBMetadataParser {
 			case DESCRIPTION:
 				vdb.setDescription(reader.getElementText());
 				break;
+			case CONNECTION_TYPE:
+				vdb.setConnectionType(reader.getElementText());
+				break;
 			case PROPERTY:
 		    	parseProperty(reader, vdb);
 				break;
@@ -149,7 +152,9 @@ public class VDBMetadataParser {
 
 	private static void ignoreTillEnd(XMLStreamReader reader)
 			throws XMLStreamException {
-		while(reader.nextTag() != XMLStreamConstants.END_ELEMENT);
+		while(reader.nextTag() != XMLStreamConstants.END_ELEMENT) {
+			;
+		}
 	}
 
 	private static void parseProperty(XMLStreamReader reader, AdminObjectImpl anObj)
@@ -371,6 +376,7 @@ public class VDBMetadataParser {
 	    NAME("name"),
 	    VERSION("version"),
 	    DESCRIPTION("description"),
+	    CONNECTION_TYPE("connection-type"),
 	    PROPERTY("property"),
 	    VALUE("value"),
 	    MODEL("model"),
@@ -426,7 +432,9 @@ public class VDBMetadataParser {
 	        final Map<String, Element> map = new HashMap<String, Element>();
 	        for (Element element : values()) {
 	            final String name = element.getLocalName();
-	            if (name != null) map.put(name, element);
+	            if (name != null) {
+					map.put(name, element);
+				}
 	        }
 	        elements = map;
 	    }
@@ -453,6 +461,7 @@ public class VDBMetadataParser {
 		if (vdb.getDescription() != null) {
 			writeElement(writer, Element.DESCRIPTION, vdb.getDescription());
 		}
+		writeElement(writer, Element.CONNECTION_TYPE, vdb.getConnectionType().name());
 		writeProperties(writer, vdb.getPropertiesMap());
 
 		for (VDBImport vdbImport : vdb.getVDBImports()) {

--- a/admin/src/test/java/org/teiid/adminapi/impl/TestVDBMetaData.java
+++ b/admin/src/test/java/org/teiid/adminapi/impl/TestVDBMetaData.java
@@ -21,7 +21,12 @@
  */
 package org.teiid.adminapi.impl;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -65,6 +70,7 @@ public class TestVDBMetaData {
 		ModelMetaData modelTwo;
 		assertEquals("myVDB", vdb.getName()); //$NON-NLS-1$
 		assertEquals("vdb description", vdb.getDescription()); //$NON-NLS-1$
+		assertEquals("connection-type", "NONE", vdb.getConnectionType().name());
 		assertEquals(1, vdb.getVersion());
 		assertEquals("vdb-value", vdb.getPropertyValue("vdb-property")); //$NON-NLS-1$ //$NON-NLS-2$
 		assertEquals("vdb-value2", vdb.getPropertyValue("vdb-property2")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -150,6 +156,7 @@ public class TestVDBMetaData {
 		VDBMetaData vdb = new VDBMetaData();
 		vdb.setName("myVDB"); //$NON-NLS-1$
 		vdb.setDescription("vdb description"); //$NON-NLS-1$
+		vdb.setConnectionType("NONE");
 		vdb.setVersion(1);
 		vdb.addProperty("vdb-property", "vdb-value"); //$NON-NLS-1$ //$NON-NLS-2$
 		vdb.addProperty("vdb-property2", "vdb-value2"); //$NON-NLS-1$ //$NON-NLS-2$

--- a/admin/src/test/resources/parser-test-vdb.xml
+++ b/admin/src/test/resources/parser-test-vdb.xml
@@ -1,5 +1,6 @@
 <vdb name="myVDB" version="1">
     <description>vdb description</description>
+    <connection-type>NONE</connection-type>
     <property name="vdb-property2">vdb-value2</property>
     <property name="vdb-property" value="vdb-value"></property>
     <import-vdb name="x" version="2"/>

--- a/client/src/main/resources/vdb-deployer.xsd
+++ b/client/src/main/resources/vdb-deployer.xsd
@@ -7,6 +7,7 @@
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="description" type="xs:string" minOccurs="0"/>
+                <xs:element name="connection-type" type="xs:string" minOccurs="0" default="BY_VERSION"/>
 				<xs:element name="property" type="property" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element name="import-vdb" maxOccurs="unbounded" minOccurs="0">
 					<xs:annotation>


### PR DESCRIPTION
...ma or to persistence classes. It was only captured in the VDBMetadata class, thus during the restarts of the server previously set value was being lost.
