### PR TITLE
TEIID-3513: move saxon from lib to optional

### DIFF
--- a/build/assembly/embedded-dist.xml
+++ b/build/assembly/embedded-dist.xml
@@ -104,6 +104,7 @@
                 <dependencySet>
                     <excludes>
                         <exclude>io.netty:netty</exclude>
+			<exclude>net.sf.saxon:Saxon-HE</exclude>
                     </excludes>
                     <useProjectArtifact>true</useProjectArtifact>
                     <unpack>false</unpack>
@@ -113,6 +114,15 @@
                     <outputDirectory>optional</outputDirectory>
                     <includes>
                         <include>io.netty:netty</include>
+                    </includes>
+                    <useProjectArtifact>false</useProjectArtifact>
+                    <unpack>false</unpack>
+                    <useTransitiveDependencies>true</useTransitiveDependencies>
+                </dependencySet>
+                <dependencySet>
+                    <outputDirectory>optional/saxon</outputDirectory>
+                    <includes>
+                        <include>net.sf.saxon:Saxon-HE</include>
                     </includes>
                     <useProjectArtifact>false</useProjectArtifact>
                     <unpack>false</unpack>


### PR DESCRIPTION
Update embedded dist, move Saxon-HE jar from lib to optional.