### PR TITLE
TEIID-3533 and TEIID-3535

### DIFF
--- a/connectors/connector-infinispan-dsl/src/main/rar/META-INF/ra.xml
+++ b/connectors/connector-infinispan-dsl/src/main/rar/META-INF/ra.xml
@@ -37,17 +37,15 @@
             <managedconnectionfactory-class>org.teiid.resource.adapter.infinispan.dsl.InfinispanManagedConnectionFactory</managedconnectionfactory-class>
   
             <config-property>
-               <description>{$display:"Cache Type Mapping",$description:"Cache Type Map(cacheName:className[;pkFieldName][,cacheName:className[;pkFieldName]...])",$required="true"}</description>
+               <description>{$display:"Cache Type Mapping",$description:"Cache Type Map(cacheName:className[;pkFieldName[:cacheKeyJavaType]])",$required="true"}</description>
                <config-property-name>CacheTypeMap</config-property-name>
                <config-property-type>java.lang.String</config-property-type>
-            </config-property>  
-            
+            </config-property>   
             <config-property>
                <description>{$display:"Module",$description:"Module defining the cache classes (module,[module,..])"}</description>
                <config-property-name>Module</config-property-name>
                <config-property-type>java.lang.String</config-property-type>
-            </config-property>
-                
+            </config-property>      
             <config-property>
                <description>{$display:"Server List",$description:"Server List (host:port[;host:port...]) to connect to"}</description>
                <config-property-name>RemoteServerList</config-property-name>

--- a/connectors/translator-infinispan-dsl/src/main/java/org/teiid/translator/infinispan/dsl/ClassRegistry.java
+++ b/connectors/translator-infinispan-dsl/src/main/java/org/teiid/translator/infinispan/dsl/ClassRegistry.java
@@ -56,10 +56,10 @@ public class ClassRegistry {
 
 	private TeiidScriptEngine readEngine = new TeiidScriptEngine();
 	
-	private Map<String, Class<?>> registeredClasses = new HashMap<String, Class<?>>(); // fullClassName, Class
-	private Map<String, Class<?>> tableNameClassMap = new HashMap<String, Class<?>>(); // simpleClassName(i.e., tableName), Class 
-	private Map<String, Map<String, Method>> classReadMethodMap = new HashMap<String, Map<String, Method>>();
-	private Map<String, Map<String, Method>> classWriteMethodMap = Collections.synchronizedMap(new LRUCache<String, Map<String,Method>>(100));;
+	private Map<String, Class<?>> registeredClasses = new HashMap<String, Class<?>>(3); // fullClassName, Class
+	private Map<String, Class<?>> tableNameClassMap = new HashMap<String, Class<?>>(3); // simpleClassName(i.e., tableName), Class 
+	private Map<String, Map<String, Method>> classReadMethodMap = new HashMap<String, Map<String, Method>>(100);
+	private Map<String, Map<String, Method>> classWriteMethodMap = Collections.synchronizedMap(new LRUCache<String, Map<String,Method>>(100));
 
 	public synchronized void registerClass(Class<?> clz) throws TranslatorException {
 			// preload methods
@@ -168,16 +168,20 @@ public class ClassRegistry {
 					methodMap.put(name, m);
 				}
 			}
-//			if (clazzMaps == null) {
-//				clazzMaps = Collections.synchronizedMap(new LRUCache<Class<?>, Map<String,Method>>(100));
-//				classWriteMethodMap = new SoftReference<Map<Class<?>,Map<String,Method>>>(clazzMaps);
-//			}
-//			clazzMaps.put(clazz, methodMap);
+
 		} catch (IntrospectionException e) {
 			throw new TranslatorException(e);
 		}
 		return methodMap;
 	}
+    
+    public void cleanUp() {
+    	registeredClasses.clear();
+    	tableNameClassMap.clear();
+    	classReadMethodMap.clear();
+    	classWriteMethodMap.clear();
+
+    }
 
 
 }

