### PR TITLE
TEIID-4306: change to batch create xa ds

### DIFF
--- a/connectors/translator-jdbc/kits/wildfly/docs/teiid/datasources/db2/create-db2-xa-ds.cli
+++ b/connectors/translator-jdbc/kits/wildfly/docs/teiid/datasources/db2/create-db2-xa-ds.cli
@@ -1,10 +1,12 @@
 /subsystem=datasources/jdbc-driver=db2XA:add(driver-name=db2XA,driver-module-name=com.ibm.db2,driver-xa-datasource-class-name="${db.driver}")
 
 # XA Data source
+batch
 /subsystem=datasources/xa-data-source=db2XADS:add(jndi-name="${db.jndi_name}",  driver-name=db2XA, user-name="${db.user}", password="${db.password}", use-java-context=true)
 /subsystem=datasources/xa-data-source=db2XADS/xa-datasource-properties=DatabaseName:add(value="${db.database_name}")
 /subsystem=datasources/xa-data-source=db2XADS/xa-datasource-properties=PortNumber:add(value="${db.port}")
 /subsystem=datasources/xa-data-source=db2XADS/xa-datasource-properties=ServerName:add(value="${db.host}")
+run-batch
 /subsystem=datasources/xa-data-source=db2XADS:enable
 
 

--- a/connectors/translator-jdbc/kits/wildfly/docs/teiid/datasources/mysql/create-mysql-xa-ds.cli
+++ b/connectors/translator-jdbc/kits/wildfly/docs/teiid/datasources/mysql/create-mysql-xa-ds.cli
@@ -1,10 +1,12 @@
 /subsystem=datasources/jdbc-driver=mysqlXA:add(driver-name=mysqlXA,driver-module-name=com.mysql,driver-xa-datasource-class-name="${db.driver}")
 
 # XA Data source
+batch
 /subsystem=datasources/xa-data-source=mysqlXADS:add(jndi-name="${db.jndi_name}",  driver-name=mysqlXA, user-name="${db.user}", password="${db.password}", use-java-context=true)
 /subsystem=datasources/xa-data-source=mysqlXADS/xa-datasource-properties=DatabaseName:add(value="${db.database_name}")
 /subsystem=datasources/xa-data-source=mysqlXADS/xa-datasource-properties=PortNumber:add(value="${db.port}")
 /subsystem=datasources/xa-data-source=mysqlXADS/xa-datasource-properties=ServerName:add(value="${db.host}")
+run-batch
 /subsystem=datasources/xa-data-source=mysqlXADS:enable
 
 

--- a/connectors/translator-jdbc/kits/wildfly/docs/teiid/datasources/oracle/create-oracle-xa-ds.cli
+++ b/connectors/translator-jdbc/kits/wildfly/docs/teiid/datasources/oracle/create-oracle-xa-ds.cli
@@ -1,8 +1,10 @@
 /subsystem=datasources/jdbc-driver=oracleXA:add(driver-name=oracleXA,driver-module-name=com.oracle,driver-xa-datasource-class-name="${db.driver}")
 
 # XA Data source
+batch
 /subsystem=datasources/xa-data-source=oracleXADS:add(jndi-name="${db.jndi_name}",  driver-name=oracleXA, user-name="${db.user}", password="${db.password}", use-java-context=true)
 /subsystem=datasources/xa-data-source=oracleXADS/xa-datasource-properties=URL:add(value="${db.url}")
+run-batch
 /subsystem=datasources/xa-data-source=oracleXADS:enable
 
 

--- a/connectors/translator-jdbc/kits/wildfly/docs/teiid/datasources/postgresql/create-postgresql-xa-ds.cli
+++ b/connectors/translator-jdbc/kits/wildfly/docs/teiid/datasources/postgresql/create-postgresql-xa-ds.cli
@@ -1,10 +1,12 @@
 /subsystem=datasources/jdbc-driver=postgresXA:add(driver-name=postgresXA,driver-module-name=org.postgresql,driver-xa-datasource-class-name="${db.driver}")
 
 # XA Data source
+batch
 /subsystem=datasources/xa-data-source=postgresXADS:add(jndi-name="${db.jndi_name}",  driver-name=postgresXA, user-name="${db.user}", password="${db.password}", use-java-context=true)
 /subsystem=datasources/xa-data-source=postgresXADS/xa-datasource-properties=DatabaseName:add(value="${db.database_name}")
 /subsystem=datasources/xa-data-source=postgresXADS/xa-datasource-properties=PortNumber:add(value="${db.port}")
 /subsystem=datasources/xa-data-source=postgresXADS/xa-datasource-properties=ServerName:add(value="${db.host}")
