### PR TITLE
TEIID-3557: Based changes in EAP JGroups channel, the close call has …

### DIFF
--- a/runtime/src/main/java/org/teiid/replication/jgroups/JGroupsObjectReplicator.java
+++ b/runtime/src/main/java/org/teiid/replication/jgroups/JGroupsObjectReplicator.java
@@ -499,6 +499,7 @@ public class JGroupsObjectReplicator implements ObjectReplicator, Serializable {
 		ReplicatedInvocationHandler<?> handler = (ReplicatedInvocationHandler<?>) Proxy.getInvocationHandler(object);
 		Channel c = handler.disp.getChannel();
 		handler.disp.stop();
+		c.disconnect();
 		c.close();
 	}
 	


### PR DESCRIPTION
…been overridden, this now requires disconnect and then close to properly close the JGroups channel