### PR TITLE
added command to add AUDIT_LOG to standard install, …

### DIFF
--- a/build/kits/jboss-as7/overlay/bin/scripts/teiid-domain-auditcommand-logging.cli
+++ b/build/kits/jboss-as7/overlay/bin/scripts/teiid-domain-auditcommand-logging.cli
@@ -5,29 +5,33 @@ connect
 batch
 
 # Add the periodic rotating file handlers corresponding to those added to the logging properties file
-/profile=ha/subsystem=logging/periodic-rotating-file-handler=TEIID_COMMAND_LOG/:add(suffix=.yyyy-MM-dd,formatter="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %X{teiid-session} %s%E%n",level=DEBUG,append=true,file={"path"=>"teiid-command.log", "relative-to"=>"jboss.server.log.dir"})
-/profile=ha/subsystem=logging/periodic-rotating-file-handler=TEIID_AUDIT_LOG/:add(suffix=.yyyy-MM-dd,formatter="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %X{teiid-session} %s%E%n",level=DEBUG,append=true,file={"path"=>"teiid-audit.log", "relative-to"=>"jboss.server.log.dir"})
+/profile=ha/subsystem=logging/periodic-rotating-file-handler=TEIID_COMMAND_LOG/:add(suffix=.yyyy-MM-dd,formatter="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %X{teiid-session} %s%E%n",level=WARN,append=true,file={"path"=>"teiid-command.log", "relative-to"=>"jboss.server.log.dir"})
+/profile=ha/subsystem=logging/periodic-rotating-file-handler=TEIID_AUDIT_LOG/:add(suffix=.yyyy-MM-dd,formatter="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %X{teiid-session} %s%E%n",level=WARN,append=true,file={"path"=>"teiid-audit.log", "relative-to"=>"jboss.server.log.dir"})
 
-/profile=full-ha/subsystem=logging/periodic-rotating-file-handler=TEIID_COMMAND_LOG/:add(suffix=.yyyy-MM-dd,formatter="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %X{teiid-session} %s%E%n",level=DEBUG,append=true,file={"path"=>"teiid-command.log", "relative-to"=>"jboss.server.log.dir"})
-/profile=full-ha/subsystem=logging/periodic-rotating-file-handler=TEIID_AUDIT_LOG/:add(suffix=.yyyy-MM-dd,formatter="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %X{teiid-session} %s%E%n",level=DEBUG,append=true,file={"path"=>"teiid-audit.log", "relative-to"=>"jboss.server.log.dir"})
+/profile=full-ha/subsystem=logging/periodic-rotating-file-handler=TEIID_COMMAND_LOG/:add(suffix=.yyyy-MM-dd,formatter="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %X{teiid-session} %s%E%n",level=WARN,append=true,file={"path"=>"teiid-command.log", "relative-to"=>"jboss.server.log.dir"})
+/profile=full-ha/subsystem=logging/periodic-rotating-file-handler=TEIID_AUDIT_LOG/:add(suffix=.yyyy-MM-dd,formatter="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %X{teiid-session} %s%E%n",level=WARN,append=true,file={"path"=>"teiid-audit.log", "relative-to"=>"jboss.server.log.dir"})
 
 
 # Configure the logging async handlers
-/profile=ha/subsystem=logging/async-handler=TEIID_COMMAND_LOG_ASYNC:add(level=DEBUG,queue-length=1024,overflow-action=BLOCK,subhandlers=["TEIID_COMMAND_LOG"], enabled=true)
-/profile=ha/subsystem=logging/async-handler=TEIID_AUDIT_LOG_ASYNC:add(level=DEBUG,queue-length=1024,overflow-action=BLOCK,subhandlers=["TEIID_AUDIT_LOG"], enabled=true)
+/profile=ha/subsystem=logging/async-handler=TEIID_COMMAND_LOG_ASYNC:add(level=WARN,queue-length=1024,overflow-action=BLOCK,subhandlers=["TEIID_COMMAND_LOG"], enabled=true)
+/profile=ha/subsystem=logging/async-handler=TEIID_AUDIT_LOG_ASYNC:add(level=WARN,queue-length=1024,overflow-action=BLOCK,subhandlers=["TEIID_AUDIT_LOG"], enabled=true)
 
