### PR TITLE
TEIID-3215: When using external materialization management, ON_VDB_START...

### DIFF
--- a/build/kits/jboss-as7/docs/teiid/teiid-releasenotes.html
+++ b/build/kits/jboss-as7/docs/teiid/teiid-releasenotes.html
@@ -53,6 +53,7 @@
   <li>TEIID-2477 Most of the JDBC translator static String version constants were replaced by org.teiid.translator.jdbc.Version constants.  Use the .toString() method to obtain a version string if needed.
   <li>TEIID-2527 The admin method assignToModel has been deprecated.  See the updateSource, addSource, and removeSource methods instead.
   <li>TEIID-2904 The createMetadataProcessor method on JDBCExcutionFactory has been deprecated. Use getMetadataProcessor instead.</li>
+  <li>TEIID-3215 When using external materialization management, ON_VDB_START_SCRIPT will be executed at VDB deployment and server restarts. Previously it only executed when VDB is deployed</li>
 </ul>
 
 <h4>from 8.6</h4>

--- a/runtime/src/main/java/org/teiid/runtime/MaterializationManager.java
+++ b/runtime/src/main/java/org/teiid/runtime/MaterializationManager.java
@@ -111,15 +111,13 @@ public abstract class MaterializationManager implements VDBLifeCycleListener {
 			doMaterializationActions(vdb, new MaterializationAction() {
 				@Override
 				public void process(Table table) {
-					if (!reloading) {
-						String start = table.getProperty(MaterializationMetadataRepository.ON_VDB_START_SCRIPT, false);
-						if (start != null) {
-							for (String script : StringUtil.tokenize(start, ';')) {
-								try {
-									executeQuery(vdb, script);
-								} catch (SQLException e) {
-									LogManager.logWarning(LogConstants.CTX_MATVIEWS, e, e.getMessage());
-								}
+					String start = table.getProperty(MaterializationMetadataRepository.ON_VDB_START_SCRIPT, false);
+					if (start != null) {
+						for (String script : StringUtil.tokenize(start, ';')) {
+							try {
+								executeQuery(vdb, script);
+							} catch (SQLException e) {
+								LogManager.logWarning(LogConstants.CTX_MATVIEWS, e, e.getMessage());
 							}
 						}
 					}


### PR DESCRIPTION
..._SCRIPT will be executed at VDB deployment and server restarts. Previously it only executed when VDB is deployed
