### PR TITLE
Changed for product build only to produce javadocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,25 +190,6 @@
           This profile is activated manually, as in "mvn ... -P release ..."
 		  -->
       <id>release</id>
-      <properties>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-      </properties>
-      <modules>
-        <module>build</module>        
-      </modules>
-      <build>
-        <plugins>
-       
-        </plugins>
-      </build>
-    </profile>
-        
-    <profile>
-      <id>releasewithjavadoc</id>
-      <properties>
-        <!--maven.javadoc.skip>true</maven.javadoc.skip-->
-        <skipTests>true</skipTests>
-      </properties>
       <modules>
         <module>build</module>        
       </modules>


### PR DESCRIPTION
Changed for product build only, so the javadocs can be produced at the same time as the -Prelease is done, in one step.