### PR TITLE
TEIID-4360: adding Bearer as default token type when OAuth Access tok…

### DIFF
--- a/jboss-security/src/main/java/org/teiid/jboss/oauth/OAuth20CredentialImpl.java
+++ b/jboss-security/src/main/java/org/teiid/jboss/oauth/OAuth20CredentialImpl.java
@@ -61,7 +61,7 @@ public class OAuth20CredentialImpl implements OAuthCredential {
         OAuthClientUtils.Consumer consumer = new OAuthClientUtils.Consumer(getClientId(), getClientSecret());
         WebClient client = WebClient.create(getAccessTokenURI());
         RefreshTokenGrant grant = new RefreshTokenGrant(getRefreshToken());
-        return OAuthClientUtils.getAccessToken(client, consumer, grant, null, false);
+        return OAuthClientUtils.getAccessToken(client, consumer, grant, null, "Bearer", false);
     }
 
     public String getClientId() {


### PR DESCRIPTION
…en request does not return a mandatory token_type in response