### PR TITLE
TEIID-4166 setting defaults

### DIFF
--- a/connectors/translator-infinispan-cache/src/main/java/org/teiid/translator/infinispan/cache/InfinispanCacheExecutionFactory.java
+++ b/connectors/translator-infinispan-cache/src/main/java/org/teiid/translator/infinispan/cache/InfinispanCacheExecutionFactory.java
@@ -51,7 +51,11 @@ import org.teiid.translator.object.simpleMap.SimpleKeyVisitor;
 @Translator(name = "infinispan-cache", description = "The Infinispan Cache Translator")
 public class InfinispanCacheExecutionFactory extends ObjectExecutionFactory {
 
-	public static final int MAX_SET_SIZE = 10000;
+	// max available without having to try to override 
+	// BooleanQuery.setMaxClauseCount(), and
+	// infinispan doesn't currently support that option.
+	// https://issues.jboss.org/browse/ISPN-6728
+	public static final int MAX_SET_SIZE = 1024;
 
 	private boolean supportsLuceneSearching = false;
 	private boolean supportsDSLSearching = true;
@@ -59,17 +63,20 @@ public class InfinispanCacheExecutionFactory extends ObjectExecutionFactory {
 	private boolean supportsCompareCriteriaOrdered = false;
 	private boolean supportNotCriteria = false;
 	private boolean supportsIsNullCriteria = false;
+	
 
 	public InfinispanCacheExecutionFactory() {
 		super();
 		setSourceRequiredForMetadata(true);
 		setMaxInCriteriaSize(MAX_SET_SIZE);
-		setMaxDependentInPredicates(1);
+		setMaxDependentInPredicates(5);
 		
 		setSupportsSelectDistinct(false);
 		setSupportsInnerJoins(true);
 		setSupportsFullOuterJoins(false);
 		setSupportsOuterJoins(true);
+		
+		setSupportsDSLSearching(true);
 		
 		setSupportedJoinCriteria(SupportedJoinCriteria.EQUI);
 

--- a/connectors/translator-infinispan-dsl/src/main/java/org/teiid/translator/infinispan/dsl/InfinispanExecutionFactory.java
+++ b/connectors/translator-infinispan-dsl/src/main/java/org/teiid/translator/infinispan/dsl/InfinispanExecutionFactory.java
@@ -52,7 +52,11 @@ import org.teiid.translator.object.ObjectExecutionFactory;
 @Translator(name = "infinispan-cache-dsl", description = "The Infinispan Translator Using DSL to Query Cache")
 public class InfinispanExecutionFactory extends ObjectExecutionFactory {
 
-	public static final int MAX_SET_SIZE = 10000;
+	// max available without having to try to override 
+	// BooleanQuery.setMaxClauseCount(), and
+	// infinispan doesn't currently support that option.
+	// https://issues.jboss.org/browse/ISPN-6728
+	public static final int MAX_SET_SIZE = 1024;
 	
 	private boolean supportsCompareCriteriaOrdered = false;
 	
@@ -60,7 +64,7 @@ public class InfinispanExecutionFactory extends ObjectExecutionFactory {
 		super();
 		setSourceRequiredForMetadata(true);
 		setMaxInCriteriaSize(MAX_SET_SIZE);
-		setMaxDependentInPredicates(1);
+		setMaxDependentInPredicates(5);
 
 		setSupportsOrderBy(true);
 		setSupportsSelectDistinct(false);


### PR DESCRIPTION
TEIID-4166 setting defaults for MaxDependentInPredicates and MaxInCriteriaSize for accessing JDG caches