### PR TITLE
TEIID-2816: update phoenix ds create cli script

### DIFF
--- a/build/kits/jboss-as7/docs/teiid/datasources/phoenix/create-phoenix-driver.cli
+++ b/build/kits/jboss-as7/docs/teiid/datasources/phoenix/create-phoenix-driver.cli
@@ -1,0 +1,5 @@
+# phoenix should depend on sun.jdk and org.apache.log4j
+
+module add --name=org.apache.phoenix --resources=phoenix-[version]-client.jar --dependencies=javax.api,sun.jdk,org.apache.log4j,javax.transaction.api
+
+/subsystem=datasources/jdbc-driver=phoenix:add(driver-name=phoenix,driver-module-name=org.apache.phoenix,driver-class-name=org.apache.phoenix.jdbc.PhoenixDriver)

--- a/build/kits/jboss-as7/docs/teiid/datasources/phoenix/create-phoenix-ds.cli
+++ b/build/kits/jboss-as7/docs/teiid/datasources/phoenix/create-phoenix-ds.cli
@@ -1,5 +1,5 @@
-# note that driver-name must be created as a precondition.
+# note that driver-name could be driver's module name if you went module approach.
 
-/subsystem=datasources/data-source=phoenixDS:add(jndi-name=java:/phoenixDS, driver-name=phoenix, enabled=true,use-java-context=true, connection-url=jdbc:phoenix:{zookeeper quorum server},user-name={user}, password={password})
+/subsystem=datasources/data-source=phoenixDS:add(jndi-name=java:/phoenixDS, driver-name=phoenix-[version]-client.jar, driver-class=org.apache.phoenix.jdbc.PhoenixDriver, enabled=true,use-java-context=true, connection-url=jdbc:phoenix:{zookeeper quorum server},user-name={user}, password={password})
 
 ## If you are working in a clustered environment, prepend "/profile=ha" to all the above commands that start with "/subsystem=.." 

--- a/build/kits/jboss-as7/docs/teiid/datasources/phoenix/create-phoenix-ds.cli
+++ b/build/kits/jboss-as7/docs/teiid/datasources/phoenix/create-phoenix-ds.cli
@@ -1,4 +1,5 @@
-# note that driver-name could be driver's module name if you went module approach.
-/subsystem=datasources/data-source=phoenixDS:add(jndi-name=java:/phoenixDS,  driver-name=phoenix-[version].jar, driver-class=org.apache.phoenix.jdbc.PhoenixDriver, connection-url=jdbc:phoenix:{zookeeper quorum server},user-name={user}, password={password})
+# note that driver-name must be created as a precondition.
+
+/subsystem=datasources/data-source=phoenixDS:add(jndi-name=java:/phoenixDS, driver-name=phoenix, enabled=true,use-java-context=true, connection-url=jdbc:phoenix:{zookeeper quorum server},user-name={user}, password={password})
 
 ## If you are working in a clustered environment, prepend "/profile=ha" to all the above commands that start with "/subsystem=.." 

--- a/build/kits/jboss-as7/docs/teiid/datasources/phoenix/modules/org/apache/phoenix/main/module.xml
+++ b/build/kits/jboss-as7/docs/teiid/datasources/phoenix/modules/org/apache/phoenix/main/module.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module xmlns="urn:jboss:module:1.0" name="org.apache.derby">
+<module xmlns="urn:jboss:module:1.0" name="org.apache.phoenix">
   <resources>
-    <resource-root path="phoenix-[version].jar"/>
+    <resource-root path="phoenix-[version]-client.jar"/>
   </resources>
   <dependencies>
     <module name="javax.api"/>
+    <module name="sun.jdk"/>
+    <module name="org.apache.log4j"/>
+    <module name="javax.transaction.api"/>
   </dependencies>
 </module>

--- a/build/kits/jboss-as7/docs/teiid/datasources/phoenix/phoenix-ds.xml
+++ b/build/kits/jboss-as7/docs/teiid/datasources/phoenix/phoenix-ds.xml
@@ -1,19 +1,16 @@
 <!-- Add the below contents under "datasources" subsystem in the standalone-teiid.xml or deploy as -ds.xml file -->
