### PR TITLE
TEIID-3124: resolve InetAddress getLocalHost return UnknownHostException...

### DIFF
--- a/runtime/src/main/java/org/teiid/transport/SocketConfiguration.java
+++ b/runtime/src/main/java/org/teiid/transport/SocketConfiguration.java
@@ -79,7 +79,9 @@ public class SocketConfiguration {
 				this.hostName = InetAddress.getLocalHost().getHostName();
 			}
 		} catch (UnknownHostException e) {
-			 throw new TeiidRuntimeException(RuntimePlugin.Event.TEIID40065, RuntimePlugin.Util.gs(RuntimePlugin.Event.TEIID40065));
+			// TEIID-3124
+			// throw new TeiidRuntimeException(RuntimePlugin.Event.TEIID40065, RuntimePlugin.Util.gs(RuntimePlugin.Event.TEIID40065));
+			this.hostName = "localhost" ;
 		}
 	}
 


### PR DESCRIPTION
If no hostname InetAddress mapping, InetAddress.getLocalHost() throw UnknownHostException then ignore the exception, set hostname to localhost mandatorily
