### PR TITLE
TEIID-3556: during the close operation the command context is not set…

### DIFF
--- a/engine/src/main/java/org/teiid/dqp/internal/process/RequestWorkItem.java
+++ b/engine/src/main/java/org/teiid/dqp/internal/process/RequestWorkItem.java
@@ -478,6 +478,7 @@ public class RequestWorkItem extends AbstractWorkItem implements PrioritizedRunn
 	protected void close() {
 		int rowcount = -1;
 		try {
+		    CommandContext.pushThreadLocalContext(this.processor.getContext());
 			cancelCancelTask();
 			if (moreWorkTask != null) {
 				moreWorkTask.cancel(false);
@@ -545,7 +546,7 @@ public class RequestWorkItem extends AbstractWorkItem implements PrioritizedRunn
 			handleThrowable(t);
 		} finally {
 			isClosed = true;
-			
+			CommandContext.popThreadLocalContext();	
 			dqpCore.removeRequest(this);
 		    
 			if (this.processingException != null) {


### PR DESCRIPTION
… on the calling thread, thus missing the required updates to the command context, thus decrementing the reserved memory field twice leading to negitive number