### PR TITLE
TEIID-2716: Support INSERT/UPDATE/DELETE on Cassandra

### DIFF
--- a/connectors/translator-cassandra/src/main/java/org/teiid/translator/cassandra/CassandraExecutionFactory.java
+++ b/connectors/translator-cassandra/src/main/java/org/teiid/translator/cassandra/CassandraExecutionFactory.java
@@ -25,6 +25,7 @@ package org.teiid.translator.cassandra;
 import javax.resource.cci.ConnectionFactory;
 
 import org.teiid.core.BundleUtil;
+import org.teiid.language.Command;
 import org.teiid.language.QueryExpression;
 import org.teiid.language.Select;
 import org.teiid.logging.LogConstants;
@@ -36,7 +37,9 @@ import org.teiid.translator.ExecutionFactory;
 import org.teiid.translator.ResultSetExecution;
 import org.teiid.translator.Translator;
 import org.teiid.translator.TranslatorException;
+import org.teiid.translator.UpdateExecution;
 import org.teiid.translator.cassandra.execution.CassandraQueryExecution;
+import org.teiid.translator.cassandra.execution.CassandraUpdateExecution;
 import org.teiid.translator.cassandra.metadata.CassandraMetadataProcessor;
 
 
@@ -56,6 +59,13 @@ public class CassandraExecutionFactory extends ExecutionFactory<ConnectionFactor
 			CassandraConnection connection) throws TranslatorException {
 		return new CassandraQueryExecution((Select) command, connection, executionContext);
 	}
