### PR TITLE
Teiid 2696 - changed to property drive CLI scripting of the resource adapters

### DIFF
--- a/build/kits/jboss-as7/docs/teiid/datasources/file/create-ds.cli
+++ b/build/kits/jboss-as7/docs/teiid/datasources/file/create-ds.cli
@@ -1,4 +1,0 @@
-/subsystem=resource-adapters/resource-adapter=file/connection-definitions=fileDS:add(jndi-name=java:/fileDS, class-name=org.teiid.resource.adapter.file.FileManagedConnectionFactory, enabled=true, use-java-context=true)
-/subsystem=resource-adapters/resource-adapter=file/connection-definitions=fileDS/config-properties=ParentDirectory:add(value=/home/rareddy/testing/)
-/subsystem=resource-adapters/resource-adapter=file/connection-definitions=fileDS/config-properties=AllowParentPaths:add(value=true)
-/subsystem=resource-adapters/resource-adapter=file:activate

--- a/build/kits/jboss-as7/docs/teiid/datasources/file/create-file-ds.cli
+++ b/build/kits/jboss-as7/docs/teiid/datasources/file/create-file-ds.cli
@@ -1,0 +1,5 @@
+/subsystem=resource-adapters/resource-adapter=file:add(module=org.jboss.teiid.resource-adapter.file)
+/subsystem=resource-adapters/resource-adapter=file/connection-definitions=fileDS:add(jndi-name="${jndi.name}", class-name=org.teiid.resource.adapter.file.FileManagedConnectionFactory, enabled=true, use-java-context=true)
+/subsystem=resource-adapters/resource-adapter=file/connection-definitions=fileDS/config-properties=ParentDirectory:add(value="${parent.dir}" )
+/subsystem=resource-adapters/resource-adapter=file/connection-definitions=fileDS/config-properties=AllowParentPaths:add(value="${allow.parent.paths}" )
+/subsystem=resource-adapters/resource-adapter=file:activate

--- a/build/kits/jboss-as7/docs/teiid/datasources/file/create-file-ds.properties
+++ b/build/kits/jboss-as7/docs/teiid/datasources/file/create-file-ds.properties
@@ -1,0 +1,11 @@
+# name of the resource adapter
+ra.name=fileRA
+
+# the jndi name to assign to the resource
+jndi.name=java:/fileDS
+
+# the folder location that file(s) will be located
+parent.dir=\${jboss.server.base.dir}/myData
+
+# indicates whether parent paths are allowed
+allow.parent.paths=true

--- a/build/kits/jboss-as7/docs/teiid/datasources/file/readme.txt
+++ b/build/kits/jboss-as7/docs/teiid/datasources/file/readme.txt
@@ -1,3 +1,8 @@
-In Teiid, for File datasource a JCA connector is provided and deployed at the install time. To create
-file datasource connection edit the "standalone-teiid.xml" file or "doamin-teiid.xml" file and add 
+In Teiid, for File datasource a JCA connector is provided and deployed at the install time. 1 of the 2
+following ways can be used to create file datasource connection:
+
+1.  edit the "standalone-teiid.xml" file or "doamin-teiid.xml" file and add 
 the contents of the file.xml under "resource-adapters" subsystem section.
+
+2.  edit the create-file-ds.properties to set accordingly, and then  
+run the following CLI script in the JBOSS_HOME/bin/jboss-cli.sh -c --file=create-file-ds.cli   --properties=create-file-ds.properties

