### PR TITLE
Fix test integration and transitive dependencies

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -56,6 +56,10 @@
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>org.jboss.teiid</groupId>
+            <artifactId>teiid-common-core</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.jboss.teiid</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
         <version.org.mongodb.mongo-java-driver>2.12.3</version.org.mongodb.mongo-java-driver>
         <version.org.jboss.as>7.4.0.Final-redhat-4</version.org.jboss.as>
         
+        <version.org.springframework>3.2.12.RELEASE</version.org.springframework>
+        
         <!-- Not in integration BOM; Need to check these jboss-parent BOM-->
         <version.org.jboss.jboss-vfs>3.2.2.Final-redhat-1</version.org.jboss.jboss-vfs>
         <version.org.picketbox>4.0.19.SP4-redhat-1</version.org.picketbox>               
@@ -720,6 +722,21 @@
                 <artifactId>jboss-as-arquillian-container-managed</artifactId>
                 <version>${version.org.jboss.as.arquillian}</version>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-arquillian-common</artifactId>
+                <version>${version.org.jboss.as.arquillian}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-arquillian-protocol-jmx</artifactId>
+                <version>${version.org.jboss.as.arquillian}</version>
+            </dependency>   
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-arquillian-testenricher-msc</artifactId>
+                <version>${version.org.jboss.as.arquillian}</version>
+            </dependency>                       
 			<dependency>
 				<groupId>net.sf.saxon</groupId>
 				<artifactId>Saxon-HE</artifactId>

--- a/test-integration/common/src/test/java/org/teiid/arquillian/IntegrationTestDeployment.java
+++ b/test-integration/common/src/test/java/org/teiid/arquillian/IntegrationTestDeployment.java
@@ -239,7 +239,9 @@ public class IntegrationTestDeployment {
 
 	@Test
 	public void testVDBConnectionType() throws Exception {
-		admin.deploy("bqt.vdb", new FileInputStream(UnitTestUtil.getTestDataFile("bqt.vdb")));			
+		admin.deploy("bqt.vdb", new FileInputStream(UnitTestUtil.getTestDataFile("bqt.vdb")));	
+		
+		AdminUtil.waitForVDBLoad(admin, "bqt2", 1, 3);	
 		
 		VDB vdb = admin.getVDB("bqt", 1);
 		Model model = vdb.getModels().get(0);
@@ -268,6 +270,8 @@ public class IntegrationTestDeployment {
 		}
 
 		admin.deploy("bqt2.vdb", new FileInputStream(UnitTestUtil.getTestDataFile("bqt2.vdb")));
+		AdminUtil.waitForVDBLoad(admin, "bqt2", 1, 3);	
+
 		admin.updateSource("bqt", 2, "Source", "h2", "java:jboss/datasources/ExampleDS");
 		
 		conn = TeiidDriver.getInstance().connect("jdbc:teiid:bqt@mm://localhost:31000;user=user;password=user", null);
@@ -317,6 +321,7 @@ public class IntegrationTestDeployment {
 		s = sessions.iterator().next();
 
 		admin.terminateSession(s.getSessionId());
+		Thread.sleep(2000);
 		sessions = admin.getSessions();
 		assertEquals (0, sessions.size());			
 		conn.close();
@@ -462,7 +467,8 @@ public class IntegrationTestDeployment {
 	@Test
 	public void testDataRoleMapping() throws Exception{
 		admin.deploy("bqt2.vdb", new FileInputStream(UnitTestUtil.getTestDataFile("bqt2.vdb")));			
-		
+		AdminUtil.waitForVDBLoad(admin, "bqt2", 1, 3);
+
 		VDB vdb = admin.getVDB("bqt", 2);
 		Model model = vdb.getModels().get(0);
 		admin.assignToModel("bqt", 2, model.getName(), "Source", "h2", "java:jboss/datasources/ExampleDS");


### PR DESCRIPTION
Fix test integration related to loading VDB's.  The VDB's were not able to load by the time it was trying to be used.   So added calls to wait till it was loaded.

Also, fixed transitive dependencies that need to be specified.  As we move forward, the goal is to either add or exclude transitive dependencies specifically.
