### PR TITLE
TEIID-4146: Fix unit test

### DIFF
--- a/connectors/translator-infinispan-dsl/src/test/java/org/teiid/translator/infinispan/dsl/metadata/TestAnnotationMetadataProcessor.java
+++ b/connectors/translator-infinispan-dsl/src/test/java/org/teiid/translator/infinispan/dsl/metadata/TestAnnotationMetadataProcessor.java
@@ -42,7 +42,7 @@ public class TestAnnotationMetadataProcessor {
 
 		System.out.println("Schema: " + metadataDDL);
 		String expected = "CREATE FOREIGN TABLE Person (\n"
-	    + "\tPersonObject object OPTIONS (NAMEINSOURCE 'this', SELECTABLE FALSE, SEARCHABLE 'Unsearchable', NATIVE_TYPE 'org.jboss.as.quickstarts.datagrid.hotrod.query.domain.Person'),\n"
+	    + "\tPersonObject object OPTIONS (NAMEINSOURCE 'this', SELECTABLE FALSE, UPDATABLE FALSE, SEARCHABLE 'Unsearchable', NATIVE_TYPE 'org.jboss.as.quickstarts.datagrid.hotrod.query.domain.Person'),\n"
 	    + "\tid integer NOT NULL OPTIONS (NAMEINSOURCE 'id', SEARCHABLE 'Searchable', NATIVE_TYPE 'int'),\n"
 	    + "\temail string OPTIONS (NAMEINSOURCE 'email', SEARCHABLE 'Searchable', NATIVE_TYPE 'java.lang.String'),\n"
 	    + "\tname string NOT NULL OPTIONS (NAMEINSOURCE 'name', SEARCHABLE 'Searchable', NATIVE_TYPE 'java.lang.String'),\n"	    


### PR DESCRIPTION
This got broken due to changes introduced in 93c9435cbe4f293c3a909f5cac6a8c571ea3c41e, because AnnotationMetadataProcessor extends JavaBeanMetadataProcessor