+
+	@Override
+	public UpdateExecution createUpdateExecution(Command command,
+			ExecutionContext executionContext, RuntimeMetadata metadata,
+			CassandraConnection connection) throws TranslatorException {
+		return new CassandraUpdateExecution(command, executionContext, metadata, connection);
+	} 	
 	
 	@Override
 	public void getMetadata(MetadataFactory metadataFactory,

--- a/connectors/translator-cassandra/src/main/java/org/teiid/translator/cassandra/execution/CassandraQueryExecution.java
+++ b/connectors/translator-cassandra/src/main/java/org/teiid/translator/cassandra/execution/CassandraQueryExecution.java
@@ -68,12 +68,16 @@ public class CassandraQueryExecution implements ResultSetExecution {
 	public void execute() throws TranslatorException {
 		CassandraSQLVisitor visitor = new CassandraSQLVisitor();
 		visitor.translateSQL(query);
-		resultSet = connection.executeQuery(visitor.getTranslatedSQL());
+		try {
+			resultSet = connection.executeQuery(visitor.getTranslatedSQL());
+		} catch(Throwable t) {
+			throw new TranslatorException(t);
+		}
 	}
 
 	@Override
 	public List<?> next() throws TranslatorException, DataNotAvailableException {
-			return getRow(resultSet.one());
+		return getRow(resultSet.one());
 	}
 	
 	/**

--- a/connectors/translator-cassandra/src/main/java/org/teiid/translator/cassandra/execution/CassandraSQLVisitor.java
+++ b/connectors/translator-cassandra/src/main/java/org/teiid/translator/cassandra/execution/CassandraSQLVisitor.java
@@ -54,11 +54,7 @@ public class CassandraSQLVisitor extends SQLStringVisitor {
 			NamedTable table = (NamedTable)obj.getFrom().get(0);
 		
 			if(table.getMetadataObject().getColumns() !=  null){
-				if (obj.getDerivedColumns().size() == table.getMetadataObject().getColumns().size()){
-					buffer.append("*");
-				}else{
-					append(obj.getDerivedColumns());
-				}
+				append(obj.getDerivedColumns());
 			}
 			buffer.append(Tokens.SPACE).append(FROM).append(Tokens.SPACE);
 			append(obj.getFrom());

--- a/connectors/translator-cassandra/src/main/java/org/teiid/translator/cassandra/execution/CassandraUpdateExecution.java
+++ b/connectors/translator-cassandra/src/main/java/org/teiid/translator/cassandra/execution/CassandraUpdateExecution.java
@@ -1,0 +1,74 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.cassandra.execution;
+
+import org.teiid.language.Command;
+import org.teiid.metadata.RuntimeMetadata;
+import org.teiid.translator.DataNotAvailableException;
+import org.teiid.translator.ExecutionContext;
+import org.teiid.translator.TranslatorException;
+import org.teiid.translator.UpdateExecution;
+import org.teiid.translator.cassandra.CassandraConnection;
+
+public class CassandraUpdateExecution implements UpdateExecution {
+	
+	private CassandraConnection connection;
+	private ExecutionContext executionContext;
+	private RuntimeMetadata metadata;
+	private Command command;
+	private int updateCount = 1;
+	
+	public CassandraUpdateExecution(Command command,
+			ExecutionContext executionContext, RuntimeMetadata metadata,
+			CassandraConnection connection) {
+		this.command = command;
+		this.executionContext = executionContext;
+		this.metadata = metadata;
+		this.connection = connection;
+	}
+
+	@Override
+	public void close() {
+	}
+
+	@Override
+	public void cancel() throws TranslatorException {
+	}
+
+	@Override
+	public void execute() throws TranslatorException {
+		CassandraSQLVisitor visitor = new CassandraSQLVisitor();
+		visitor.translateSQL(this.command);
+		try {
+			connection.executeQuery(visitor.getTranslatedSQL());
+		} catch(Throwable t) {
+			throw new TranslatorException(t);
+		}
+	}
+
+	@Override
+	public int[] getUpdateCounts() throws DataNotAvailableException,
+			TranslatorException {
+		return new int[] {this.updateCount};
+	}
+
+}

--- a/connectors/translator-cassandra/src/main/java/org/teiid/translator/cassandra/metadata/CassandraMetadataProcessor.java
+++ b/connectors/translator-cassandra/src/main/java/org/teiid/translator/cassandra/metadata/CassandraMetadataProcessor.java
@@ -25,6 +25,8 @@ package org.teiid.translator.cassandra.metadata;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.teiid.metadata.Column;
+import org.teiid.metadata.Column.SearchType;
 import org.teiid.metadata.MetadataFactory;
 import org.teiid.metadata.Table;
 import org.teiid.translator.TypeFacility;
@@ -49,7 +51,6 @@ public class CassandraMetadataProcessor {
 		for (TableMetadata columnFamily : keyspaceMetadata.getTables()){
 			addTable(columnFamily);
 		}
-		
 	}
 
 	/**
@@ -60,6 +61,7 @@ public class CassandraMetadataProcessor {
 		Table table = metadataFactory.addTable(columnFamily.getName());
 		addColumnsToTable(table, columnFamily);
 		addPrimaryKey(table, columnFamily);
+		table.setSupportsUpdate(true);
 	}
 
 	/**
@@ -74,10 +76,9 @@ public class CassandraMetadataProcessor {
 		
 		for (ColumnMetadata columnName : primaryKeys){
 			PKNames.add(columnName.getName());
+			table.getColumnByName(columnName.getName()).setSearchType(SearchType.Searchable);
 		}
-		
-		metadataFactory.addPrimaryKey("PK_" + columnFamily.getName(), PKNames, table);
-		
+		metadataFactory.addPrimaryKey("PK_" + columnFamily.getName(), PKNames, table); //$NON-NLS-1$
 	}
 
 	/**
@@ -92,9 +93,9 @@ public class CassandraMetadataProcessor {
 			Class<?> teiidRuntimeTypeFromJavaClass = TypeFacility.getRuntimeType(cqlTypeToJavaClass);
 			String type = TypeFacility.getDataTypeName(teiidRuntimeTypeFromJavaClass);
 			
-			metadataFactory.addColumn(column.getName(), type, table);
+			Column c = metadataFactory.addColumn(column.getName(), type, table);
+			c.setUpdatable(true);
+			c.setSearchType(SearchType.Unsearchable);
 		}
-		
 	}
-
 }


### PR DESCRIPTION
1) Added code to support update operations on Cassendra translator
2) removed select \* representation from SQL string, as this will generate results out of order than expected by the engine
3) Cassendra does not support criteria to pushed on non index columns, updated the metadata as such to non-searchable
4) added some exception handling, instead of bubling up