-/profile=full-ha/subsystem=logging/async-handler=TEIID_COMMAND_LOG_ASYNC:add(level=DEBUG,queue-length=1024,overflow-action=BLOCK,subhandlers=["TEIID_COMMAND_LOG"], enabled=true)
-/profile=full-ha/subsystem=logging/async-handler=TEIID_AUDIT_LOG_ASYNC:add(level=DEBUG,queue-length=1024,overflow-action=BLOCK,subhandlers=["TEIID_AUDIT_LOG"], enabled=true)
+/profile=full-ha/subsystem=logging/async-handler=TEIID_COMMAND_LOG_ASYNC:add(level=WARN,queue-length=1024,overflow-action=BLOCK,subhandlers=["TEIID_COMMAND_LOG"], enabled=true)
+/profile=full-ha/subsystem=logging/async-handler=TEIID_AUDIT_LOG_ASYNC:add(level=WARN,queue-length=1024,overflow-action=BLOCK,subhandlers=["TEIID_AUDIT_LOG"], enabled=true)
 
 
 # Create the logger for teiid
 /profile=ha/subsystem=logging/logger=org.teiid.COMMAND_LOG:remove
-/profile=ha/subsystem=logging/logger=org.teiid.COMMAND_LOG:add(level=DEBUG, handlers=[TEIID_COMMAND_LOG_ASYNC], use-parent-handlers=false)
-/profile=ha/subsystem=logging/logger=org.teiid.AUDIT_LOG:add(level=DEBUG, handlers=[TEIID_AUDIT_LOG_ASYNC], use-parent-handlers=false)
+/profile=ha/subsystem=logging/logger=org.teiid.AUDIT_LOG:remove
+
+/profile=ha/subsystem=logging/logger=org.teiid.COMMAND_LOG:add(level=WARN, handlers=[TEIID_COMMAND_LOG_ASYNC], use-parent-handlers=false)
+/profile=ha/subsystem=logging/logger=org.teiid.AUDIT_LOG:add(level=WARN, handlers=[TEIID_AUDIT_LOG_ASYNC], use-parent-handlers=false)
 
 /profile=full-ha/subsystem=logging/logger=org.teiid.COMMAND_LOG:remove
-/profile=full-ha/subsystem=logging/logger=org.teiid.COMMAND_LOG:add(level=DEBUG, handlers=[TEIID_COMMAND_LOG_ASYNC], use-parent-handlers=false)
-/profile=full-ha/subsystem=logging/logger=org.teiid.AUDIT_LOG:add(level=DEBUG, handlers=[TEIID_AUDIT_LOG_ASYNC], use-parent-handlers=false)
+/profile=full-ha/subsystem=logging/logger=org.teiid.AUDIT_LOG:remove
+
+/profile=full-ha/subsystem=logging/logger=org.teiid.COMMAND_LOG:add(level=WARN, handlers=[TEIID_COMMAND_LOG_ASYNC], use-parent-handlers=false)
+/profile=full-ha/subsystem=logging/logger=org.teiid.AUDIT_LOG:add(level=WARN, handlers=[TEIID_AUDIT_LOG_ASYNC], use-parent-handlers=false)
 
 # Run the batch commands
 run-batch

--- a/build/kits/jboss-as7/overlay/bin/scripts/teiid-domain-mode-install.cli
+++ b/build/kits/jboss-as7/overlay/bin/scripts/teiid-domain-mode-install.cli
@@ -18,8 +18,14 @@
 /profile=ha/subsystem=logging/logger=org.teiid.COMMAND_LOG:add
 /profile=ha/subsystem=logging/logger=org.teiid.COMMAND_LOG:write-attribute(name="level", value="WARN")
 
