### PR TITLE
TEIID-3105: add allowDuplicateDomains in Infinispan global configuration

### DIFF
--- a/runtime/src/main/resources/infinispan-config.xml
+++ b/runtime/src/main/resources/infinispan-config.xml
@@ -27,7 +27,9 @@
       xsi:schemaLocation="urn:infinispan:config:5.1 http://www.infinispan.org/schemas/infinispan-config-5.1.xsd"
       xmlns="urn:infinispan:config:5.1">
 
-    <global/>
+    <global>
+        <globalJmxStatistics allowDuplicateDomains="true"/>
+    </global>
 
     <namedCache name="resultset">
         <transaction transactionMode="TRANSACTIONAL"/>

--- a/runtime/src/test/java/org/teiid/runtime/TestEmbeddedServer.java
+++ b/runtime/src/test/java/org/teiid/runtime/TestEmbeddedServer.java
@@ -968,5 +968,38 @@ public class TestEmbeddedServer {
 		}
 		
 	}
+	
+	@Test
+	public void testMultipleEmbeddedServerInOneVM() throws TranslatorException {
+		es.addTranslator(MyEFES1.class);
+		es.start(new EmbeddedConfiguration());
+		assertTrue(isES1started);
+
+		EmbeddedServer es2 = new EmbeddedServer();
+		es2.start(new EmbeddedConfiguration());
+		es2.addTranslator(MyEFES2.class);
+		assertTrue(isES2started);
+		es2.stop();
+	}
+
+	public static boolean isES1started;
+	public static boolean isES2started;
+
+	public static class MyEFES1 extends ExecutionFactory<Void, Void> {
+
+		@Override
+		public void start() throws TranslatorException {
+			isES1started = true;
+		}
+	}
+
+	public static class MyEFES2 extends ExecutionFactory<Void, Void> {
+
+		@Override
+		public void start() throws TranslatorException {
+			isES2started = true;
+		}
+	}
+
 
 }


### PR DESCRIPTION
add allowDuplicateDomains in Infinispan global configuration, this will guarantee the following scenarios work fine:
- two or more embedded server instances in one VM 
- VM already have a Infinispan CacheManager, and want create a teiid embedded instance.
- VM already run a teiid embedded instance, and want create a Infinispan CacheManager