--- a/build/kits/jboss-as7/docs/teiid/datasources/google/create-google-ds.cli
+++ b/build/kits/jboss-as7/docs/teiid/datasources/google/create-google-ds.cli
@@ -1,0 +1,8 @@
+/subsystem=resource-adapters/resource-adapter=google:add(module=org.jboss.teiid.resource-adapter.google)
+/subsystem=resource-adapters/resource-adapter=google/connection-definitions=googleDS:add(jndi-name="${jndi.name}", class-name=org.teiid.resource.adapter.google.SpreadsheetManagedConnectionFactory, enabled=true, use-java-context=true)
+/subsystem=resource-adapters/resource-adapter=google/connection-definitions=googleDS/config-properties=AuthMethod:add(value="${auth.method}" )
+/subsystem=resource-adapters/resource-adapter=google/connection-definitions=googleDS/config-properties=SpreadsheetName:add(value="${spreadsheet.name}" )
+/subsystem=resource-adapters/resource-adapter=google/connection-definitions=googleDS/config-properties=Username:add(value="${username}" )
+/subsystem=resource-adapters/resource-adapter=google/connection-definitions=googleDS/config-properties=Password:add(value="${password}" )
+/subsystem=resource-adapters/resource-adapter=google/connection-definitions=googleDS/config-properties=BatchSize:add(value="${batch.size}" )
+/subsystem=resource-adapters/resource-adapter=google:activate

--- a/build/kits/jboss-as7/docs/teiid/datasources/google/create-google-ds.properties
+++ b/build/kits/jboss-as7/docs/teiid/datasources/google/create-google-ds.properties
@@ -1,0 +1,9 @@
+# name of the resource adapter
+ra.name=googleRA
+
+jndi.name=java:/googleDS
+auth.method=ClientLogin
+spreadsheet.name=spreadsheetName
+batch.size=4096
+username=GoogleUserName
+password=Password

--- a/build/kits/jboss-as7/docs/teiid/datasources/google/readme.txt
+++ b/build/kits/jboss-as7/docs/teiid/datasources/google/readme.txt
@@ -1,5 +1,16 @@
+To install the google JCA connector do the following:
+
 1) Stop the server if it is running.
 2) Overlay the "modules" directory on the "<jboss-as>/modules" directory 
 3) Copy the Gdata jars (gdata-core-1.0.jar, gdata-spreadsheet-3.0.jar) to <jboss-as>/modules/com/google/gdata/main
-4) Edit the standalone-teiid.xml or domain-teiid.xml file and add contents of the "google.xml" file under the "resource-adapters" subsystem. Configure it according to the documentation.
+
+4) Then to complete the installation, choose 1 of the 2 following ways to create the datasource:
+
+a.  edit the "standalone-teiid.xml" file or "doamin-teiid.xml" file and add 
+the contents of the google.xml under "resource-adapters" subsystem section.
+
+b.  edit the create-google-ds.properties to set accordingly, and then  
+run the following CLI script in the JBOSS_HOME/bin/jboss-cli.sh -c --file=create-google-ds.cli   --properties=create-google-ds.properties
+
+
 5) restart  

--- a/build/kits/jboss-as7/docs/teiid/datasources/infinispan/create-ds.cli
+++ b/build/kits/jboss-as7/docs/teiid/datasources/infinispan/create-ds.cli
@@ -1,5 +1,0 @@
-/subsystem=resource-adapters/resource-adapter=infinispan/connection-definitions=infinispanDS:add(jndi-name=java:/infinispanDS, class-name=org.teiid.resource.adapter.infinispan.InfinispanManagedConnectionFactory, enabled=true, use-java-context=true)
-/subsystem=resource-adapters/resource-adapter=infinispan/connection-definitions=infinispanDS/config-properties=CacheTypeMap:add(value=trades:org.somewhere.Trade;tradeId)
-/subsystem=resource-adapters/resource-adapter=infinispan/connection-definitions=infinispanDS/config-properties=Module:add(value=org.somewhere)
-/subsystem=resource-adapters/resource-adapter=infinispan/connection-definitions=infinispanDS/config-properties=CacheJndiName:add(value=java:/myCache)
-/subsystem=resource-adapters/resource-adapter=infinispan:activate