+run-batch
 /subsystem=datasources/xa-data-source=postgresXADS:enable
 
 

--- a/connectors/translator-jdbc/kits/wildfly/docs/teiid/datasources/sqlserver/jtds/create-jtds-xa-ds.cli
+++ b/connectors/translator-jdbc/kits/wildfly/docs/teiid/datasources/sqlserver/jtds/create-jtds-xa-ds.cli
@@ -1,10 +1,12 @@
 /subsystem=datasources/jdbc-driver=sqlserverXA:add(driver-name=sqlserverXA, driver-module-name=net.sourceforge.jtds, driver-xa-datasource-class-name="${db.driver}")
 
 # XA Data source
+batch
 /subsystem=datasources/xa-data-source=sqlserverXADS:add(jndi-name="${db.jndi_name}",  driver-name=sqlserverXA, user-name="${db.user}", password="${db.password}", use-java-context=true)
 /subsystem=datasources/xa-data-source=sqlserverXADS/xa-datasource-properties=DatabaseName:add(value="${db.database_name}")
 /subsystem=datasources/xa-data-source=sqlserverXADS/xa-datasource-properties=PortNumber:add(value="${db.port}")
 /subsystem=datasources/xa-data-source=sqlserverXADS/xa-datasource-properties=ServerName:add(value="${db.host}")
+run-batch
 /subsystem=datasources/xa-data-source=sqlserverXADS:enable
 
 

--- a/connectors/translator-jdbc/kits/wildfly/docs/teiid/datasources/sqlserver/native/create-ms-native-xa-ds.cli
+++ b/connectors/translator-jdbc/kits/wildfly/docs/teiid/datasources/sqlserver/native/create-ms-native-xa-ds.cli
@@ -1,10 +1,12 @@
 /subsystem=datasources/jdbc-driver=sqlserverXA:add(driver-name=sqlserverXA,driver-module-name=com.microsoft.sqlserver,driver-xa-datasource-class-name="${db.driver}")
 
 # XA Data source
+batch
 /subsystem=datasources/xa-data-source=sqlserverXADS:add(jndi-name="${db.jndi_name}",  driver-name=sqlserverXA, user-name="${db.user}", password="${db.password}", use-java-context=true)
 /subsystem=datasources/xa-data-source=sqlserverXADS/xa-datasource-properties=DatabaseName:add(value="${db.database_name}")
 /subsystem=datasources/xa-data-source=sqlserverXADS/xa-datasource-properties=PortNumber:add(value="${db.port}")
 /subsystem=datasources/xa-data-source=sqlserverXADS/xa-datasource-properties=ServerName:add(value="${db.host}")
+run-batch
 /subsystem=datasources/xa-data-source=sqlserverXADS:enable
 
 

--- a/connectors/translator-jdbc/kits/wildfly/docs/teiid/datasources/teiid/create-teiid-xa-ds.cli
+++ b/connectors/translator-jdbc/kits/wildfly/docs/teiid/datasources/teiid/create-teiid-xa-ds.cli
@@ -2,10 +2,12 @@
 #/subsystem=datasources/jdbc-driver=teiidXA:add(driver-name=teiid,driver-module-name=org.jboss.teiid.client,driver-xa-datasource-class-name="${db.driver}")
 
 # XA Data source
+batch
 /subsystem=datasources/xa-data-source=teiidXADS:add(jndi-name="${db.jndi_name}",  driver-name=teiid, user-name="${db.user}", password="${db.password}", use-java-context=true)
 /subsystem=datasources/xa-data-source=teiidXADS/xa-datasource-properties=DatabaseName:add(value="${db.database_name}")
 /subsystem=datasources/xa-data-source=teiidXADS/xa-datasource-properties=PortNumber:add(value="${db.port}")
 /subsystem=datasources/xa-data-source=teiidXADS/xa-datasource-properties=ServerName:add(value="${db.host}")
+run-batch
 /subsystem=datasources/xa-data-source=teiidXADS:enable
 
 


### PR DESCRIPTION
Without batch, "WFLYJCA0069: At least one xa-datasource-property is required for an xa-datasource" will throw.