### PR TITLE
TEIID-3409 PostgreSQLExecutionFactory TranslatorProperty annotation in wrong place

### DIFF
--- a/connectors/translator-jdbc/src/main/java/org/teiid/translator/jdbc/postgresql/PostgreSQLExecutionFactory.java
+++ b/connectors/translator-jdbc/src/main/java/org/teiid/translator/jdbc/postgresql/PostgreSQLExecutionFactory.java
@@ -762,20 +762,20 @@ public class PostgreSQLExecutionFactory extends JDBCExecutionFactory {
     	};
     }
     
-	@TranslatorProperty(display="PostGIS Version", description="The version of the PostGIS extension.",advanced=true)
     public void setPostGisVersion(String postGisVersion) {
 		this.postGisVersion = Version.getVersion(postGisVersion);
 	}
     
+    @TranslatorProperty(display="PostGIS Version", description="The version of the PostGIS extension.",advanced=true)
     public String getPostGisVersion() {
 		return postGisVersion.toString();
 	}
     
+    @TranslatorProperty(display="Proj support enabled", description="If PostGIS Proj support is enabled for ST_TRANSFORM",advanced=true)
     public boolean isProjSupported() {
 		return projSupported;
 	}
     
-    @TranslatorProperty(display="Proj support enabled", description="If PostGIS Proj support is enabled for ST_TRANSFORM",advanced=true)
     public void setProjSupported(boolean projSupported) {
 		this.projSupported = projSupported;
 	}


### PR DESCRIPTION
...tGisVersion when using postgresql jdbc translator

when I use postgresql translator of Teiid 8.10.0, it throw when deploying on jboss-as-7.4
the @TranslatorProperty annoation position is not right accoring to code in org.teiid.deployers.TranslatorUtil
getSetter method code
if (method.getName().startsWith("get")) { //$NON-NLS-1$
	setter = "set"+setter.substring(3);//$NON-NLS-1$
}
else if (method.getName().startsWith("is")) { //$NON-NLS-1$
	setter = "set"+setter.substring(2); //$NON-NLS-1$
}
else {
	setter = "set"+method.getName().substring(0,1).toUpperCase()+method.getName().substring(1); //$NON-NLS-1$
}
this annoation can only be annoated on getXXX(), or isXXX() method.