### PR TITLE
Multiple ddl files in one static VDB

### DIFF
--- a/engine/src/main/java/org/teiid/query/metadata/DDLFileMetadataRepository.java
+++ b/engine/src/main/java/org/teiid/query/metadata/DDLFileMetadataRepository.java
@@ -21,11 +21,17 @@
  */
 package org.teiid.query.metadata;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 
+import org.teiid.core.util.FileUtils;
 import org.teiid.metadata.MetadataException;
 import org.teiid.metadata.MetadataFactory;
 import org.teiid.metadata.MetadataRepository;
@@ -35,22 +41,76 @@ import org.teiid.query.QueryPlugin.Event;
 import org.teiid.translator.ExecutionFactory;
 import org.teiid.translator.TranslatorException;
 
+@SuppressWarnings("rawtypes")
 public class DDLFileMetadataRepository extends MetadataRepository {
+	
+	public static final String SEPARATION = ",";
+	public static final String SUFFIX = ".tmp";
+	public static final boolean APPEND = true;
 	
 	@Override
 	public void loadMetadata(MetadataFactory factory, ExecutionFactory executionFactory, Object connectionFactory) throws TranslatorException {
-		String ddlFile = factory.getModelProperties().getProperty("ddl-file");
-		if (ddlFile == null) {
-			ddlFile = factory.getRawMetadata();
+		String ddlFileString = factory.getModelProperties().getProperty("ddl-file");
+		
+		if (ddlFileString == null) {
+			ddlFileString = factory.getRawMetadata();
 		}
-		if (ddlFile != null) {
-			VDBResource resource = factory.getVDBResources().get(ddlFile);
-			if (resource == null) {
-				throw new MetadataException(Event.TEIID31137, QueryPlugin.Util.gs(Event.TEIID31137, ddlFile));
+		
+		String[] ddlFiles =  ddlFileString.split(SEPARATION);
+		
+		File tempDir = new File(FileUtils.TEMP_DIRECTORY);
+	    
+		File tempFile = null;
+		try {
+			tempFile = File.createTempFile(factory.getVdbName() +"_"+ factory.getVdbVersion() , SUFFIX, tempDir);
+		} catch (IOException ioException) {
+			throw new MetadataException(Event.TEIID31137, QueryPlugin.Util.gs(Event.TEIID31137, factory.getVdbName() +"_"+ factory.getVdbVersion()+SUFFIX));
+		}
+	    
+	    /* if old file already exist , delete content of old file before writing new content */
+	    if (tempFile != null && tempFile.exists()) {
+	    	tempFile.delete();
+        }
+		
+		/* merge multiple ddl file into temp file */
+		for(String filePath : ddlFiles){
+			
+			VDBResource resource = factory.getVDBResources().get(filePath);
+			
+			if (resource == null) {	
+				throw new MetadataException(Event.TEIID31137, QueryPlugin.Util.gs(Event.TEIID31137, filePath));	
 			}
+			
+			try {
+				BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(resource.openStream(), "UTF-8"));
+				BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter(tempFile, APPEND));
+				
+				String line = "";
+				
+				while ( (line = bufferedReader.readLine()) != null) {
+					bufferedWriter.write(line);
+					bufferedWriter.newLine();
+				}
+				
+				if(bufferedReader != null)
+					bufferedReader.close();
+				if(bufferedWriter != null){
+					bufferedWriter.flush();
+					bufferedWriter.close();
+				}
+			} catch (Exception e) {
+				// TODO Auto-generated catch block
+				throw new MetadataException(Event.TEIID31137, QueryPlugin.Util.gs(Event.TEIID31137, "closing stream"));
+			}
+		}
+		
+		
+		
+		if (tempFile != null && tempFile.exists() ) {
+			
 			InputStream is;
 			try {
-				is = resource.openStream();
+				is = new FileInputStream(tempFile.getAbsolutePath());
 			} catch (IOException e1) {
 				throw new MetadataException(e1);
 			}
@@ -60,10 +120,15 @@ public class DDLFileMetadataRepository extends MetadataRepository {
 			} finally {
 				try {
 					is.close();
+					
+					if(tempFile != null && tempFile.exists())	
+						if(!tempFile.delete())
+							tempFile.deleteOnExit();
+					
 				} catch (IOException e) {
 				}
 			}
 		}
-	}	
+	}
 
 }


### PR DESCRIPTION
i did some changes in DDLFileMetadataRepository.java file to add support of multiple ddl files in one static vdb in teiid ,
now multiple ddl files can be add in vdb.xml like
<metadata type="DDL-FILE">
     /ddl/CM_Def.ddl,/ddl/CM_Project.ddl,
     /ddl/CM_Field.ddl,/ddl/Rem.ddl
  </metadata>
 
 
and DDL script files will be place in the DDL folder.
Order of files is depend on sequence which is defined in vdb.xml
 
 
I am splitting the path of files based on the comma delimiter, and then merging the all files in one temp file, and storing that temp file in temp folder,
and then passing the stream of temp file for parsing,
after parsing, temp file will be delete from temp folder