### PR TITLE
TEIID-2857  changed the jboss-integration-bom to the lastest CR6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
-      <groupId>org.jboss</groupId>
-      <artifactId>jboss-parent</artifactId>
-      <version>10</version>
-    </parent>    
+        <groupId>org.jboss.integration-platform</groupId>
+        <artifactId>jboss-integration-platform-parent</artifactId>
+        <version>6.0.0.CR6</version>
+    </parent>   
     <modelVersion>4.0.0</modelVersion>
 	<groupId>org.jboss.teiid</groupId>
 	<artifactId>teiid-parent</artifactId>
@@ -14,8 +14,7 @@
 	<description>Federated SQL and XML query engine.</description>
 	<properties>
 		<site.url>http://www.jboss.org/teiid</site.url>
-        <version.org.jboss.integration-platform>6.0.0-SNAPSHOT</version.org.jboss.integration-platform>
-        <jbossas-version>7.2.0.Alpha1-redhat-4</jbossas-version>
+        <version.ip-bom>6.0.0.CR3</version.ip-bom>
         <jbossas-test-version>jboss-eap-6.1</jbossas-test-version>
         <arquillian-container-version>7.2.0.Final</arquillian-container-version>
         <version.ant.plugin>1.7.0</version.ant.plugin>
@@ -23,13 +22,12 @@
         <version.org.jboss.jboss-dmr>1.1.6.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.msc.jboss-msc>1.0.4.GA</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.jboss-vfs>3.1.0.Final</version.org.jboss.jboss-vfs>
+        <version.org.jboss.modules.jboss-modules>1.2.0.CR1</version.org.jboss.modules.jboss-modules>
         <version.org.picketbox>4.0.15.Final</version.org.picketbox>
-        <version.org.infinispan>5.2.7.Final</version.org.infinispan>
         <version.org.picketbox.jbosssx-client>3.0.0.CR2</version.org.picketbox.jbosssx-client>
-        <version.org.jboss.logging.jboss-logging>3.1.2.GA</version.org.jboss.logging.jboss-logging>
-        <version.org.jboss.marshalling.jboss-marshalling-river>1.3.16.GA</version.org.jboss.marshalling.jboss-marshalling-river>
+        <version.org.jboss.marshalling.jboss-marshalling-river>${version.org.jboss.marshalling.jboss-marshalling}</version.org.jboss.marshalling.jboss-marshalling-river>
         <version.asm>3.3.1</version.asm>
-        <version.org.jboss.arquillian.core>1.0.0.Final</version.org.jboss.arquillian.core>
+        <version.org.jboss.arquillian.core>${version.org.jboss.arquillian}</version.org.jboss.arquillian.core>
         <version.javax.enterprise>1.0-SP4</version.javax.enterprise>
         <version.org.jboss.netty>3.6.2.Final</version.org.jboss.netty>
         <version.net.sourceforge.saxon>9.2.1.5</version.net.sourceforge.saxon>
@@ -38,10 +36,9 @@
         <version.jta>1.1</version.jta>
         <version.sun.jaxb>2.2.5.jboss-1</version.sun.jaxb>
         <version.javax.wsdl4j>1.6.2</version.javax.wsdl4j>
-        <version.javax.ws.rs>1.1</version.javax.ws.rs>
         <version.org.odata4j>0.8.0-SNAPSHOT-redhat</version.org.odata4j>
         <version.core4j>0.5</version.core4j>
-        <version.resteasy-jaxrs>2.3.6.Final</version.resteasy-jaxrs>
+        <version.resteasy-jaxrs>${version.org.jboss.resteasy}</version.resteasy-jaxrs>
         <version.com.force.api>26.0.0</version.com.force.api>
         <version.jaxen>1.1.4</version.jaxen>
         <version.xom>1.2.5</version.xom>
@@ -53,12 +50,10 @@
         <version.gdata-core>1.0</version.gdata-core>
         <version.mongo-java-driver>2.11.1</version.mongo-java-driver>
         <version.org.infinispan.6>6.0.0.CR1</version.org.infinispan.6>
-        <version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>1.0.1.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>
+        <version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>${version.org.hibernate.javax.persistence}</version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>
         <version.olap4j>1.1.0</version.olap4j>
-        <version.cxf>2.6.6</version.cxf>
+        <version.cxf>${version.org.apache.cxf}</version.cxf>
         <version.org.hibernate>4.1.1.Final</version.org.hibernate>
