### PR TITLE
Fixed following

### DIFF
--- a/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBPlugin.java
+++ b/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBPlugin.java
@@ -56,6 +56,9 @@ public class MongoDBPlugin {
     	TEIID18020,
     	TEIID18021,
     	TEIID18022,
-    	TEIID18023
+    	TEIID18023,
+    	TEIID18024,
+    	TEIID18025,
+    	TEIID18026
     }
 }

--- a/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBQueryExecution.java
+++ b/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/MongoDBQueryExecution.java
@@ -36,11 +36,7 @@ import org.teiid.translator.ExecutionContext;
 import org.teiid.translator.ResultSetExecution;
 import org.teiid.translator.TranslatorException;
 
-import com.mongodb.AggregationOutput;
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBCollection;
-import com.mongodb.DBObject;
-import com.mongodb.MongoException;
+import com.mongodb.*;
 
 public class MongoDBQueryExecution extends MongoDBBaseExecution implements ResultSetExecution {
 	private Select command;
@@ -75,6 +71,10 @@ public class MongoDBQueryExecution extends MongoDBBaseExecution implements Resul
 			// TODO: check to see how to pass the hint
 			ArrayList<DBObject> ops = new ArrayList<DBObject>();
 			buildAggregate(ops, "$project", this.visitor.unwindProject); //$NON-NLS-1$
+			
+			if (this.visitor.project.isEmpty()) {
+			    throw new TranslatorException(MongoDBPlugin.Event.TEIID18025, MongoDBPlugin.Util.gs(MongoDBPlugin.Event.TEIID18025));
+			}
 			
 			if (this.visitor.projectBeforeMatch) {
 				buildAggregate(ops, "$project", this.visitor.project); //$NON-NLS-1$

--- a/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/SQLRewriterVisitor.java
+++ b/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/SQLRewriterVisitor.java
@@ -26,19 +26,25 @@ import java.util.List;
 
 import org.teiid.language.*;
 import org.teiid.language.visitor.HierarchyVisitor;
+import org.teiid.translator.TranslatorException;
 
 public class SQLRewriterVisitor {
+    protected ArrayList<TranslatorException> exceptions = new ArrayList<TranslatorException>();
     ArrayList<HierarchyVisitor> rewriters = new ArrayList<HierarchyVisitor>();
     
-    public static void rewrite(Select obj) {
+    public static void rewrite(Select obj) throws TranslatorException {
         new SQLRewriterVisitor(obj);
     }
     
-    private SQLRewriterVisitor(Select obj) {
+    private SQLRewriterVisitor(Select obj) throws TranslatorException {
         this.rewriters.add(new CountElementRewriter());
         
         for (HierarchyVisitor visitor:this.rewriters) {
             visitor.visitNode(obj);
+        }
+        
+        if (!this.exceptions.isEmpty()) {
+            throw this.exceptions.get(0);
         }
     }
     
@@ -48,10 +54,14 @@ public class SQLRewriterVisitor {
      * to
      * select count(*) from customer where name is not null
      */
-    public static class CountElementRewriter extends HierarchyVisitor {
+    public class CountElementRewriter extends HierarchyVisitor {
         @Override
         public void visit(Select obj) {
             if (!isAppplicable(obj)) {
+                return;
+            }
+            
+            if (!isSupported(obj)) {
                 return;
             }
             
@@ -62,7 +72,7 @@ public class SQLRewriterVisitor {
                if (column.getExpression() instanceof AggregateFunction) {
                    AggregateFunction agg = (AggregateFunction)column.getExpression();
                    if (agg.getName().equals(AggregateFunction.COUNT) && !agg.getParameters().isEmpty()) {
-                                          
+                                  
                        // now add criteria on parameter
                        Condition crit = new IsNull(agg.getParameters().get(0), true); 
                        if (obj.getWhere() != null) {
@@ -81,11 +91,25 @@ public class SQLRewriterVisitor {
             }
         }        
         
+        private boolean isSupported(Select obj) {
+            int applicable = 0;
+            for (DerivedColumn column:obj.getDerivedColumns()) {
+                if (column.getExpression() instanceof AggregateFunction) {
+                    applicable++;
+                }
+            }
+            if (applicable > 1) {
+                exceptions.add(new TranslatorException(MongoDBPlugin.Event.TEIID18024, MongoDBPlugin.Util.gs(MongoDBPlugin.Event.TEIID18024)));
+            }
+
+            return (applicable <= 1);            
+        }
+        
         private boolean isAppplicable(Select obj) {
             for (DerivedColumn column:obj.getDerivedColumns()) {
                 if (column.getExpression() instanceof AggregateFunction) {
                     AggregateFunction agg = (AggregateFunction)column.getExpression();
-                    if (agg.getName().equals(AggregateFunction.COUNT) && !agg.getParameters().isEmpty()) {
+                    if (agg.getName().equals(AggregateFunction.COUNT) && !agg.getParameters().isEmpty()) {                        
                         return true;
                     }
                 }

--- a/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/Version.java
+++ b/connectors/translator-mongodb/src/main/java/org/teiid/translator/mongodb/Version.java
@@ -1,0 +1,117 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+
+package org.teiid.translator.mongodb;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.teiid.core.util.StringUtil;
+
+/**
+ * Represents a comparable version
+ */
+public class Version implements Comparable<Version> {
+	
+	public static Version DEFAULT_VERSION = new Version(new Integer[] {0}); 
+	private static final Pattern NUMBER_PATTERN = Pattern.compile("(\\d+)"); //$NON-NLS-1$
+
+	private Integer[] parts;
+	
+	public static Version getVersion(String version) {
+		if (version == null) {
+			return null;
+		}
+		String[] parts = version.split("\\."); //$NON-NLS-1$
+		List<Integer> versionParts = new ArrayList<Integer>();
+		for (String part : parts) {
+			Integer val = null;
+			Matcher m = NUMBER_PATTERN.matcher(part);
+			if (!m.find()) {
+				continue;
+			}
+
+			String num = m.group(1);
+			try {
+				val = Integer.parseInt(num);
+			} catch (NumberFormatException e) {
+				
+			}
+			versionParts.add(val == null ? 0 : val);
+		}
+		if (versionParts.isEmpty()) {
+			return DEFAULT_VERSION;
+		}
+		return new Version(versionParts.toArray(new Integer[versionParts.size()]));
+	}
+	
+	Version(Integer[] parts) {
+		this.parts = parts;
+	}
+	
+	@Override
+	public String toString() {
+		return StringUtil.toString(this.parts, ".", false); //$NON-NLS-1$
+	}
+	
+	public int getMajorVersion() {
+		return parts[0];
+	}
+	
+	@Override
+	public int compareTo(Version o) {
+		int length = Math.min(this.parts.length, o.parts.length);
+		for (int i = 0; i < length; i++) {
+			int comp = this.parts[i].compareTo(o.parts[i]);
+			if (comp != 0) {
+				return comp;
+			}
+		}
+		if (this.parts.length > length) {
+			return 1;
+		}
+		if (o.parts.length > length) {
+			return -1;
+		}
+		return 0;
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == this) {
+			return true;
+		}
+		if (!(obj instanceof Version)) {
+			return false;
+		}
+		return this.compareTo((Version)obj) == 0;
+	}
+	
+	@Override
+	public int hashCode() {
+		return Arrays.hashCode(parts);
+	}
+
+}

--- a/connectors/translator-mongodb/src/main/resources/org/teiid/translator/mongodb/i18n.properties
+++ b/connectors/translator-mongodb/src/main/resources/org/teiid/translator/mongodb/i18n.properties
@@ -42,3 +42,6 @@ TEIID18020=Collection {0} not found in MongoDB repository.
 TEIID18021=Direct Query execution command needs to be in the form "collectionName;{$pipeline instr;}+", Even in the cases of "select *", provide at least $project clause.
 TEIID18022=Table {0} embeds table {1}, with given join clause it is not possible to produce valid results as all possible results of table {1} are not available in {0}; Thus this join is not supported.
 TEIID18023=Join query can only be based key equality 
+TEIID18024=multiple aggregate symbols are not supported in single statement
+TEIID18025=projection clause is empty, the submitted query is currently not supported
+TEIID18026=Literal expressions are supported in MongoDB from version 2.6; Upgrade MongoDB version and set database version translator property, or avoid using the Literal expression in select statement

--- a/connectors/translator-mongodb/src/test/java/org/teiid/translator/mongodb/TestMongoDBSelectVisitor.java
+++ b/connectors/translator-mongodb/src/test/java/org/teiid/translator/mongodb/TestMongoDBSelectVisitor.java
@@ -248,7 +248,6 @@ public class TestMongoDBSelectVisitor {
     	visitor.visitNode(cmd);
     	BasicDBObject expected = new BasicDBObject("_m1", 1);
     	expected.put("_m2", -1);
-    	System.out.println(visitor.project.toString());
     	assertEquals(expected, visitor.sort);
     }
 


### PR DESCRIPTION
TEIID-2983: disallowed multiple count aggregates in single select statement by throwing an exception
TEIID-2990: If no columns are projected the query will end up in exception; also if literal is being selected then added support for  from MongoDb 2.6
TEIID-2988: Added third paramters to  function to indicate the length of the string if only two parameters are supplied substring function
TEIID-2987: correctly projected when functions, aggregatefunctions are used in criteria of the sql statement, previously only column refereces were being projected
