### PR TITLE
TEIID-3102 - changed to useAnsiJoin syntax

### DIFF
--- a/connectors/translator-jdbc/src/main/java/org/teiid/translator/jdbc/modeshape/ModeShapeExecutionFactory.java
+++ b/connectors/translator-jdbc/src/main/java/org/teiid/translator/jdbc/modeshape/ModeShapeExecutionFactory.java
@@ -256,5 +256,16 @@ public class ModeShapeExecutionFactory extends JDBCExecutionFactory {
     @Override
     public MetadataProcessor<Connection> getMetadataProcessor() {
         return new ModeShapeJDBCMetdataProcessor();
-    }	   
+    }	
+    
+    /**
+     * TEIID-3102 - ModeShape requires the use of JOIN, and not ',' when joining tables.
+     * {@inheritDoc}
+     *
+     * @see org.teiid.translator.ExecutionFactory#useAnsiJoin()
+     */
+	@Override
+	public boolean useAnsiJoin() {
+		return true;
+	}
 }

--- a/connectors/translator-jdbc/src/test/java/org/teiid/translator/jdbc/modeshape/TestModeShapeCapabilities.java
+++ b/connectors/translator-jdbc/src/test/java/org/teiid/translator/jdbc/modeshape/TestModeShapeCapabilities.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+
+package org.teiid.translator.jdbc.modeshape;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class TestModeShapeCapabilities {
+	
+	@Test public void testUseAnsiJoin() {
+		ModeShapeExecutionFactory msCapabilities = new ModeShapeExecutionFactory();
+		assertTrue(msCapabilities.useAnsiJoin());
+	}
+	
+
+}

--- a/connectors/translator-jdbc/src/test/java/org/teiid/translator/jdbc/modeshape/TestModeShapeSqlTranslator.java
+++ b/connectors/translator-jdbc/src/test/java/org/teiid/translator/jdbc/modeshape/TestModeShapeSqlTranslator.java
@@ -70,6 +70,18 @@ public class TestModeShapeSqlTranslator {
 		cols.get(0).setNameInSource("\"jcr:path\"");
 		cols.get(1).setNameInSource("\"mode:properties\"");
 		cols.get(2).setNameInSource("\"jcr:primaryType\"");
+		
+    	Table nt_version = RealMetadataFactory.createPhysicalGroup("nt_version", modeshape);
+    	nt_version.setNameInSource("\"nt:version\"");
+		List<Column> cols2 = RealMetadataFactory.createElements(nt_version, new String[] { "jcr_path",
+				"mode_properties", "jcr_primaryType", "prop" }, new String[] {
+				TypeFacility.RUNTIME_NAMES.STRING,
+				TypeFacility.RUNTIME_NAMES.STRING,
+				TypeFacility.RUNTIME_NAMES.STRING,
+				TypeFacility.RUNTIME_NAMES.STRING });
+		cols2.get(0).setNameInSource("\"jcr:path\"");
+		cols2.get(1).setNameInSource("\"mode:properties\"");
+		cols2.get(2).setNameInSource("\"jcr:primaryType\"");		
     	return RealMetadataFactory.createTransformationMetadata(store, "modeshape");
     }
 
@@ -114,7 +126,20 @@ public class TestModeShapeSqlTranslator {
 		String output = "SELECT g_0.\"jcr:primaryType\" FROM \"nt:base\" AS g_0 WHERE g_0.\"jcr:primaryType\" LIKE '%relational%'"; //$NON-NLS-1$
 
 		helpTestVisitor(input, output);
-
 	}
+	
+	/**
+	 * TEIID-3102
+	 * @throws Exception 
+	 */
+	@Test
+	public void testSelectJoin() throws Exception {
+
+		String input = "select nt_base.jcr_path from nt_base join nt_version  ON JCR_ISCHILDNODE(nt_base.jcr_path, nt_version.jcr_path)"; //$NON-NLS-1$
+		String output = "SELECT g_0.\"jcr:path\" FROM \"nt:base\" AS g_0 INNER JOIN \"nt:version\" AS g_1 ON ISCHILDNODE(g_0, g_1)"; //$NON-NLS-1$
+
+		helpTestVisitor(input, output);
+
+	}		
 	
 }


### PR DESCRIPTION
TEIID-3102 - changed to useAnsiJoin syntax because ModeShape requires JOIN syntax

TEIID-3102 added unit test

TEIID-3102  added unit test for JOIN and JCR_ISCHILDNODE