-        <version.org.apache.lucene>3.6.2</version.org.apache.lucene>
-        <cxf.version>2.6.6</cxf.version>
         <version.accumulo>1.5.0</version.accumulo>
         <version.hadoop-core>0.20.2</version.hadoop-core>
         <version.thrift>0.9.1</version.thrift>
@@ -307,17 +302,10 @@
            <dependency>
             <groupId>org.jboss.integration-platform</groupId>
             <artifactId>jboss-integration-platform-bom</artifactId>
-            <version>${version.org.jboss.integration-platform}</version>
+            <version>${version.ip-bom}</version>
             <scope>import</scope>
             <type>pom</type>
-          </dependency>   
-          <dependency>
-             <groupId>org.jboss.as</groupId>
-             <artifactId>jboss-as-parent</artifactId>
-             <version>${jbossas-version}</version>
-             <type>pom</type>
-             <scope>import</scope>
-          </dependency> 
+          </dependency>
                                            
       <!--
       Declare all dependency versions and default scopes here, but not optional.
@@ -437,9 +425,14 @@
 				</exclusions>
 			</dependency>
             <dependency>
+                <groupId>org.jboss.modules</groupId>
+                <artifactId>jboss-modules</artifactId>
+                <version>${version.org.jboss.modules.jboss-modules}</version>
+            </dependency>                         
+            <dependency>
                 <groupId>org.jboss</groupId>
                 <artifactId>jboss-common-core</artifactId>
-                <version>${version.org.jboss.common-core}</version>
+                <version>${version.org.jboss.jboss-common-core}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>
@@ -447,6 +440,36 @@
                     </exclusion>
                 </exclusions>
             </dependency>                        
+            <dependency>
+                <groupId>org.jboss</groupId>
+                <artifactId>jboss-dmr</artifactId>
+                <version>${version.org.jboss.jboss-dmr}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.msc</groupId>
+                <artifactId>jboss-msc</artifactId>
+                <version>${version.org.jboss.msc.jboss-msc}</version>
+            </dependency> 
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-subsystem-test</artifactId>
+                <version>${version.org.jboss.as}</version>
+            </dependency>     
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-cli</artifactId>  
+                <version>${version.org.jboss.as}</version>          
+            </dependency>   
+            <dependency>
+              <groupId>org.jboss.as</groupId>
+              <artifactId>jboss-as-clustering-jgroups</artifactId>
+              <version>${version.org.jboss.as}</version>
+            </dependency>             
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-controller</artifactId>
+                <version>${version.org.jboss.as}</version>
+            </dependency>                                                                                                                                    
             <dependency>
                 <groupId>org.jboss</groupId>
                 <artifactId>jboss-vfs</artifactId>
@@ -465,7 +488,7 @@
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-server</artifactId>
-                <version>${jbossas-version}</version>
+                <version>${version.org.jboss.as}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.as</groupId>
@@ -476,7 +499,7 @@
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-connector</artifactId>
-                <version>${jbossas-version}</version>
+                <version>${version.org.jboss.as}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.as</groupId>
@@ -491,7 +514,7 @@
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-security</artifactId>
-                <version>${jbossas-version}</version>
+                <version>${version.org.jboss.as}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.as</groupId>
@@ -506,12 +529,12 @@
             <dependency>
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging-generator</artifactId>
-                <version>${version.org.jboss.logging.jboss-logging-tools}</version>            
+                <version>${version.org.jboss.logging-tools}</version>            
             </dependency>   
             <dependency>
               <groupId>org.jboss.as</groupId>
               <artifactId>jboss-as-clustering-infinispan</artifactId>
-              <version>${jbossas-version}</version>
+              <version>${version.org.jboss.as}</version>
               <exclusions>
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>
@@ -706,7 +729,7 @@
             <dependency>
                 <groupId>nux</groupId>
                 <artifactId>nux</artifactId>
-                <version>1.6</version>
+                <version>{$version.nux}</version>
             </dependency>            
             <dependency>
                   <groupId>jaxen</groupId>
@@ -726,7 +749,7 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-ws-security</artifactId>
-                <version>${cxf.version}</version>
+                <version>${version.org.apache.cxf}</version>
             </dependency>                                                
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
TEIID-2857  changed the jboss-integration-bom to the lastest CR6 and jboss-as will be based on what it defines, which is version 7.2.0.Final, and some additional cleanup so that the versions are derived thru the bom dependency