--- a/build/kits/jboss-as7/docs/teiid/datasources/infinispan/create-infinispan-ds.cli
+++ b/build/kits/jboss-as7/docs/teiid/datasources/infinispan/create-infinispan-ds.cli
@@ -1,0 +1,6 @@
+/subsystem=resource-adapters/resource-adapter=infinispan:add(module=org.jboss.teiid.resource-adapter.infinispan)
+/subsystem=resource-adapters/resource-adapter=infinispan/connection-definitions=infinispanDS:add(jndi-name="${jndi.name}", class-name=org.teiid.resource.adapter.infinispan.InfinispanManagedConnectionFactory, enabled=true, use-java-context=true)
+/subsystem=resource-adapters/resource-adapter=infinispan/connection-definitions=infinispanDS/config-properties=CacheTypeMap:add(value="${cache.type.map}")
+/subsystem=resource-adapters/resource-adapter=infinispan/connection-definitions=infinispanDS/config-properties=Module:add(value="${module.name}")
+/subsystem=resource-adapters/resource-adapter=infinispan/connection-definitions=infinispanDS/config-properties=RemoteServerList:add(value="${remote.server.list}")
+/subsystem=resource-adapters/resource-adapter=infinispan:activate

--- a/build/kits/jboss-as7/docs/teiid/datasources/infinispan/create-infinispan-ds.properties
+++ b/build/kits/jboss-as7/docs/teiid/datasources/infinispan/create-infinispan-ds.properties
@@ -1,0 +1,17 @@
+# name of the resource adapter
+ra.name=infinispanRA
+
+# the jndi name to assign to the resource
+jndi.name=java:/infinispanDS
+
+# Cache Type Map(cacheName:className[;pkFieldName][,cacheName:className[;pkFieldName]...])
+cache.type.map=cacheName:org.somewhere.ClassName;fieldName
+
+# indicates which module to find the cachType
+module.name=org.somewhere
+
+# remote server host:port[;host:port….]
+remote.server.list=localhost:11222
+
+# jndi name of the cache
+#cache.jndi.name=java:/myCache

--- a/build/kits/jboss-as7/docs/teiid/datasources/infinispan/readme.txt
+++ b/build/kits/jboss-as7/docs/teiid/datasources/infinispan/readme.txt
@@ -15,3 +15,11 @@ The CacheTypeMap config property must also be set with additional metadata
 about the cache classes.  It provides a mapping from cache name to cache
 class.  When using a dynamic vdb, it should also specify the pk field
 name for each of the cache classes. 
+
+To install the infinispan connector, choose 1 of the 2 following options:
+
+1.  edit the "standalone-teiid.xml" file or "doamin-teiid.xml" file and add 
+the contents of the infinispan.xml under "resource-adapters" subsystem section.
+
+2.  edit the create-ldap-ds.properties to set accordingly, and then  
+run the following CLI script in the JBOSS_HOME/bin/jboss-cli.sh -c --file=create-infinspan-ds.cli   --properties=create-infinispan-ds.properties

