### PR TITLE
TEIID-3471: updated the OReva to 0.8.3, to accpept the header 'applic…

### DIFF
--- a/connectors/translator-odata/src/main/java/org/teiid/translator/odata/ODataMetadataProcessor.java
+++ b/connectors/translator-odata/src/main/java/org/teiid/translator/odata/ODataMetadataProcessor.java
@@ -97,25 +97,13 @@ public class ODataMetadataProcessor implements MetadataProcessor<WSConnection> {
 	public void setExecutionfactory(ODataExecutionFactory ef) {
         this.ef = ef;
     }
-
-	// TEIID-3471
-    private Map<String, List<String>> resteasySpecificHeaders() {
-        Map<String, List<String>> headers = new HashMap<String, List<String>>();
-        headers.put("Accept", Arrays.asList("application/xml;charset=utf-8")); //$NON-NLS-1$
-        headers.put("Content-Type", Arrays.asList("application/xml")); //$NON-NLS-1$ //$NON-NLS-2$
-        return headers;
-    }	
 	
     private EdmDataServices getEds(WSConnection conn) throws TranslatorException {
         try {
             BaseQueryExecution execution = new BaseQueryExecution(ef, null, null, conn);
             BinaryWSProcedureExecution call = execution.executeDirect("GET", "$metadata", null, execution.getDefaultHeaders()); //$NON-NLS-1$ //$NON-NLS-2$
             if (call.getResponseCode() != Status.OK.getStatusCode()) {
-                execution = new BaseQueryExecution(ef, null, null, conn);
-                call = execution.executeDirect("GET", "$metadata", null, resteasySpecificHeaders()); //$NON-NLS-1$ //$NON-NLS-2$
-                if (call.getResponseCode() != Status.OK.getStatusCode()) {
-                    throw execution.buildError(call);
-                }
+                throw execution.buildError(call);
             }
 
             Blob out = (Blob)call.getOutputParameterValues().get(0);

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <version.connector-api>1.5</version.connector-api>
         <version.jta>1.1</version.jta>
         <jbossas-test-version>jboss-eap-6.4</jbossas-test-version>
-        <version.org.jboss.oreva>0.8.2</version.org.jboss.oreva>
+        <version.org.jboss.oreva>0.8.3</version.org.jboss.oreva>
         <jbossas-module-root>modules/system/layers/dv</jbossas-module-root>
         <version.com.force.api>22.0.0</version.com.force.api>
         <version.nux>1.6</version.nux>


### PR DESCRIPTION
…ation/xml' in addition to 'application/xml;charset=utf-8' so that when a REST client issues just with accepts header 'application/xml' it is not going to fail anymore