### PR TITLE
TEIID-3667 LDAPSyncQueryExecution.createSearchContext() hides a root …

### DIFF
--- a/connectors/translator-ldap/src/main/java/org/teiid/translator/ldap/LDAPSyncQueryExecution.java
+++ b/connectors/translator-ldap/src/main/java/org/teiid/translator/ldap/LDAPSyncQueryExecution.java
@@ -146,7 +146,7 @@ public class LDAPSyncQueryExecution implements ResultSetExecution {
 			return (LdapContext) this.ldapConnection.lookup(contextName);
 		} catch (NamingException ne) {			
 			if (contextName != null) {
-				LogManager.logError(LogConstants.CTX_CONNECTOR, LDAPPlugin.Util.gs(LDAPPlugin.Event.TEIID12002, contextName));
+                            LogManager.logError(LogConstants.CTX_CONNECTOR, ne, LDAPPlugin.Util.gs(LDAPPlugin.Event.TEIID12002, contextName));
 			}
             final String msg = LDAPPlugin.Util.getString("LDAPSyncQueryExecution.createContextError"); //$NON-NLS-1$
 			throw new TranslatorException(ne, msg); 


### PR DESCRIPTION
…cause when an error occurs