### PR TITLE
TEIID-2914 removing the SupportsLuceneSearching option

### DIFF
--- a/connectors/connector-infinispan.6/src/main/rar/META-INF/ra.xml
+++ b/connectors/connector-infinispan.6/src/main/rar/META-INF/ra.xml
@@ -70,13 +70,7 @@
                <description>{$display:"Cache JndiName",$description:"JNDI Name to find CacheContainer"}</description>
                <config-property-name>CacheJndiName</config-property-name>
                <config-property-type>java.lang.String</config-property-type>
-            </config-property>           
- 
-             <config-property>
-               <description>{$display:"Support Lucene Searching",$description:"Support Lucene Searching"}</description>
-               <config-property-name>SupportLuceneSearching</config-property-name>
-               <config-property-type>java.lang.Boolean</config-property-type>
-            </config-property>                                 
+            </config-property>                                        
             
             <connectionfactory-interface>javax.resource.cci.ConnectionFactory</connectionfactory-interface>
             <connectionfactory-impl-class>org.teiid.resource.spi.WrappedConnectionFactory</connectionfactory-impl-class>

--- a/connectors/connector-infinispan/src/main/rar/META-INF/ra.xml
+++ b/connectors/connector-infinispan/src/main/rar/META-INF/ra.xml
@@ -71,12 +71,7 @@
                <config-property-name>CacheJndiName</config-property-name>
                <config-property-type>java.lang.String</config-property-type>
             </config-property>           
- 
-             <config-property>
-               <description>{$display:"Support Lucene Searching",$description:"Support Lucene Searching"}</description>
-               <config-property-name>SupportLuceneSearching</config-property-name>
-               <config-property-type>java.lang.Boolean</config-property-type>
-            </config-property>                                 
+                               
             
             <connectionfactory-interface>javax.resource.cci.ConnectionFactory</connectionfactory-interface>
             <connectionfactory-impl-class>org.teiid.resource.spi.WrappedConnectionFactory</connectionfactory-impl-class>


### PR DESCRIPTION
TEIID-2914 removing the SupportsLuceneSearching option in the resource adapters, for which the option is provided at the translator