+/profile=ha/subsystem=logging/logger=org.teiid.AUDIT_LOG:add
+/profile=ha/subsystem=logging/logger=org.teiid.AUDIT_LOG:write-attribute(name="level", value="WARN")
+
 /profile=full-ha/subsystem=logging/logger=org.teiid.COMMAND_LOG:add
 /profile=full-ha/subsystem=logging/logger=org.teiid.COMMAND_LOG:write-attribute(name="level", value="WARN")
+
+/profile=full-ha/subsystem=logging/logger=org.teiid.AUDIT_LOG:add
+/profile=full-ha/subsystem=logging/logger=org.teiid.AUDIT_LOG:write-attribute(name="level", value="WARN")
 
 
 /profile=ha/subsystem=infinispan/cache-container=teiid-cache:add(default-cache=resultset)
@@ -220,9 +226,5 @@
 /deployment=teiid-odata-${project.version}.war:add(runtime-name=teiid-odata-${project.version}.war,content=[{path=dataVirtualization/vdb/teiid-odata-${project.version}.war/,archive=false,relative-to=jboss.home.dir}])
 /server-group=main-server-group/deployment=teiid-odata-${project.version}.war:add(enabled=true)
 /server-group=other-server-group/deployment=teiid-odata-${project.version}.war:add(enabled=true)
-
-/deployment=teiid-olingo-${project.version}-odata4.war:add(runtime-name=teiid-olingo-${project.version}-odata4.war,content=[{path=dataVirtualization/vdb/teiid-olingo-${project.version}-odata4.war/,archive=false,relative-to=jboss.home.dir}])
-/server-group=main-server-group/deployment=teiid-olingo-${project.version}-odata4.war:add(enabled=true)
-/server-group=other-server-group/deployment=teiid-olingo-${project.version}-odata4.war:add(enabled=true)
 
 /host=master:reload(restart-servers=true)  

--- a/build/kits/jboss-as7/overlay/bin/scripts/teiid-standalone-auditcommand-logging.cli
+++ b/build/kits/jboss-as7/overlay/bin/scripts/teiid-standalone-auditcommand-logging.cli
@@ -5,18 +5,20 @@ connect
 batch
 
 # Add the periodic rotating file handlers corresponding to those added to the logging properties file
-/subsystem=logging/periodic-rotating-file-handler=TEIID_COMMAND_LOG/:add(suffix=.yyyy-MM-dd,formatter="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %X{teiid-session} %s%E%n",level=DEBUG,append=true,file={"path"=>"teiid-command.log", "relative-to"=>"jboss.server.log.dir"})
-/subsystem=logging/periodic-rotating-file-handler=TEIID_AUDIT_LOG/:add(suffix=.yyyy-MM-dd,formatter="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %X{teiid-session} %s%E%n",level=DEBUG,append=true,file={"path"=>"teiid-audit.log", "relative-to"=>"jboss.server.log.dir"})
+/subsystem=logging/periodic-rotating-file-handler=TEIID_COMMAND_LOG/:add(suffix=.yyyy-MM-dd,formatter="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %X{teiid-session} %s%E%n",level=WARN,append=true,file={"path"=>"teiid-command.log", "relative-to"=>"jboss.server.log.dir"})
+/subsystem=logging/periodic-rotating-file-handler=TEIID_AUDIT_LOG/:add(suffix=.yyyy-MM-dd,formatter="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %X{teiid-session} %s%E%n",level=WARN,append=true,file={"path"=>"teiid-audit.log", "relative-to"=>"jboss.server.log.dir"})
 
 # Configure the logging async handlers
