### PR TITLE
TEIID-3632: introduced 5 second caching of the data source names, so …

### DIFF
--- a/admin/src/main/java/org/teiid/adminapi/Admin.java
+++ b/admin/src/main/java/org/teiid/adminapi/Admin.java
@@ -36,7 +36,7 @@ public interface Admin {
 
 	public enum SchemaObjectType {TABLES, PROCEDURES, FUNCTIONS};
 	
-	public enum TranlatorPropertyType{IMPORT, OVERRIDE, EXTENSION_METADATA};
+	public enum TranlatorPropertyType{IMPORT, OVERRIDE, EXTENSION_METADATA, ALL};
 
     /**
      * Assign a {@link Translator} and Data source to a {@link VDB}'s Model

--- a/admin/src/main/java/org/teiid/adminapi/PropertyDefinition.java
+++ b/admin/src/main/java/org/teiid/adminapi/PropertyDefinition.java
@@ -130,7 +130,11 @@ public interface PropertyDefinition extends AdminObject {
      */
     boolean isMasked();
 
-    
+    /**
+     * Get the category of the property
+     * @return if null, no category exists
+     */
+    String getCategory();
     
 }
 

--- a/admin/src/main/java/org/teiid/adminapi/impl/PropertyDefinitionMetadata.java
+++ b/admin/src/main/java/org/teiid/adminapi/impl/PropertyDefinitionMetadata.java
@@ -42,7 +42,7 @@ public class PropertyDefinitionMetadata extends AdminObjectImpl implements Prope
     private boolean masked = false;
     private boolean modifiable = true;
     private boolean required = false;
-    
+    private String category; 
     
     /**
      * @see java.lang.Object#toString()
@@ -59,6 +59,7 @@ public class PropertyDefinitionMetadata extends AdminObjectImpl implements Prope
         result.append(" Required:").append(isRequired()); //$NON-NLS-1$
         result.append(" Expert:").append(isAdvanced()); //$NON-NLS-1$
         result.append(" Masked:").append(isMasked()); //$NON-NLS-1$
+        result.append(" Category:").append(getCategory()); //$NON-NLS-1$
         result.append(" Modifiable:").append(isModifiable()); //$NON-NLS-1$
         result.append(" RequiresRestart:").append(getRequiresRestart()); //$NON-NLS-1$
         return result.toString();
@@ -212,4 +213,13 @@ public class PropertyDefinitionMetadata extends AdminObjectImpl implements Prope
 	public boolean isConstrainedToAllowedValues() {
 		return allowedValues != null && !allowedValues.isEmpty();
 	}
+
+    @Override
+    public String getCategory() {
+        return this.category;
+    }
+    
+    public void setCategory(String category) {
+        this.category = category;
+    }
 }

--- a/runtime/src/test/java/org/teiid/runtime/TestEmbeddedServerAdmin.java
+++ b/runtime/src/test/java/org/teiid/runtime/TestEmbeddedServerAdmin.java
@@ -236,6 +236,9 @@ public class TestEmbeddedServerAdmin {
 	public void testGetTranslatorPropertyDefinitions() throws AdminException {
 		List<PropertyDefinition> list = (List<PropertyDefinition>) admin.getTranslatorPropertyDefinitions("file", TranlatorPropertyType.OVERRIDE);
 		assertEquals(19, list.size());
+		
+		list = (List<PropertyDefinition>) admin.getTranslatorPropertyDefinitions("file", TranlatorPropertyType.ALL);
+        assertEquals(19, list.size());		
 	}
 	
 	@Test


### PR DESCRIPTION
…that repreated cli calls can be avoided, also introduced ALL property type where it represents all the property types of translator