--- a/connectors/translator-infinispan-dsl/src/main/java/org/teiid/translator/infinispan/dsl/DSLSearch.java
+++ b/connectors/translator-infinispan-dsl/src/main/java/org/teiid/translator/infinispan/dsl/DSLSearch.java
@@ -72,9 +72,8 @@ import org.teiid.translator.TranslatorException;
 public final class DSLSearch   {
 	
 	public static Object performKeySearch(String cacheName, String columnNameInSource, Object value, InfinispanConnection conn) throws TranslatorException {
-	    @SuppressWarnings("rawtypes")
 	    
-		RemoteCache<?, Object> c = (RemoteCache<?, Object>) conn.getCache(cacheName);
+		RemoteCache<?, Object> c = (RemoteCache<?, Object>) conn.getCache();
 	    Object v = c.get(value);
 	    return v;
 
@@ -110,7 +109,7 @@ public final class DSLSearch   {
 		    	if (spec.getOrdering().name().equalsIgnoreCase(SortOrder.DESC.name())) {
 		    		so = SortOrder.DESC;
 		    	}
-		    	qb = qb.orderBy(mdIDElement.getNameInSource(), so);
+		    	qb = qb.orderBy(getNameInSource(mdIDElement), so);
 		    }
 	    }
 	    	
@@ -136,7 +135,7 @@ public final class DSLSearch   {
 
 		} else {
 		    results = new ArrayList<Object>();
-			RemoteCache<?, Object> c = (RemoteCache<?, Object>) conn.getCache(cacheName);
+			RemoteCache<?, Object> c = (RemoteCache<?, Object>) conn.getCache();
 		    for (Object id : c.keySet()) {
 		          results. add(c.get(id));
 		    }
@@ -149,9 +148,9 @@ public final class DSLSearch   {
 	@SuppressWarnings("rawtypes")
 	private static QueryBuilder getQueryBuilder(String cacheName, InfinispanConnection conn) throws TranslatorException {
 		
-		Class<?> type = conn.getType(cacheName);
+		Class<?> type = conn.getCacheClassType();
 		
-		QueryFactory qf = conn.getQueryFactory(cacheName);
+		QueryFactory qf = conn.getQueryFactory();
 	    		  
 	    QueryBuilder qb = qf.from(type);
 
@@ -175,7 +174,7 @@ public final class DSLSearch   {
 			case AND:
 
 				FilterConditionContext f_and = buildQueryFromWhereClause(
-						crit.getLeftCondition(), queryBuilder, null);
+						crit.getLeftCondition(), queryBuilder, fcbc);
 				FilterConditionBeginContext fcbca =  null;
 				if (f_and != null) {
 					fcbca = f_and.and();
@@ -188,7 +187,7 @@ public final class DSLSearch   {
 			case OR:
 				
 				FilterConditionContext f_or = buildQueryFromWhereClause(
-						crit.getLeftCondition(), queryBuilder, null);
+						crit.getLeftCondition(), queryBuilder, fcbc);
 				FilterConditionBeginContext fcbcb = null;
 				if (f_or != null) {
 					fcbcb = f_or.or();

--- a/connectors/translator-infinispan-dsl/src/main/java/org/teiid/translator/infinispan/dsl/InfinispanConnection.java
+++ b/connectors/translator-infinispan-dsl/src/main/java/org/teiid/translator/infinispan/dsl/InfinispanConnection.java
@@ -37,56 +37,65 @@ import org.infinispan.protostream.descriptors.Descriptor;
  */
 public interface InfinispanConnection {
 	
-		
-	/**
-	 * Return the root class type stored in the specified cache
-	 * @param cacheName 
-	 * @return Class
-	 * @throws TranslatorException
-	 */
-	public Class<?> getType(String cacheName) throws TranslatorException;
-	
+			
 	/**
 	 * Returns the name of the primary key to the cache
 	 * @param cacheName
 	 * @return String key name
 	 * @throws TranslatorException 
 	 */
-	public String getPkField(String cacheName) throws TranslatorException;
-		
+	public String getPkField() throws TranslatorException;
+	
 	/**
-	 * Returns a map of all defined caches, and their respective root object class type,
-	 * that are accessible using this connection.
-	 * @return Map<String, Class>  --> CacheName, ClassType
+	 * Returns the class type of the key to the cache.
+	 * If the primary key class type is different from the 
+	 * cache key type, then the value will be converted
+	 * to the cache key class type before performing a get/put on the cache.
+	 * @return
+	 * @throws TranslatorException
+	 * @see {@link #getPkField()}
+	 */
+	public Class<?> getCacheKeyClassType() throws TranslatorException;
+	
+	
+	/**
+	 * Returns the name of the cache
+	 * @return String cacheName
 	 * @throws TranslatorException 
 	 */
-	public Map<String, Class<?>> getCacheNameClassTypeMapping() throws TranslatorException;
+	public String getCacheName() throws TranslatorException;
+	
+		
+	/**
+	 * Returns root object class type
+	 * that is defined for the cache.
+	 * @return Cache ClassType
+	 * @throws TranslatorException 
+	 */
+	public Class<?> getCacheClassType() throws TranslatorException;
 	
 
 	/**
 	 * Returns the descriptor that desribes the messages being serialized
-	 * @param cacheName
 	 * @return Descriptor
 	 * @throws TranslatorException
 	 */
-	public Descriptor getDescriptor(String cacheName) throws TranslatorException;
+	public Descriptor getDescriptor() throws TranslatorException;
 	
 	/**
 	 * Call to obtain the cache object
-	 * @param cacheName
 	 * @return Map cache
 	 * @throws TranslatorException 
 	 */
-	public Map<Object, Object> getCache(String cacheName) throws TranslatorException;
+	public Map<Object, Object> getCache() throws TranslatorException;
 	
 	/**
 	 * Return the QueryFactory used by the cache.
-	 * @param cacheName
 	 * @return QueryFactory
 	 * @throws TranslatorException
 	 */
 	@SuppressWarnings("rawtypes")
-	public QueryFactory getQueryFactory(String cacheName) throws TranslatorException;
+	public QueryFactory getQueryFactory() throws TranslatorException;
 	
 	/**
 	 * Return the ClassRegistry that contains which classes and their methods.

--- a/connectors/translator-infinispan-dsl/src/main/java/org/teiid/translator/infinispan/dsl/InfinispanExecutionFactory.java
+++ b/connectors/translator-infinispan-dsl/src/main/java/org/teiid/translator/infinispan/dsl/InfinispanExecutionFactory.java
@@ -69,10 +69,11 @@ public class InfinispanExecutionFactory extends
 		setSupportsInnerJoins(true);
 		setSupportsFullOuterJoins(false);
 		setSupportsOuterJoins(true);
+		
 	
 		setSupportedJoinCriteria(SupportedJoinCriteria.KEY);
 	}
-	
+
 	@Override
 	public int getMaxFromGroups() {
 		return 2;
@@ -88,7 +89,11 @@ public class InfinispanExecutionFactory extends
     @Override
 	public UpdateExecution createUpdateExecution(Command command,
 			ExecutionContext executionContext, RuntimeMetadata metadata,
-			InfinispanConnection connection) {
+			InfinispanConnection connection) throws TranslatorException {
+    	// if no primary key defined,then updates are not enabled
+    	if (connection.getPkField() == null) {
+			throw new TranslatorException(InfinispanPlugin.Util.gs(InfinispanPlugin.Event.TEIID25007, new Object[] {connection.getCacheName()}));
+    	}
     	return new InfinispanUpdateExecution(command, connection, executionContext, this);
 	}
     

--- a/connectors/translator-infinispan-dsl/src/main/resources/org/teiid/translator/infinispan/dsl/i18n.properties
+++ b/connectors/translator-infinispan-dsl/src/main/resources/org/teiid/translator/infinispan/dsl/i18n.properties
@@ -27,14 +27,14 @@ TEIID25003=Registered Class not found for table {0}, check table name matches a 
 TEIID25004=Unable to perform {0}, no Primary or Foreign Key defined for table {1}
 TEIID25005=Table {0} has defined a container class of type Maps, which is not currently supported
 TEIID25006=Updating primary key column {0} in table {1} is not supported, use delete and insert.
-TEIID25007=No Primary key defined for cache {0}
+TEIID25007=Updates are disabled, no Primary key defined for cache {0} 
 TEIID25008=Primary Key {0} defined for cache {1} does not match a method on class {2}
 TEIID25009=Unable to insert duplicate into table {0} with key value {1}
 
 
 TEIID25020=MessageDescriptor must be specified
 TEIID25021=CacheTypeMap has not been set
-TEIID25022=CacheTypeMap incorrectly configured, must be in the form of - cacheName:ClassName
+TEIID25022=CacheTypeMap incorrectly configured, must be in the form of - cacheName:className[;pkFieldName[:cacheKeyJavaType]]
 TEIID25023=Must set configuration as to how the cache will be obtained (i.e., jndi, server list or properties file)
 TEIID25025=Unable to find cache using JNDI {0}
 TEIID25026=Cache Container {0} is not an instance of RemoteCacheManager

--- a/connectors/translator-infinispan-dsl/src/test/java/org/jboss/teiid/jdg_remote/pojo/AllTypes.java
+++ b/connectors/translator-infinispan-dsl/src/test/java/org/jboss/teiid/jdg_remote/pojo/AllTypes.java
@@ -28,7 +28,6 @@ public class AllTypes implements Serializable{
 	private String stringKey;
 	private Time timeValue;
 	private Date dateValue;
-	private byte[] byteArrayValue;
 
 	public String getStringNum() {
 		return stringNum;
@@ -156,13 +155,6 @@ public class AllTypes implements Serializable{
 
 	public void setDateValue(Date dateValue) {
 		this.dateValue = dateValue;
-	}
-	
-	public byte[] getByteArrayValue() {
-		return byteArrayValue;
-	}
-	public void setByteArrayValue(byte[] value) {
-		byteArrayValue = value;
 	}
 	
 

--- a/connectors/translator-infinispan-dsl/src/test/java/org/teiid/translator/infinispan/dsl/TestAbstractInfinispanConnectionFactory.java
+++ b/connectors/translator-infinispan-dsl/src/test/java/org/teiid/translator/infinispan/dsl/TestAbstractInfinispanConnectionFactory.java
@@ -1,0 +1,201 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.infinispan.dsl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.InvalidPropertyException;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.protostream.SerializationContext;
+import org.jboss.teiid.jdg_remote.pojo.AllTypes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.teiid.resource.adapter.infinispan.dsl.base.AbstractInfinispanManagedConnectionFactory;
+
+
+@SuppressWarnings("nls")
+public class TestAbstractInfinispanConnectionFactory  {
+	protected static final String JNDI_NAME = "java/MyCacheManager";
+
+
+	private static AbstractInfinispanManagedConnectionFactory afactory;
+	
+	@Before
+    public void beforeEach() throws Exception {  
+  
+        afactory = new AbstractInfinispanManagedConnectionFactory() {
+			/**
+			 */
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			protected SerializationContext getContext() {
+				// TODO Auto-generated method stub
+				return null;
+			}
+
+			@Override
+			protected RemoteCacheManager createRemoteCacheWrapperFromProperties(
+					ClassLoader classLoader) throws ResourceException {
+				// TODO Auto-generated method stub
+				return null;
+			}
+
+			@Override
+			protected RemoteCacheManager createRemoteCacheWrapperFromServerList(
+					ClassLoader classLoader) throws ResourceException {
+				// TODO Auto-generated method stub
+				return null;
+			}
+			
+			@Override
+			protected void registerMarshallers(SerializationContext ctx, ClassLoader cl) throws ResourceException {
+			
+			}
+
+		};
+		
+	}	
+	
+    @SuppressWarnings("unchecked")
+	@After
+    public void closeConnection() throws Exception {
+ 
+      	afactory.cleanUp();
+
+    }
+    
+    /**
+     * Test CacheTypeMap 1:
+     * - cache key type is the same
+     * - 
+     * @throws Exception
+     */
+	@Test public void testtCacheTypeMap1() throws Exception {
+		afactory.setProtobufDefinitionFile("allTypes.proto");
+		afactory.setMessageMarshallers("");
+		afactory.setMessageDescriptor("org.jboss.teiid.jdg_remote.pojo.AllTypes");
+		afactory.setCacheTypeMap("AllTypesCache:org.jboss.teiid.jdg_remote.pojo.AllTypes;intKey:" + Integer.class.getName());
+		afactory.setHotRodClientPropertiesFile("");
+		
+		
+		afactory.createConnectionFactory().getConnection();
+		
+		assertEquals("CacheClass Type not the same", AllTypes.class, afactory.getCacheClassType());
+		assertEquals("Cache name not the same", "AllTypesCache", afactory.getCacheName());
+		
+		assertEquals("CacheKeyTypeClass not the same", afactory.getCacheKeyClassType(), Integer.class);
+	}
+	
+	 /**
+     * Test tCacheTypeMap 2:
+     * - cache key type is different, meaning transformation will be needed for updates
+     * - 
+     * @throws Exception
+     */
+	@Test public void testCacheTypeMap2() throws Exception {
+		afactory.setProtobufDefinitionFile("allTypes.proto");
+		afactory.setMessageMarshallers("");
+		afactory.setMessageDescriptor("org.jboss.teiid.jdg_remote.pojo.AllTypes");
+		afactory.setCacheTypeMap("AllTypesCache:org.jboss.teiid.jdg_remote.pojo.AllTypes;intKey:" + String.class.getName());
+		afactory.setHotRodClientPropertiesFile("");
+		
+		
+		afactory.createConnectionFactory().getConnection();
+		
+		assertEquals("CacheClass Type not the same", AllTypes.class, afactory.getCacheClassType());
+		assertEquals("Cache name not the same", "AllTypesCache", afactory.getCacheName());
+		
+		// should not be equal because the cache key type is not the same as its method return value for getIntKey
+		assertNotEquals("CacheKeyClass Type not the same", Integer.class, afactory.getCacheKeyClassType());
+	}
+	
+	 /**
+     * Test tCacheTypeMap 3:
+     * - CacheTypeMap doesn't define the key or cache key type.  Used in cases where no updates are being done
+     * - 
+     * @throws Exception
+     */
+	//  @Test( expected = SQLException.class )
+	@Test public void testCacheTypeMap3() throws Exception {
+		afactory.setProtobufDefinitionFile("allTypes.proto");
+		afactory.setMessageMarshallers("");
+		afactory.setMessageDescriptor("org.jboss.teiid.jdg_remote.pojo.AllTypes");
+		afactory.setCacheTypeMap("AllTypesCache:org.jboss.teiid.jdg_remote.pojo.AllTypes");
+		afactory.setHotRodClientPropertiesFile("");
+		
+		
+		afactory.createConnectionFactory().getConnection();
+		
+		assertEquals("CacheClass Type not the same", AllTypes.class, afactory.getCacheClassType());
+		assertEquals("Cache name not the same", "AllTypesCache", afactory.getCacheName());
+		
+	}
+
+	 /**
+     * testCacheTypeMapNoCacheKeytype:
+     * - defining only the cache key
+     * - 
+     * @throws Exception
+     */
+	@Test public void testCacheTypeMapNoCacheKeytype() throws Exception {
+		afactory.setProtobufDefinitionFile("allTypes.proto");
+		afactory.setMessageMarshallers("");
+		afactory.setMessageDescriptor("org.jboss.teiid.jdg_remote.pojo.AllTypes");
+		afactory.setCacheTypeMap("AllTypesCache:org.jboss.teiid.jdg_remote.pojo.AllTypes;intKey");
+		afactory.setHotRodClientPropertiesFile("");
+		
+		
+		afactory.createConnectionFactory().getConnection();
+		
+		assertEquals("CacheClass Type not the same", AllTypes.class, afactory.getCacheClassType());
+		assertEquals("Cache name not the same", "AllTypesCache", afactory.getCacheName());
+		
+		assertNull(afactory.getCacheKeyClassType());
+	}
+	
+	 /**
+     * Test tCacheTypeMap 3:
+     * - CacheTypeMap doesn't define the key or cache key type.  Used in cases where no updates are being done
+     * - 
+     * @throws Exception
+     */
+	@Test( expected = InvalidPropertyException.class )
+	public void testInvalidCacheTypeMap() throws Exception {
+		afactory.setProtobufDefinitionFile("allTypes.proto");
+		afactory.setMessageMarshallers("");
+		afactory.setMessageDescriptor("org.jboss.teiid.jdg_remote.pojo.AllTypes");
+		afactory.setCacheTypeMap("AllTypesCache");
+		afactory.setHotRodClientPropertiesFile("");
+		
+		
+		afactory.createConnectionFactory().getConnection();
+		
+	}	
+
+
+}

--- a/connectors/translator-infinispan-dsl/src/test/java/org/teiid/translator/infinispan/dsl/TestInfinispanExecution.java
+++ b/connectors/translator-infinispan-dsl/src/test/java/org/teiid/translator/infinispan/dsl/TestInfinispanExecution.java
@@ -61,7 +61,7 @@ public class TestInfinispanExecution {
     @BeforeClass
     public static void setUp()  {
         
-		CONNECTION = PersonCacheSource.createConnection();
+		CONNECTION = PersonCacheSource.createConnection(true);
 
     }	
 

--- a/connectors/translator-infinispan-dsl/src/test/java/org/teiid/translator/infinispan/dsl/TestInfinispanExecutionFactory.java
+++ b/connectors/translator-infinispan-dsl/src/test/java/org/teiid/translator/infinispan/dsl/TestInfinispanExecutionFactory.java
@@ -47,7 +47,7 @@ public class TestInfinispanExecutionFactory {
 	private Select command;
 	
 	
-	private InfinispanConnection connection = PersonCacheSource.createConnection();
+	private InfinispanConnection connection = PersonCacheSource.createConnection(true);
 	
     @BeforeClass
     public static void setUp() throws TranslatorException {

--- a/connectors/translator-infinispan-dsl/src/test/java/org/teiid/translator/infinispan/dsl/TestInfinispanUpdateExecution.java
+++ b/connectors/translator-infinispan-dsl/src/test/java/org/teiid/translator/infinispan/dsl/TestInfinispanUpdateExecution.java
@@ -42,14 +42,26 @@ public class TestInfinispanUpdateExecution {
 	@Before public void beforeEach() throws Exception{	
 		 
 		MockitoAnnotations.initMocks(this);
-		CONNECTION = PersonCacheSource.createConnection();
     }
 
 	@Test
 	public void testInsertRootClass() throws Exception {
 
+		CONNECTION = PersonCacheSource.createConnection(true);
+		insertRoot();
+	}
+	
+	@Test
+	public void testInsertRootClassNoCacheTypeClassDefined() throws Exception {
+
+		CONNECTION = PersonCacheSource.createConnection(false);
+		insertRoot();
+	}
+
+	
+	private void insertRoot() throws Exception {
 		// check the object doesn't exist before inserting
-		Object o = CONNECTION.getCache(PersonCacheSource.PERSON_CACHE_NAME).get(99);
+		Object o = CONNECTION.getCache().get((new Integer(99).intValue()));
 		assertNull(o);
 		
 		Command command = translationUtility
@@ -61,18 +73,28 @@ public class TestInfinispanUpdateExecution {
 
 		ie.execute();
 
-		Person p = (Person) CONNECTION.getCache(PersonCacheSource.PERSON_CACHE_NAME).get(99);
+		Person p = (Person) CONNECTION.getCache().get((new Integer(99).intValue()));
 
 		assertNotNull(p);
 		assertTrue(p.getName().equals("TestName"));
 		assertTrue(p.getEmail().equals("testName@mail.com"));
 		
 	}
-
+	
 	@Test
 	public void testInsertChildClass() throws Exception {
+		CONNECTION = PersonCacheSource.createConnection(true);
+		insertChildClass();
+	}
+
+	@Test
+	public void testInsertChildClassNoClassTypeDefined() throws Exception {
+		CONNECTION = PersonCacheSource.createConnection(false);
+		insertChildClass();
+	}
 		
-		assertNotNull(CONNECTION.getCache(PersonCacheSource.PERSON_CACHE_NAME).get(2));
+	private void insertChildClass() throws Exception {
+		assertNotNull(CONNECTION.getCache().get((new Integer(2).intValue())));
 
 		Command command = translationUtility
 				.parseCommand("Insert into PhoneNumber (id, number, type) VALUES (2, '999-888-7777', 'HOME')");
@@ -83,7 +105,7 @@ public class TestInfinispanUpdateExecution {
 
 		ie.execute();
 
-		Person p = (Person) CONNECTION.getCache(PersonCacheSource.PERSON_CACHE_NAME).get(2);
+		Person p = (Person) CONNECTION.getCache().get((new Integer(2).intValue()));
 		assertNotNull(p);
 
 		boolean found = false;
@@ -94,12 +116,23 @@ public class TestInfinispanUpdateExecution {
 		}
 		assertTrue(found);
 	}
-	
+
 	@Test
 	public void testUpdateRootClass() throws Exception {
-
+		CONNECTION = PersonCacheSource.createConnection(true);
+		updateRootClass();
+	}
+		
+	@Test
+	public void testUpdateRootClassNoClassTypeDefined() throws Exception {
+		CONNECTION = PersonCacheSource.createConnection(false);
+		updateRootClass();
+	}
+	
+	private void updateRootClass() throws Exception {
+		
 		// check the object doesn't exist before inserting
-		Object o = CONNECTION.getCache(PersonCacheSource.PERSON_CACHE_NAME).get(5);
+		Object o = CONNECTION.getCache().get((new Integer(5).intValue()));
 		assertNotNull(o);
 		
 		Command command = translationUtility
@@ -113,7 +146,7 @@ public class TestInfinispanUpdateExecution {
 
 		ie.execute();
 
-		Person p = (Person) CONNECTION.getCache(PersonCacheSource.PERSON_CACHE_NAME).get(5);
+		Person p = (Person) CONNECTION.getCache().get((new Integer(5).intValue()));
 
 		assertNotNull(p);
 		assertTrue(p.getName().equals("Person 5 Changed"));
@@ -121,44 +154,65 @@ public class TestInfinispanUpdateExecution {
 		
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testDeleteRootByKey() throws Exception {
+		CONNECTION = PersonCacheSource.createConnection(true);
+		deleteRootClass();
+	}
+
+	@Test
+	public void testDeleteRootByKeyNoClassTypeDefined() throws Exception {
+		CONNECTION = PersonCacheSource.createConnection(false);
+		deleteRootClass();
+	}
+	
+	private void deleteRootClass() throws Exception {
 		
-		assertNotNull(CONNECTION.getCache(PersonCacheSource.PERSON_CACHE_NAME).get(1));
+		assertNotNull(CONNECTION.getCache().get(new Integer(1).intValue()));
 
 		Command command = translationUtility
 				.parseCommand("Delete From Person Where id = 1");
 
 		@SuppressWarnings("rawtypes")
 		List rows = new ArrayList();
-		rows.add(TestInfinispanUpdateExecution.DATA.get(1));
+		rows.add(TestInfinispanUpdateExecution.DATA.get(new Integer(1).intValue()));
 
 		InfinispanUpdateExecution ie = createExecution(command, rows);
 
 		ie.execute();
-		assertNull(CONNECTION.getCache(PersonCacheSource.PERSON_CACHE_NAME)
+		assertNull(CONNECTION.getCache()
 				.get(new Integer(1).intValue()));
 
 	}
 
 	@Test
 	public void testDeleteRootByValue() throws Exception {
+		CONNECTION = PersonCacheSource.createConnection(true);
+		deleteRootByValue();
+	}
 
-		assertNotNull(CONNECTION.getCache(PersonCacheSource.PERSON_CACHE_NAME).get(2));
+	@Test
+	public void testDeleteRootByValueNoClassTypeDefined() throws Exception {
+		CONNECTION = PersonCacheSource.createConnection(false);
+		deleteRootByValue();
+	}
+	
+	private void deleteRootByValue() throws Exception {
+			
+		assertNotNull(CONNECTION.getCache().get(new Integer(2).intValue()));
 
 		Command command = translationUtility
 				.parseCommand("Delete From Person Where Name = 'Person 2'");
 
 
 		List rows = new ArrayList();
-		rows.add(TestInfinispanUpdateExecution.DATA.get(2));
+		rows.add(TestInfinispanUpdateExecution.DATA.get((new Integer(2).intValue())));
 
 		InfinispanUpdateExecution ie = createExecution(command, rows);
 		
 		ie.execute();
-		assertNull(CONNECTION.getCache(PersonCacheSource.PERSON_CACHE_NAME)
-				.get(2));
+		assertNull(CONNECTION.getCache()
+				.get((new Integer(2).intValue())));
 
 	}
 
@@ -167,7 +221,7 @@ public class TestInfinispanUpdateExecution {
 		String phoneNumber="(111)222-3451";	
 		
 		// check the phone number exists
-		Iterator it=CONNECTION.getCache(PersonCacheSource.PERSON_CACHE_NAME).values().iterator();
+		Iterator it=CONNECTION.getCache().values().iterator();
 		boolean found = false;
 		while (it.hasNext()) {
 			Person p = (Person) it.next();
@@ -188,13 +242,13 @@ public class TestInfinispanUpdateExecution {
 
 		InfinispanUpdateExecution ie = createExecution(command, rows);
 
-		assertNotNull(CONNECTION.getCache(PersonCacheSource.PERSON_CACHE_NAME).get(2));
+		assertNotNull(CONNECTION.getCache().get(2));
 		
 		ie.execute();
 		int[] cnts = ie.getUpdateCounts();
 		assertTrue(cnts[0] == 10);
 		
-		it=CONNECTION.getCache(PersonCacheSource.PERSON_CACHE_NAME).values().iterator();
+		it=CONNECTION.getCache().values().iterator();
 		// verify phone was completely removed
 		while (it.hasNext()) {
 			Person p = (Person) it.next();

--- a/connectors/translator-infinispan-dsl/src/test/java/org/teiid/translator/infinispan/dsl/TestInfinispanUpdateUsingAllTypes.java
+++ b/connectors/translator-infinispan-dsl/src/test/java/org/teiid/translator/infinispan/dsl/TestInfinispanUpdateUsingAllTypes.java
@@ -42,14 +42,24 @@ public class TestInfinispanUpdateUsingAllTypes {
 	@Before public void beforeEach() throws Exception{	
 		 
 		MockitoAnnotations.initMocks(this);
-		CONNECTION = AllTypesCacheSource.createConnection();
     }
 
 	@Test
 	public void testInsertRootClass() throws Exception {
+		CONNECTION = AllTypesCacheSource.createConnection();
+		insertRootClass();
+	}
+	
+	@Test
+	public void testInsertRootClassNoClasTypeKeyDefined() throws Exception {
+		CONNECTION = AllTypesCacheSource.createConnection(false);
+		insertRootClass();
+	}	
+	
+	private void insertRootClass() throws Exception {
 
 		// check the object doesn't exist before inserting
-		Object o = CONNECTION.getCache(AllTypesCacheSource.ALLTYPES_CACHE_NAME).get(99);
+		Object o = CONNECTION.getCache().get(99);
 		assertNull(o);
 		
 		Command command = translationUtility
@@ -60,27 +70,14 @@ public class TestInfinispanUpdateUsingAllTypes {
 //		.parseCommand("Insert into AllTypes (intKey, intNum, stringKey, stringNum, booleanValue, longNum, doubleNum, floatNum) " + 
 //				"VALUES (99, 991, 'string key value', '999', true, 1200, 23.45, 12.456  )");
 
-	/**	
-		private Character charValue;
-		private Double doubleNum;
-		private BigInteger bigIntegerValue;
-		private Short shortValue;
-		private Float floatNum;
-		private Object  objectValue;
 
-		private BigDecimal bigDecimalValue;
-		private Timestamp timeStampValue;
-		private Time timeValue;
-		private Date dateValue;
-		private byte[] byteArrayValue;
-		*/
 		// no search required by the UpdateExecution logic
 		@SuppressWarnings("unchecked")
 		InfinispanUpdateExecution ie = createExecution(command, Collections.EMPTY_LIST);
 
 		ie.execute();
 
-		AllTypes p = (AllTypes) CONNECTION.getCache(AllTypesCacheSource.ALLTYPES_CACHE_NAME).get(99);
+		AllTypes p = (AllTypes) CONNECTION.getCache().get(99);
 
 		String stringNum = String.valueOf("999");
 		
@@ -100,9 +97,20 @@ public class TestInfinispanUpdateUsingAllTypes {
 	// TEIID-3534 - cannot insert Boolean attribute with null
 	@Test
 	public void testInsertBooleanOfNull() throws Exception {
+		CONNECTION = AllTypesCacheSource.createConnection();
+		insertBooleanOfNull();
+	}
+
+	@Test
+	public void testInsertBooleanOfNullNoClassKeyTypeDefined() throws Exception {
+		CONNECTION = AllTypesCacheSource.createConnection(false);
+		insertBooleanOfNull();
+	}
+
+	private void insertBooleanOfNull() throws Exception {
 
 		// check the object doesn't exist before inserting
-		Object o = CONNECTION.getCache(AllTypesCacheSource.ALLTYPES_CACHE_NAME).get(99);
+		Object o = CONNECTION.getCache().get(99);
 		assertNull(o);
 		
 		Command command = translationUtility
@@ -115,7 +123,7 @@ public class TestInfinispanUpdateUsingAllTypes {
 
 		ie.execute();
 
-		AllTypes p = (AllTypes) CONNECTION.getCache(AllTypesCacheSource.ALLTYPES_CACHE_NAME).get(99);
+		AllTypes p = (AllTypes) CONNECTION.getCache().get(99);
 
 		String stringNum = String.valueOf("999");
 		
@@ -136,9 +144,10 @@ public class TestInfinispanUpdateUsingAllTypes {
 	// TEIID-3539 -  Can't use IS [NOT] NULL operator for non-string columns
 	//@Test
 	public void testInsertIsNotNullOperator() throws Exception {
+		CONNECTION = AllTypesCacheSource.createConnection();
 
 		// check the object doesn't exist before inserting
-		Object o = CONNECTION.getCache(AllTypesCacheSource.ALLTYPES_CACHE_NAME).get(99);
+		Object o = CONNECTION.getCache().get(99);
 		assertNull(o);
 		
 		Command command = translationUtility
@@ -162,7 +171,7 @@ public class TestInfinispanUpdateUsingAllTypes {
 		
 		
 
-		AllTypes p = (AllTypes) CONNECTION.getCache(AllTypesCacheSource.ALLTYPES_CACHE_NAME).get(99);
+		AllTypes p = (AllTypes) CONNECTION.getCache().get(99);
 
 		String stringNum = String.valueOf("999");
 		
@@ -179,9 +188,21 @@ public class TestInfinispanUpdateUsingAllTypes {
 
 	@Test
 	public void testUpdateRootClass() throws Exception {
+		CONNECTION = AllTypesCacheSource.createConnection();
+		updateRootClass();
+	}
 
-		// check the object doesn't exist before inserting
-		Object o = CONNECTION.getCache(AllTypesCacheSource.ALLTYPES_CACHE_NAME).get(5);
+	@Test
+	public void testUpdateRootClassNoClassKeyTypeDefined() throws Exception {
+		CONNECTION = AllTypesCacheSource.createConnection(false);
+		updateRootClass();
+	}
+	
+	private void updateRootClass() throws Exception {
+	
+	
+	// check the object doesn't exist before inserting
+		Object o = CONNECTION.getCache().get(5);
 		assertNotNull(o);
 		
 		Command command = translationUtility
@@ -195,7 +216,7 @@ public class TestInfinispanUpdateUsingAllTypes {
 
 		ie.execute();
 
-		AllTypes p = (AllTypes) CONNECTION.getCache(AllTypesCacheSource.ALLTYPES_CACHE_NAME).get(5);
+		AllTypes p = (AllTypes) CONNECTION.getCache().get(5);
 
 		String stringNum = String.valueOf("10000");
 		
@@ -204,11 +225,21 @@ public class TestInfinispanUpdateUsingAllTypes {
 		
 	}
 
-//	@SuppressWarnings("unchecked")
 	@Test
 	public void testDeleteRootByKey() throws Exception {
+		CONNECTION = AllTypesCacheSource.createConnection();
+		deleteRootByKey();
+	}
 		
-		assertNotNull(CONNECTION.getCache(AllTypesCacheSource.ALLTYPES_CACHE_NAME).get(1));
+	@Test
+	public void testDeleteRootByKeyNoClassKeyTypeDefined() throws Exception {
+		CONNECTION = AllTypesCacheSource.createConnection(false);
+		deleteRootByKey();
+	}
+
+	private void deleteRootByKey() throws Exception {
+	
+		assertNotNull(CONNECTION.getCache().get(1));
 
 		Command command = translationUtility
 				.parseCommand("Delete From AllTypes Where intKey=99");
@@ -220,7 +251,7 @@ public class TestInfinispanUpdateUsingAllTypes {
 		InfinispanUpdateExecution ie = createExecution(command, rows);
 
 		ie.execute();
-		assertNull(CONNECTION.getCache(AllTypesCacheSource.ALLTYPES_CACHE_NAME)
+		assertNull(CONNECTION.getCache()
 				.get(new Integer(1).intValue()));
 
 	}

--- a/connectors/translator-infinispan-dsl/src/test/java/org/teiid/translator/infinispan/dsl/metadata/TestProtobufMetadataProcessor.java
+++ b/connectors/translator-infinispan-dsl/src/test/java/org/teiid/translator/infinispan/dsl/metadata/TestProtobufMetadataProcessor.java
@@ -2,11 +2,6 @@ package org.teiid.translator.infinispan.dsl.metadata;
 
 import static org.junit.Assert.assertEquals;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
 import java.util.Properties;
 
 import org.jboss.as.quickstarts.datagrid.hotrod.query.domain.PersonCacheSource;
@@ -14,7 +9,6 @@ import org.jboss.teiid.jdg_remote.pojo.AllTypesCacheSource;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.MockitoAnnotations;
 import org.teiid.metadata.MetadataFactory;
 import org.teiid.query.metadata.DDLStringVisitor;
 import org.teiid.query.metadata.SystemMetadata;
@@ -43,7 +37,7 @@ public class TestProtobufMetadataProcessor {
 				SystemMetadata.getInstance().getRuntimeTypeMap(),
 				new Properties(), null);
 
-		InfinispanConnection conn = PersonCacheSource.createConnection();
+		InfinispanConnection conn = PersonCacheSource.createConnection(true);
 
 		TRANSLATOR.getMetadataProcessor().process(mf, conn);
 
@@ -57,14 +51,14 @@ public class TestProtobufMetadataProcessor {
 				+ "\tname string OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'java.lang.String'),\n"
 				+ "\temail string OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'java.lang.String'),\n"
 				+ "\tCONSTRAINT PK_ID PRIMARY KEY(id)\n"
-				+ ") OPTIONS (NAMEINSOURCE 'PersonsCache', UPDATABLE TRUE);\n"
+				+ ") OPTIONS (UPDATABLE TRUE);\n"
 				+ "\n"
 				+ "CREATE FOREIGN TABLE PhoneNumber (\n"
 				+ "\tnumber string OPTIONS (NAMEINSOURCE 'phone.number', SEARCHABLE 'Searchable', NATIVE_TYPE 'java.lang.String'),\n"
 				+ "\ttype object OPTIONS (NAMEINSOURCE 'phone.type', SEARCHABLE 'Unsearchable', NATIVE_TYPE 'org.jboss.as.quickstarts.datagrid.hotrod.query.domain.PhoneType'),\n"
 				+ "\tid integer NOT NULL OPTIONS (SELECTABLE FALSE, UPDATABLE FALSE, SEARCHABLE 'Searchable', NATIVE_TYPE 'int'),\n"
 				+ "\tCONSTRAINT FK_PERSON FOREIGN KEY(id) REFERENCES Person (id) OPTIONS (NAMEINSOURCE 'phones')\n"
-				+ ") OPTIONS (NAMEINSOURCE 'PersonsCache', UPDATABLE TRUE);"
+				+ ") OPTIONS (UPDATABLE TRUE);"
 				;
 		assertEquals(expected, metadataDDL);	
 
@@ -104,9 +98,8 @@ public class TestProtobufMetadataProcessor {
 				+ "\ttimeValue time OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'java.sql.Time'),\n"
 				+ "\tdateValue date OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'java.sql.Date'),\n"
 				+ "\tcharValue char OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'java.lang.Character'),\n"
-				+ "\tbyteArrayValue varbinary OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'byte[]'),\n"
 				+ "\tCONSTRAINT PK_INTKEY PRIMARY KEY(intKey)\n"
-				+ ") OPTIONS (NAMEINSOURCE 'AllTypesCache', UPDATABLE TRUE);"
+				+ ") OPTIONS (UPDATABLE TRUE);"
 				;
 
 		

--- a/connectors/translator-infinispan-dsl/src/test/java/org/teiid/translator/infinispan/dsl/util/PersonSchemaVDBUtility.java
+++ b/connectors/translator-infinispan-dsl/src/test/java/org/teiid/translator/infinispan/dsl/util/PersonSchemaVDBUtility.java
@@ -69,7 +69,7 @@ public class PersonSchemaVDBUtility {
 					SystemMetadata.getInstance().getRuntimeTypeMap(),
 					new Properties(), null);
 	
-			InfinispanConnection conn = PersonCacheSource.createConnection();
+			InfinispanConnection conn = PersonCacheSource.createConnection(true);
 	
 			translator.getMetadataProcessor().process(mf, conn);
 		

--- a/connectors/translator-infinispan-dsl/src/test/resources/allTypes.proto
+++ b/connectors/translator-infinispan-dsl/src/test/resources/allTypes.proto
@@ -1,23 +1,22 @@
-package org.jboss.teiid.jdg_remote.protobuf;
+package org.jboss.qe.jdg_remote.protobuf;
 
 message AllTypes {
 
    required int32 intKey = 1;
    optional string stringNum = 2;
    required string stringKey = 3;
-   optional float floatNum = 4;
-   optional int64 bigIntegerValue = 5;
+   optional float floatNum = 4 [default = 0];
+   optional int64 bigIntegerValue = 5 [default = 0];
    optional int32 shortValue = 6;      
-   optional double doubleNum = 7;
+   optional double doubleNum = 7 [default = 0];
    optional bytes objectValue = 8;
-   optional int32 intNum = 9;   
-   optional double bigDecimalValue = 10;   
-   optional int64 longNum = 11;   
-   optional bool booleanValue = 12;   
-   optional int64 timeStampValue = 13;    
+   optional int32 intNum = 9 [default = 0];   
+   optional double bigDecimalValue = 10 [default = 0];   
+   optional int64 longNum = 11 [default = 0];   
+   optional bool booleanValue = 12 [default = false];  
+   optional int64 timeStampValue = 13;     
    optional int64 timeValue = 14;
    optional int64 dateValue = 15; 
    optional int32 charValue = 16;
-   optional bytes byteArrayValue = 17;
 
 }


### PR DESCRIPTION
TEIID-3533 changed to use DataType.transform to convert values to the native object types for inserts and updates, TEIID-3535 add an NPE check for if a table has a primary key defined, fixed order by issue that wasnt using getNameInSource method logic.