-/subsystem=logging/async-handler=TEIID_COMMAND_LOG_ASYNC:add(level=DEBUG,queue-length=1024,overflow-action=BLOCK,subhandlers=["TEIID_COMMAND_LOG"], enabled=true)
-/subsystem=logging/async-handler=TEIID_AUDIT_LOG_ASYNC:add(level=DEBUG,queue-length=1024,overflow-action=BLOCK,subhandlers=["TEIID_AUDIT_LOG"], enabled=true)
+/subsystem=logging/async-handler=TEIID_COMMAND_LOG_ASYNC:add(level=WARN,queue-length=1024,overflow-action=BLOCK,subhandlers=["TEIID_COMMAND_LOG"], enabled=true)
+/subsystem=logging/async-handler=TEIID_AUDIT_LOG_ASYNC:add(level=WARN,queue-length=1024,overflow-action=BLOCK,subhandlers=["TEIID_AUDIT_LOG"], enabled=true)
 
 
 # Create the logger for teiid
 /subsystem=logging/logger=org.teiid.COMMAND_LOG:remove
-/subsystem=logging/logger=org.teiid.COMMAND_LOG:add(level=DEBUG, handlers=[TEIID_COMMAND_LOG_ASYNC], use-parent-handlers=false)
-/subsystem=logging/logger=org.teiid.AUDIT_LOG:add(level=DEBUG, handlers=[TEIID_AUDIT_LOG_ASYNC], use-parent-handlers=false)
+/subsystem=logging/logger=org.teiid.AUDIT_LOG:remove
+
+/subsystem=logging/logger=org.teiid.COMMAND_LOG:add(level=WARN, handlers=[TEIID_COMMAND_LOG_ASYNC], use-parent-handlers=false)
+/subsystem=logging/logger=org.teiid.AUDIT_LOG:add(level=WARN, handlers=[TEIID_AUDIT_LOG_ASYNC], use-parent-handlers=false)
 
 
 # Run the batch commands

--- a/build/kits/jboss-as7/overlay/bin/scripts/teiid-standalone-mode-install.cli
+++ b/build/kits/jboss-as7/overlay/bin/scripts/teiid-standalone-mode-install.cli
@@ -8,6 +8,9 @@
 /subsystem=logging/logger=org.teiid.COMMAND_LOG:add 
 /subsystem=logging/logger=org.teiid.COMMAND_LOG:write-attribute(name="level", value="WARN")
 
+/subsystem=logging/logger=org.teiid.AUDIT_LOG:add 
+/subsystem=logging/logger=org.teiid.AUDIT_LOG:write-attribute(name="level", value="WARN")
+
 /subsystem=infinispan/cache-container=teiid-cache:add(default-cache=resultset)
 /subsystem=infinispan/cache-container=teiid-cache/local-cache=resultset-repl:add(batching=true)
 /subsystem=infinispan/cache-container=teiid-cache/local-cache=resultset-repl/locking=LOCKING:add(isolation=READ_COMMITTED)
@@ -81,6 +84,7 @@
 /subsystem=teiid/translator=impala:add(module=org.jboss.teiid.translator.hive)
 /subsystem=teiid/translator=prestodb:add(module=org.jboss.teiid.translator.prestodb)
 /subsystem=teiid/translator=hbase:add(module=org.jboss.teiid.translator.hbase)
+/subsystem=teiid/translator=hana:add(module=org.jboss.teiid.translator.jdbc)
 /subsystem=teiid/translator=vertica:add(module=org.jboss.teiid.translator.jdbc)
 /subsystem=teiid/translator=actian-vector:add(module=org.jboss.teiid.translator.jdbc)
 /subsystem=teiid/translator=osisoft-pi:add(module=org.jboss.teiid.translator.jdbc)


### PR DESCRIPTION
added command to add AUDIT_LOG to standard install, so that all following installation scripts assume COMMAND_LOG and AUDIT_LOG are configured, changed to WARN level, like the default of COMMAND_LOG is set on initial install