-<subsystem xmlns="urn:jboss:domain:datasources:1.0">
-    <datasources>
-        <datasource jndi-name="java:/derbyDS" pool-name="derbyDS">
-            <driver-class>org.apache.phoenix.jdbc.PhoenixDriver</driver-class>
-            <connection-url>jdbc:phoenix:{zookeeper quorum server}</connection-url>
-            <driver>phoenix-[version].jar</driver>
-            <pool>
-                <prefill>false</prefill>
-                <use-strict-min>false</use-strict-min>
-                <flush-strategy>FailingConnectionOnly</flush-strategy>
-            </pool>
-            <security>
-                <user-name>{user}</user-name>
-                <password>{password}</password>
-            </security>
-        </datasource>                               
-    </datasources>
-</subsystem>            
+<datasources>
+    <datasource jndi-name="java:jboss/datasources/PhoenixDS" enabled="true" use-java-context="true" pool-name="PhoenixDS">
+        <connection-url>jdbc:phoenix:{zookeeper quorum server}</connection-url>
+        <driver>phoenix</driver>
+        <security>
+            <user-name>{user}</user-name>
+            <password>{password}</password>
+        </security>
+    </datasource> 
+    <drivers>
+	<driver name="phoenix" module="org.apache.phoenix">
+	    <driver-class>org.apache.phoenix.jdbc.PhoenixDriver</driver-class>
+	</driver>
+    </drivers>                              
+</datasources>

--- a/build/kits/jboss-as7/docs/teiid/datasources/phoenix/phoenix.xml
+++ b/build/kits/jboss-as7/docs/teiid/datasources/phoenix/phoenix.xml
@@ -1,0 +1,20 @@
+<!-- Add the below contents under "datasources" subsystem in the standalone-teiid.xml or deploy as -ds.xml file -->
+<subsystem xmlns="urn:jboss:domain:datasources:1.2">
+    <datasources>
+        <datasource jndi-name="java:jboss/datasources/PhoenixDS" enabled="true" use-java-context="true" pool-name="PhoenixDS">
+            <connection-url>jdbc:phoenix:{zookeeper quorum server}</connection-url>
+            <driver>phoenix</driver>
+            <security>
+                <user-name>{user}</user-name>
+                <password>{password}</password>
+            </security>
+        </datasource>
+        <drivers>
+            <driver name="phoenix" module="org.apache.phoenix">
+                <driver-class>org.apache.phoenix.jdbc.PhoenixDriver</driver-class>
+            </driver>
+        </drivers>
+    </datasources>
+</subsystem>
+
+

--- a/build/kits/jboss-as7/docs/teiid/datasources/phoenix/readme.txt
+++ b/build/kits/jboss-as7/docs/teiid/datasources/phoenix/readme.txt
@@ -5,8 +5,9 @@ Note that all instances of [version] should be replaced by the appropriate phoen
 
 Step 1: Deploying the JDBC Driver
  
-	Option 1: use the JBoss CLI tool, and deploy the phoenix client jar by issuing the command
-		deploy phoenix-[version].jar
+	Option 1: use the JBoss CLI tool, and add the phoenix client jar as a JDBC driver by issuing the command
+
+		./bin/jboss-cli.sh --connect --file=create-phoenix-driver.cli
 		
 	Option 2: (recommended)
 		1) Stop the server if it is running.
@@ -19,11 +20,14 @@ Step 1: Deploying the JDBC Driver
 
 Step 2: Creating the datasource 
 
-	Option 1: Edit the standalone-teiid.xml or domain-teiid.xml file and add contents of the "phoenix-ds.xml" 
+	Option 1: Edit the standalone-teiid.xml or domain-teiid.xml file and add contents of the "phoenix.xml" 
 	file under the "datasources" subsystem. You may have to edit contents according to where your Hbase server 
 	is located and credentials you need to use to access it.
 	
 	Option 2: Take a look at create-phoenix-ds.cli script, and modify and execute using JBoss CLI tool as below 
 	
-	./Jboss-admin.sh --file create-phoenix-ds.cli
+	./bin/jboss-cli.sh --connect --file=create-phoenix-ds.cli
+
+	Option 3: Deploy phoenix-ds.xml file. You may have to edit contents according to where your Hbase server
+        is located and credentials you need to use to access it.
 	


### PR DESCRIPTION
phoenix driver depend on jre library class(com.sun.security.auth.module.UnixLoginModule), so if we add module, sun.jdk module should be added as dependency, also log4j can avoid Error class not found log.