### PR TITLE
TEIID-2766: fixig batch-size=-1 to return all the rows in the resultset....

### DIFF
--- a/odata/src/main/java/org/teiid/odata/EntityList.java
+++ b/odata/src/main/java/org/teiid/odata/EntityList.java
@@ -78,6 +78,9 @@ class EntityList extends ArrayList<OEntity>{
 		if (getCount && rs.last()) {
 			this.count = rs.getRow();
 		}
+		if (size == -1) {
+			size = Integer.MAX_VALUE;
+		}
 		for (int i = 1; i <= size; i++) {
 			if (!rs.absolute(i)) {
 				break;


### PR DESCRIPTION
... This is currently mapped to Integer.MAX_VALUE
