### PR TITLE
TEIID-3098 changed to expose the ModeShape JCR functions in the metadata

### DIFF
--- a/connectors/translator-jdbc/src/main/java/org/teiid/translator/jdbc/modeshape/IdentifierFunctionModifier.java
+++ b/connectors/translator-jdbc/src/main/java/org/teiid/translator/jdbc/modeshape/IdentifierFunctionModifier.java
@@ -41,7 +41,8 @@ import org.teiid.translator.jdbc.FunctionModifier;
  */
 public class IdentifierFunctionModifier extends FunctionModifier {
 
-    public List<?> translate(Function function) {
+	@Override
+	public List<?> translate(Function function) {
     	
     	List<Object> objs = new ArrayList<Object>();
     	

--- a/connectors/translator-jdbc/src/main/java/org/teiid/translator/jdbc/modeshape/ModeShapeExecutionFactory.java
+++ b/connectors/translator-jdbc/src/main/java/org/teiid/translator/jdbc/modeshape/ModeShapeExecutionFactory.java
@@ -47,12 +47,12 @@ import org.teiid.translator.jdbc.JDBCMetdataProcessor;
 @Translator(name="modeshape", description="A translator for the open source Modeshape JCR Repository")
 public class ModeShapeExecutionFactory extends JDBCExecutionFactory {
 	
-	private static final String JCR = "JCR"; //$NON-NLS-1$
-	private static final String JCR_REFERENCE = "JCR_REFERENCE";//$NON-NLS-1$
-	private static final String JCR_CONTAINS = "JCR_CONTAINS";//$NON-NLS-1$
-	private static final String JCR_ISSAMENODE = "JCR_ISSAMENODE";//$NON-NLS-1$
-	private static final String JCR_ISDESCENDANTNODE = "JCR_ISDESCENDANTNODE";//$NON-NLS-1$
-	private static final String JCR_ISCHILDNODE = "JCR_ISCHILDNODE";//$NON-NLS-1$
+	static final String JCR = "JCR"; //$NON-NLS-1$
+	static final String JCR_REFERENCE = "JCR_REFERENCE";//$NON-NLS-1$
+	static final String JCR_CONTAINS = "JCR_CONTAINS";//$NON-NLS-1$
+	static final String JCR_ISSAMENODE = "JCR_ISSAMENODE";//$NON-NLS-1$
+	static final String JCR_ISDESCENDANTNODE = "JCR_ISDESCENDANTNODE";//$NON-NLS-1$
+	static final String JCR_ISCHILDNODE = "JCR_ISCHILDNODE";//$NON-NLS-1$
 	
 	public ModeShapeExecutionFactory() {
 		setUseBindVariables(false);
@@ -107,6 +107,11 @@ public class ModeShapeExecutionFactory extends JDBCExecutionFactory {
 		supportedFunctions.add(SourceSystemFunctions.UCASE); 
 		supportedFunctions.add(SourceSystemFunctions.LCASE); 
 		supportedFunctions.add(SourceSystemFunctions.LENGTH);
+		supportedFunctions.add(JCR_ISCHILDNODE); 
+		supportedFunctions.add(JCR_ISDESCENDANTNODE); 
+		supportedFunctions.add(JCR_ISSAMENODE);
+		supportedFunctions.add(JCR_REFERENCE); 
+		supportedFunctions.add(JCR_CONTAINS);
 		return supportedFunctions;
     }
     

--- a/connectors/translator-jdbc/src/test/java/org/teiid/translator/jdbc/modeshape/TestMetadataProcessor.java
+++ b/connectors/translator-jdbc/src/test/java/org/teiid/translator/jdbc/modeshape/TestMetadataProcessor.java
@@ -1,0 +1,59 @@
+package org.teiid.translator.jdbc.modeshape;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Properties;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.teiid.metadata.MetadataFactory;
+import org.teiid.query.metadata.DDLStringVisitor;
+import org.teiid.query.metadata.SystemMetadata;
+import org.teiid.translator.TranslatorException;
+
+@SuppressWarnings("nls")
+public class TestMetadataProcessor {
+	protected static ModeShapeExecutionFactory TRANSLATOR;
+
+	@BeforeClass
+	public static void setUp() throws TranslatorException {
+		TRANSLATOR = new ModeShapeExecutionFactory();
+		TRANSLATOR.start();
+	}
+
+	@Test
+	public void testMetadata() throws Exception {
+
+		MetadataFactory mf = new MetadataFactory("vdb", 1, "objectvdb",
+				SystemMetadata.getInstance().getRuntimeTypeMap(),
+				new Properties(), null);
+		
+		ModeShapeJDBCMetdataProcessor mp = new ModeShapeJDBCMetdataProcessor();
+
+		mp.addModeShapeProcedures(mf);
+		
+		String metadataDDL = DDLStringVisitor.getDDLString(mf.getSchema(),
+				null, null);
+
+		System.out.println("Schema: " + metadataDDL);
+		String expected = "CREATE FOREIGN FUNCTION JCR_ISCHILDNODE(path1 string, path2 string) RETURNS boolean\n"
+		+ "OPTIONS (UUID '1525', CATEGORY 'JCR');\n\n"
+
+		+ "CREATE FOREIGN FUNCTION JCR_ISSAMENODE(path1 string, path2 string) RETURNS boolean\n"
+		+ "OPTIONS (UUID '1526', CATEGORY 'JCR');\n\n"
+
+		+ "CREATE FOREIGN FUNCTION JCR_ISDESCENDANTNODE(path1 string, path2 string) RETURNS boolean\n"
+		+ "OPTIONS (UUID '1527', CATEGORY 'JCR');\n\n"
+
+		+ "CREATE FOREIGN FUNCTION JCR_REFERENCE(selectOrProperty string) RETURNS boolean\n"
+		+ "OPTIONS (UUID '1528', CATEGORY 'JCR');\n\n"
+
+		+ "CREATE FOREIGN FUNCTION JCR_CONTAINS(selectOrProperty string, searchExpr string) RETURNS boolean\n"
+		+ "OPTIONS (UUID '1529', CATEGORY 'JCR', DETERMINISM 'NONDETERMINISTIC');"
+				;
+				
+		assertEquals(expected, metadataDDL);	
+
+	}
+
+}


### PR DESCRIPTION
TEIID-3098 changed to expose the ModeShape JCR functions in the metadata so that they can be modeled.   Also, this commit cannot be backported to 8.7 due to a difference in DDLStringVisitor, so there will a different commit for that branch.