--- a/build/kits/jboss-as7/docs/teiid/datasources/ldap/create-ldap-ds.cli
+++ b/build/kits/jboss-as7/docs/teiid/datasources/ldap/create-ldap-ds.cli
@@ -1,6 +1,7 @@
-/subsystem=resource-adapters/resource-adapter=ldap/connection-definitions=ldapDS:add(jndi-name=java:/ldapDS, class-name=org.teiid.resource.adapter.ldap.LDAPManagedConnectionFactory, enabled=true, use-java-context=true)
-/subsystem=resource-adapters/resource-adapter=ldap/connection-definitions=ldapDS/config-properties=LdapUrl:add(value=ldap://ldapServer:389)
-/subsystem=resource-adapters/resource-adapter=ldap/connection-definitions=ldapDS/config-properties=LdapAdminUserDN:add(value={cn=???,ou=???,dc=???})
-/subsystem=resource-adapters/resource-adapter=ldap/connection-definitions=ldapDS/config-properties=LdapAdminUserPassword:add(value={pass})
-/subsystem=resource-adapters/resource-adapter=ldap/connection-definitions=ldapDS/config-properties=LdapTxnTimeoutInMillis:add(value=-1)
+/subsystem=resource-adapters/resource-adapter=ldap:add(module=org.jboss.teiid.resource-adapter.ldap)
+/subsystem=resource-adapters/resource-adapter=ldap/connection-definitions=ldapDS:add(jndi-name="${jndi.name}", class-name=org.teiid.resource.adapter.ldap.LDAPManagedConnectionFactory, enabled=true, use-java-context=true)
+/subsystem=resource-adapters/resource-adapter=ldap/connection-definitions=ldapDS/config-properties=LdapUrl:add(value="${ldap.url}")
+/subsystem=resource-adapters/resource-adapter=ldap/connection-definitions=ldapDS/config-properties=LdapAdminUserDN:add(value="${dn}")
+/subsystem=resource-adapters/resource-adapter=ldap/connection-definitions=ldapDS/config-properties=LdapAdminUserPassword:add(value="${user.password}")
+/subsystem=resource-adapters/resource-adapter=ldap/connection-definitions=ldapDS/config-properties=LdapTxnTimeoutInMillis:add(value="${timeout}")
 /subsystem=resource-adapters/resource-adapter=ldap:activate

--- a/build/kits/jboss-as7/docs/teiid/datasources/ldap/create-ldap-ds.properties
+++ b/build/kits/jboss-as7/docs/teiid/datasources/ldap/create-ldap-ds.properties
@@ -1,0 +1,11 @@
+# name of the resource adapter
+ra.name=ldapRA
+
+# the jndi name to assign to the resource
+jndi.name=java:/ldapDS
+
+ldap.url=ldap://ldapServer:389
+
+dn=cn=???,ou=???,dc=???
+user.password=pass
+timeout=-1

--- a/build/kits/jboss-as7/docs/teiid/datasources/ldap/readme.txt
+++ b/build/kits/jboss-as7/docs/teiid/datasources/ldap/readme.txt
@@ -1,3 +1,9 @@
 In Teiid, for LDAP datasource a JCA connector is provided and deployed at the install time. To create
-ldap datasource connection edit the "standalone-teiid.xml" file or "doamin-teiid.xml" file and add 
+ldap datasource connection, choose 1 of the 2 following options:
+
+1.  edit the "standalone-teiid.xml" file or "doamin-teiid.xml" file and add 
 the contents of the ldap.xml under "resource-adapters" subsystem section.
+
+2.  edit the create-ldap-ds.properties to set accordingly, and then  
+run the following CLI script in the JBOSS_HOME/bin/jboss-cli.sh -c --file=create-ldap-ds.cli   --properties=create-ldap-ds.properties
+

--- a/build/kits/jboss-as7/docs/teiid/datasources/mongodb/create-mongodb-ds.cli
+++ b/build/kits/jboss-as7/docs/teiid/datasources/mongodb/create-mongodb-ds.cli
@@ -1,4 +1,7 @@
-/subsystem=resource-adapters/resource-adapter=mongodb/connection-definitions=mongodbDS:add(jndi-name=java:/mongodbDS, class-name=org.teiid.resource.adapter.mongodb.MongoDBManagedConnectionFactory, enabled=true, use-java-context=true)
-/subsystem=resource-adapters/resource-adapter=mongodb/connection-definitions=mongodbDS/config-properties=RemoteServerList:add(value=localhost:27017)
-/subsystem=resource-adapters/resource-adapter=mongodb/connection-definitions=mongodbDS/config-properties=Database:add(value=test)
+/subsystem=resource-adapters/resource-adapter=mongodb:add(module=org.jboss.teiid.resource-adapter.mongodb)
+/subsystem=resource-adapters/resource-adapter=mongodb/connection-definitions=mongodbDS:add(jndi-name="${jndi.name}", class-name=org.teiid.resource.adapter.mongodb.MongoDBManagedConnectionFactory, enabled=true, use-java-context=true)
+/subsystem=resource-adapters/resource-adapter=mongodb/connection-definitions=mongodbDS/config-properties=RemoteServerList:add(value="${remote.serverlist}")
+/subsystem=resource-adapters/resource-adapter=mongodb/connection-definitions=mongodbDS/config-properties=Database:add(value="${database}")
+#/subsystem=resource-adapters/resource-adapter=mongodb/connection-definitions=mongodbDS/config-properties=Username:add(value="${username}")
+#/subsystem=resource-adapters/resource-adapter=mongodb/connection-definitions=mongodbDS/config-properties=Password:add(value="${password}")
 /subsystem=resource-adapters/resource-adapter=mongodb:activate

--- a/build/kits/jboss-as7/docs/teiid/datasources/mongodb/create-mongodb-ds.properties
+++ b/build/kits/jboss-as7/docs/teiid/datasources/mongodb/create-mongodb-ds.properties
@@ -1,0 +1,11 @@
+# name of the resource adapter
+ra.name=mongoRA
+
+# the jndi name to assign to the resource
+jndi.name=java:/mongodbDS
+
+remote.serverlist=localhost:27017
+database=test
+
+#username=user
+#password=password

--- a/build/kits/jboss-as7/docs/teiid/datasources/mongodb/readme.txt
+++ b/build/kits/jboss-as7/docs/teiid/datasources/mongodb/readme.txt
@@ -1,3 +1,7 @@
-In Teiid, for MongoDB datasource a JCA connector is provided and deployed at the install time. To create
-mongodb datasource connection edit the "standalone-teiid.xml" file and add 
+In Teiid, for MongoDB datasource a JCA connector is provided and deployed at the install time. To create mongodb datasource connection, choose 1 of the 2 following options:
+
+1.  edit the "standalone-teiid.xml" file or "doamin-teiid.xml" file and add 
 the contents of the mongodb.xml under "resource-adapters" subsystem section.
+
+2.  edit the create-mongodb-ds.properties to set accordingly, and then  
+run the following CLI script in the JBOSS_HOME/bin/jboss-cli.sh -c --file=create-mongodb-ds.cli   --properties=create-mongodb-ds.properties

--- a/build/kits/jboss-as7/docs/teiid/datasources/salesforce/create-salesforce-ds.cli
+++ b/build/kits/jboss-as7/docs/teiid/datasources/salesforce/create-salesforce-ds.cli
@@ -1,5 +1,6 @@
-/subsystem=resource-adapters/resource-adapter=salesforce/connection-definitions=sfDS:add(jndi-name=java:/sfDS, class-name=org.teiid.resource.adapter.salesforce.SalesForceManagedConnectionFactory, enabled=true, use-java-context=true)
-/subsystem=resource-adapters/resource-adapter=salesforce/connection-definitions=sfDS/config-properties=URL:add(value=https://www.salesforce.com/services/Soap/u/22.0)
-/subsystem=resource-adapters/resource-adapter=salesforce/connection-definitions=sfDS/config-properties=username:add(value={user})
-/subsystem=resource-adapters/resource-adapter=salesforce/connection-definitions=sfDS/config-properties=password:add(value={password})
-/subsystem=resource-adapters/resource-adapter=salesforce/connection-definitions=sfDS:activate
+/subsystem=resource-adapters/resource-adapter=salesforce:add(module=org.jboss.teiid.resource-adapter.salesforce)
+/subsystem=resource-adapters/resource-adapter=salesforce/connection-definitions=sfDS:add(jndi-name="${jndi.name}", class-name=org.teiid.resource.adapter.salesforce.SalesForceManagedConnectionFactory, enabled=true, use-java-context=true)
+/subsystem=resource-adapters/resource-adapter=salesforce/connection-definitions=sfDS/config-properties=URL:add(value="${url}")
+/subsystem=resource-adapters/resource-adapter=salesforce/connection-definitions=sfDS/config-properties=username:add(value="${username}")
+/subsystem=resource-adapters/resource-adapter=salesforce/connection-definitions=sfDS/config-properties=password:add(value="${password}")
+/subsystem=resource-adapters/resource-adapter=salesforce:activate

--- a/build/kits/jboss-as7/docs/teiid/datasources/salesforce/create-salesforce-ds.properties
+++ b/build/kits/jboss-as7/docs/teiid/datasources/salesforce/create-salesforce-ds.properties
@@ -1,0 +1,10 @@
+# name of the resource adapter
+ra.name=salesforceRA
+
+# the jndi name to assign to the resource
+jndi.name=java:/sfDS
+
+url=https://www.salesforce.com/services/Soap/u/22.0
+
+username=user
+password=password

--- a/build/kits/jboss-as7/docs/teiid/datasources/salesforce/readme.txt
+++ b/build/kits/jboss-as7/docs/teiid/datasources/salesforce/readme.txt
@@ -11,5 +11,5 @@ the contents of the salesforce.xml under "resource-adapters" subsystem section.
 
 Option 2:
 
-Take a look at create-salesforce-ds.cli script, and modify and execute using JBoss CLI tool as below  
-./Jboss-admin.sh --file create-salesforce-ds.cli
+edit the create-salesforce-ds.properties to set accordingly, and then run the following CLI script
+ in the JBOSS_HOME/bin/jboss-cli.sh -c --file=create-salesforce-ds.cli   --properties=create-salesforce-ds.properties

--- a/build/kits/jboss-as7/docs/teiid/datasources/web-service/create-ws-ds.cli
+++ b/build/kits/jboss-as7/docs/teiid/datasources/web-service/create-ws-ds.cli
@@ -1,3 +1,4 @@
-/subsystem=resource-adapters/resource-adapter=webservice/connection-definitions=wsDS:add(jndi-name=java:/wsDS, class-name=org.teiid.resource.adapter.ws.WSManagedConnectionFactory, enabled=true, use-java-context=true)
-/subsystem=resource-adapters/resource-adapter=webservice/connection-definitions=wsDS/config-properties=EndPoint:add(value={end_point})
+/subsystem=resource-adapters/resource-adapter=webservice:add(module=org.jboss.teiid.resource-adapter.webservice)
+/subsystem=resource-adapters/resource-adapter=webservice/connection-definitions=wsDS:add(jndi-name="${jndi.name}", class-name=org.teiid.resource.adapter.ws.WSManagedConnectionFactory, enabled=true, use-java-context=true)
+/subsystem=resource-adapters/resource-adapter=webservice/connection-definitions=wsDS/config-properties=EndPoint:add(value="${end.point}")
 /subsystem=resource-adapters/resource-adapter=webservice:activate

--- a/build/kits/jboss-as7/docs/teiid/datasources/web-service/create-ws-ds.properties
+++ b/build/kits/jboss-as7/docs/teiid/datasources/web-service/create-ws-ds.properties
@@ -1,0 +1,9 @@
+# name of the resource adapter
+ra.name=fileRA
+
+# the jndi name to assign to the resource
+jndi.name=java:/wsDS
+
+# the web service end point
+end.point=http://localhost:8080/CustomerRESTWebSvc/MyRESTApplication/customerList
+

--- a/build/kits/jboss-as7/docs/teiid/datasources/web-service/readme.txt
+++ b/build/kits/jboss-as7/docs/teiid/datasources/web-service/readme.txt
@@ -1,3 +1,8 @@
 In Teiid, for web-service(SOAP, REST/HTTP) datasource a JCA connector is provided and deployed at the install time. To create
-web service datasource connection edit the "standalone-teiid.xml" file or "doamin-teiid.xml" file and add 
+web service datasource connection, choose 1 of the 2 following options:
+
+1.  edit the "standalone-teiid.xml" file or "doamin-teiid.xml" file and add 
 the contents of the ws.xml under "resource-adapters" subsystem section.
+
+2.  edit the create-ws-ds.properties to set accordingly, and then  
+run the following CLI script in the JBOSS_HOME/bin/jboss-cli.sh -c --file=create-ws-ds.cli   --properties=create-ws-ds.properties


### PR DESCRIPTION
These changes are for the resource adapter related datasources, to make the CLI script property driven
