### PR TITLE
TEIID-3098 changed to expose the ModeShape JCR functions in the metadata

### DIFF
--- a/connectors/translator-jdbc/src/main/java/org/teiid/translator/jdbc/modeshape/IdentifierFunctionModifier.java
+++ b/connectors/translator-jdbc/src/main/java/org/teiid/translator/jdbc/modeshape/IdentifierFunctionModifier.java
@@ -41,7 +41,8 @@ import org.teiid.translator.jdbc.FunctionModifier;
  */
 public class IdentifierFunctionModifier extends FunctionModifier {
 
-    public List<?> translate(Function function) {
+    @Override
+	public List<?> translate(Function function) {
     	
     	List<Object> objs = new ArrayList<Object>();
     	

--- a/connectors/translator-jdbc/src/main/java/org/teiid/translator/jdbc/modeshape/ModeShapeExecutionFactory.java
+++ b/connectors/translator-jdbc/src/main/java/org/teiid/translator/jdbc/modeshape/ModeShapeExecutionFactory.java
@@ -47,12 +47,12 @@ import org.teiid.translator.jdbc.JDBCMetdataProcessor;
 @Translator(name="modeshape", description="A translator for the open source Modeshape JCR Repository")
 public class ModeShapeExecutionFactory extends JDBCExecutionFactory {
 	
-	private static final String JCR = "JCR"; //$NON-NLS-1$
-	private static final String JCR_REFERENCE = "JCR_REFERENCE";//$NON-NLS-1$
-	private static final String JCR_CONTAINS = "JCR_CONTAINS";//$NON-NLS-1$
-	private static final String JCR_ISSAMENODE = "JCR_ISSAMENODE";//$NON-NLS-1$
-	private static final String JCR_ISDESCENDANTNODE = "JCR_ISDESCENDANTNODE";//$NON-NLS-1$
-	private static final String JCR_ISCHILDNODE = "JCR_ISCHILDNODE";//$NON-NLS-1$
+	static final String JCR = "JCR"; //$NON-NLS-1$
+	static final String JCR_REFERENCE = "JCR_REFERENCE";//$NON-NLS-1$
+	static final String JCR_CONTAINS = "JCR_CONTAINS";//$NON-NLS-1$
+	static final String JCR_ISSAMENODE = "JCR_ISSAMENODE";//$NON-NLS-1$
+	static final String JCR_ISDESCENDANTNODE = "JCR_ISDESCENDANTNODE";//$NON-NLS-1$
+	static final String JCR_ISCHILDNODE = "JCR_ISCHILDNODE";//$NON-NLS-1$
 	
 	public ModeShapeExecutionFactory() {
 		setUseBindVariables(false);
@@ -107,6 +107,11 @@ public class ModeShapeExecutionFactory extends JDBCExecutionFactory {
 		supportedFunctions.add(SourceSystemFunctions.UCASE); 
 		supportedFunctions.add(SourceSystemFunctions.LCASE); 
 		supportedFunctions.add(SourceSystemFunctions.LENGTH);
+		supportedFunctions.add(JCR_ISCHILDNODE); 
+		supportedFunctions.add(JCR_ISDESCENDANTNODE); 
+		supportedFunctions.add(JCR_ISSAMENODE);
+		supportedFunctions.add(JCR_REFERENCE); 
+		supportedFunctions.add(JCR_CONTAINS);
 		return supportedFunctions;
     }
     

--- a/connectors/translator-jdbc/src/main/java/org/teiid/translator/jdbc/modeshape/ModeShapeJDBCMetdataProcessor.java
+++ b/connectors/translator-jdbc/src/main/java/org/teiid/translator/jdbc/modeshape/ModeShapeJDBCMetdataProcessor.java
@@ -22,8 +22,12 @@
 
 package org.teiid.translator.jdbc.modeshape;
 
+import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
 
+import org.teiid.metadata.FunctionMethod;
+import org.teiid.metadata.FunctionParameter;
 import org.teiid.metadata.MetadataFactory;
 import org.teiid.translator.jdbc.JDBCMetdataProcessor;
 
@@ -43,5 +47,50 @@ public class ModeShapeJDBCMetdataProcessor extends JDBCMetdataProcessor {
 		setImportForeignKeys(false);
 		setColumnNamePattern("%"); //$NON-NLS-1$
 	}
+	
+	@Override
+	public void getConnectorMetadata(Connection conn, MetadataFactory metadataFactory)
+			throws SQLException {
+			super.getConnectorMetadata(conn, metadataFactory);
+			addModeShapeProcedures(metadataFactory);
+	}	
+	
+	protected void addModeShapeProcedures(MetadataFactory metadataFactory)  {
+		String[] names = new String[] {"path1", "path2"};
+		String[] types = new String[] {"String", "String"};
+		int[] lengths = new int[] {4000, 4000};
+		createFunctionMethod(metadataFactory, ModeShapeExecutionFactory.JCR_ISCHILDNODE, "ModeShape ISCHILDNODE JCR Call", "JCR", "boolean", names, types, lengths, true );
+
+		createFunctionMethod(metadataFactory, ModeShapeExecutionFactory.JCR_ISSAMENODE, "ModeShape ISSAMENODE JCR Call", "JCR", "boolean", names, types, lengths, true );
+
+		createFunctionMethod(metadataFactory, ModeShapeExecutionFactory.JCR_ISDESCENDANTNODE, "ModeShape ISDESCENDANTNODE JCR Call", "JCR", "boolean", names, types, lengths, true);
+
+		names = new String[] {"selectOrProperty"};
+		types = new String[] {"String"};
+		lengths = new int[] {4000};
+		createFunctionMethod(metadataFactory, ModeShapeExecutionFactory.JCR_REFERENCE, "ModeShape REFERENCE JCR Call", "JCR", "boolean", names, types, lengths, true );
+
+		names = new String[] {"selectOrProperty", "searchExpr"};
+		types = new String[] {"String", "String"};
+		lengths = new int[] {4000, 4000};
+		createFunctionMethod(metadataFactory, ModeShapeExecutionFactory.JCR_CONTAINS, "ModeShape CONTAINS JCR Call", "JCR", "boolean", names, types, lengths, false );
+
+	}
+
+	private void createFunctionMethod(MetadataFactory metadataFactory, String name, String description, String category, String returnType, String[] names, String[] parameterTypes, int[] length, boolean deterministic) {
+		FunctionParameter[] params = new FunctionParameter[parameterTypes.length];
+		for (int i = 0; i < parameterTypes.length; i++) {
+			params[i] = new FunctionParameter(names[i], parameterTypes[i]); //$NON-NLS-1$
+
+		}
+
+		FunctionParameter returnParm = new FunctionParameter("result", returnType);
+		returnParm.setName("result");
+		FunctionMethod method = new FunctionMethod(name, description, category, params, returnParm); //$NON-NLS-1$
+		method.setNameInSource(name);
+		method.setDeterministicBoolean(Boolean.valueOf(deterministic));
+		
+		metadataFactory.getSchema().addFunction(method);	
+	}	
 	
 }

--- a/connectors/translator-jdbc/src/test/java/org/teiid/translator/jdbc/modeshape/TestMetadataProcessor.java
+++ b/connectors/translator-jdbc/src/test/java/org/teiid/translator/jdbc/modeshape/TestMetadataProcessor.java
@@ -1,0 +1,59 @@
+package org.teiid.translator.jdbc.modeshape;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Properties;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.teiid.metadata.MetadataFactory;
+import org.teiid.query.metadata.DDLStringVisitor;
+import org.teiid.query.metadata.SystemMetadata;
+import org.teiid.translator.TranslatorException;
+
+@SuppressWarnings("nls")
+public class TestMetadataProcessor {
+	protected static ModeShapeExecutionFactory TRANSLATOR;
+
+	@BeforeClass
+	public static void setUp() throws TranslatorException {
+		TRANSLATOR = new ModeShapeExecutionFactory();
+		TRANSLATOR.start();
+	}
+
+	@Test
+	public void testMetadata() throws Exception {
+
+		MetadataFactory mf = new MetadataFactory("vdb", 1, "objectvdb",
+				SystemMetadata.getInstance().getRuntimeTypeMap(),
+				new Properties(), null);
+		
+		ModeShapeJDBCMetdataProcessor mp = new ModeShapeJDBCMetdataProcessor();
+
+		mp.addModeShapeProcedures(mf);
+		
+		String metadataDDL = DDLStringVisitor.getDDLString(mf.getSchema(),
+				null, null);
+
+		System.out.println("Schema: " + metadataDDL);
+		String expected = "CREATE FOREIGN FUNCTION JCR_ISCHILDNODE(path1 string, path2 string) RETURNS boolean\n"
+		+ "OPTIONS (UUID '20', CATEGORY 'JCR');\n\n"
+
+		+ "CREATE FOREIGN FUNCTION JCR_ISSAMENODE(path1 string, path2 string) RETURNS boolean\n"
+		+ "OPTIONS (UUID '21', CATEGORY 'JCR');\n\n"
+
+		+ "CREATE FOREIGN FUNCTION JCR_ISDESCENDANTNODE(path1 string, path2 string) RETURNS boolean\n"
+		+ "OPTIONS (UUID '22', CATEGORY 'JCR');\n\n"
+
+		+ "CREATE FOREIGN FUNCTION JCR_REFERENCE(selectOrProperty string) RETURNS boolean\n"
+		+ "OPTIONS (UUID '23', CATEGORY 'JCR');\n\n"
+
+		+ "CREATE FOREIGN FUNCTION JCR_CONTAINS(selectOrProperty string, searchExpr string) RETURNS boolean\n"
+		+ "OPTIONS (UUID '24', CATEGORY 'JCR', DETERMINISM 'NONDETERMINISTIC');"
+				;
+				
+		assertEquals(expected, metadataDDL);	
+
+	}
+
+}


### PR DESCRIPTION
TEIID-3098 changed to expose the ModeShape JCR functions in the metadata so that they can be modeled.
