### PR TITLE
TEIID-4333 changed to use a Version comparable pattern

### DIFF
--- a/connectors/connector-infinispan-hotrod/pom.xml
+++ b/connectors/connector-infinispan-hotrod/pom.xml
@@ -17,19 +17,19 @@
           <dependency>
              <groupId>org.infinispan</groupId>
              <artifactId>infinispan-bom</artifactId>
-             <version>${version.org.infinispan.6}</version>
+             <version>${version.org.infinispan.ds}</version>
              <type>pom</type>
              <scope>import</scope>
           </dependency>
             <dependency>
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-remote-query-client</artifactId>
-                <version>${version.org.infinispan.6}</version>
+                <version>${version.org.infinispan.ds}</version>
             </dependency> 
             <dependency>
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-server-hotrod</artifactId>
-                <version>${version.org.infinispan.6}</version>
+                <version>${version.org.infinispan.ds}</version>
             </dependency> 
            <dependency>
              <groupId>org.apache.lucene</groupId>

--- a/connectors/connector-infinispan-hotrod/src/main/java/org/teiid/resource/adapter/infinispan/hotrod/AbstractInfinispanManagedConnectionFactory.java
+++ b/connectors/connector-infinispan-hotrod/src/main/java/org/teiid/resource/adapter/infinispan/hotrod/AbstractInfinispanManagedConnectionFactory.java
@@ -48,6 +48,7 @@ import org.teiid.translator.TranslatorException;
 import org.teiid.translator.infinispan.hotrod.InfinispanPlugin;
 import org.teiid.translator.object.CacheNameProxy;
 import org.teiid.translator.object.ClassRegistry;
+import org.teiid.translator.object.Version;
 
 
 public abstract class AbstractInfinispanManagedConnectionFactory extends
@@ -85,6 +86,7 @@ public abstract class AbstractInfinispanManagedConnectionFactory extends
 	private String module;
 	private ClassLoader cl;
 	private CacheNameProxy cacheNameProxy;
+	private Version version = null;
 
 
 
@@ -668,10 +670,10 @@ public abstract class AbstractInfinispanManagedConnectionFactory extends
 		
 	}
 	
-	public String getVersion() throws TranslatorException {
+	public Version getVersion() throws TranslatorException {
 		RemoteCache rc = this.getCache(this.getCacheNameProxy().getPrimaryCacheKey());
-		if (rc != null)  return rc.getProtocolVersion();
-		return "";
+		return Version.getVersion(rc.getProtocolVersion());
+
 	}
 
 	@Override

--- a/connectors/connector-infinispan-hotrod/src/main/java/org/teiid/resource/adapter/infinispan/hotrod/InfinispanConnectionImpl.java
+++ b/connectors/connector-infinispan-hotrod/src/main/java/org/teiid/resource/adapter/infinispan/hotrod/InfinispanConnectionImpl.java
@@ -42,6 +42,7 @@ import org.teiid.translator.infinispan.hotrod.InfinispanHotRodConnection;
 import org.teiid.translator.infinispan.hotrod.InfinispanPlugin;
 import org.teiid.translator.object.DDLHandler;
 import org.teiid.translator.object.SearchType;
+import org.teiid.translator.object.Version;
 
 
 /** 
@@ -62,7 +63,7 @@ public class InfinispanConnectionImpl extends BasicConnection implements Infinis
 	}
 	
 	@Override
-	public String getVersion() throws TranslatorException {
+	public Version getVersion() throws TranslatorException {
 		return this.config.getVersion();
 	}
 	

--- a/connectors/connector-infinispan-hotrod/src/test/java/org/teiid/resource/adapter/infinispan/hotrod/TestInfinispanConfigFileRemoteCache.java
+++ b/connectors/connector-infinispan-hotrod/src/test/java/org/teiid/resource/adapter/infinispan/hotrod/TestInfinispanConfigFileRemoteCache.java
@@ -34,10 +34,10 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.teiid.core.util.PropertiesUtils;
 import org.teiid.translator.object.ObjectConnection;
+import org.teiid.translator.object.Version;
 
 
 @SuppressWarnings("nls")
-@Ignore
 public class TestInfinispanConfigFileRemoteCache {
     
     private static InfinispanManagedConnectionFactory factory = null;
@@ -55,7 +55,7 @@ public class TestInfinispanConfigFileRemoteCache {
   		Properties props = PropertiesUtils.load(f.getAbsolutePath());
   		props.setProperty("infinispan.client.hotrod.server_list", RemoteInfinispanTestHelper.hostAddress() + ":" + RemoteInfinispanTestHelper.hostPort());
 		
-  		PropertiesUtils.print("./target/jdg.properties", props);
+  		PropertiesUtils.print("./target/hotrod-client.properties", props);
 
 		factory = new InfinispanManagedConnectionFactory();
 
@@ -87,8 +87,8 @@ public class TestInfinispanConfigFileRemoteCache {
     		
     		 assertNotNull(conn.getCache());
     		 
-    			
-    		 assertEquals("Version doesn't start with 7.2", conn.getVersion().startsWith("7.2"));
+    		 assertEquals("Support For Compare is false", conn.getVersion().compareTo(Version.getVersion("6.6")) >= 0, false );
+ //   		 assertEquals("Version doesn't start with 7.2", conn.getVersion().startsWith("7.2"));
 
     		 
     		 conn.cleanUp();

--- a/connectors/connector-infinispan-libmode/pom.xml
+++ b/connectors/connector-infinispan-libmode/pom.xml
@@ -17,7 +17,7 @@
            <dependency>
              <groupId>org.infinispan</groupId>
              <artifactId>infinispan-bom</artifactId>
-             <version>${version.org.infinispan.6}</version>
+             <version>${version.org.infinispan.ds}</version>
              <type>pom</type>
              <scope>import</scope>
           </dependency>   

--- a/connectors/connector-infinispan-libmode/src/main/java/org/teiid/resource/adapter/infinispan/InfinispanCacheRAConnection.java
+++ b/connectors/connector-infinispan-libmode/src/main/java/org/teiid/resource/adapter/infinispan/InfinispanCacheRAConnection.java
@@ -21,7 +21,6 @@
  */
 package org.teiid.resource.adapter.infinispan;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -30,10 +29,6 @@ import javax.naming.InitialContext;
 import javax.resource.ResourceException;
 
 import org.infinispan.Cache;
-import org.infinispan.client.hotrod.RemoteCache;
-import org.infinispan.configuration.cache.Configuration;
-import org.infinispan.manager.DefaultCacheManager;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.Search;
 import org.infinispan.query.dsl.QueryFactory;
 import org.teiid.logging.LogConstants;
@@ -44,6 +39,7 @@ import org.teiid.translator.infinispan.libmode.InfinispanCacheConnection;
 import org.teiid.translator.object.ClassRegistry;
 import org.teiid.translator.object.DDLHandler;
 import org.teiid.translator.object.SearchType;
+import org.teiid.translator.object.Version;
 
 /**
  * @author vanhalbert
@@ -65,7 +61,7 @@ public class InfinispanCacheRAConnection extends BasicConnection
 	}
 	
 	@Override
-	public String getVersion() throws TranslatorException {
+	public Version getVersion() throws TranslatorException {
 		return this.getConfig().getVersion();
 	}
 	/**

--- a/connectors/translator-infinispan-hotrod/pom.xml
+++ b/connectors/translator-infinispan-hotrod/pom.xml
@@ -22,7 +22,7 @@
            <dependency>
              <groupId>org.infinispan</groupId>
              <artifactId>infinispan-bom</artifactId>
-             <version>${version.org.infinispan.6}</version>
+             <version>${version.org.infinispan.ds}</version>
              <type>pom</type>
              <scope>import</scope>
           </dependency>             

--- a/connectors/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/InfinispanHotRodExecutionFactory.java
+++ b/connectors/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/InfinispanHotRodExecutionFactory.java
@@ -37,11 +37,12 @@ import org.teiid.translator.infinispan.hotrod.metadata.AnnotationMetadataProcess
 import org.teiid.translator.infinispan.hotrod.metadata.ProtobufMetadataProcessor;
 import org.teiid.translator.object.ObjectConnection;
 import org.teiid.translator.object.ObjectExecutionFactory;
+import org.teiid.translator.object.Version;
 
 
 
 /**
- * InfinispanExecutionFactory is the translator that will be use to translate  a remote Infinispan cache and issue queries
+ * InfinispanExecutionFactory is the translator that will be use to translate a remote Infinispan cache and issue queries
  * using hotrod client to query the cache.  
  * 
  * @author vhalbert
@@ -51,11 +52,7 @@ import org.teiid.translator.object.ObjectExecutionFactory;
  */
 @Translator(name = "ispn-hotrod", description = "The Infinispan Translator Using Hotrod Client to query cache")
 public class InfinispanHotRodExecutionFactory extends ObjectExecutionFactory {
-	
-	// with JDG 6.6 supportCompareCriteria no longer needs to be disabled
-	// @see @link https://issues.jboss.org/browse/TEIID-4333
-	private static final String JDG6_6 = "6.6"; 
-
+	public static final Version SIX_6 = Version.getVersion("6.6"); //$NON-NLS-1$
 
 	// max available without having to try to override 
 	// BooleanQuery.setMaxClauseCount(), and
@@ -93,8 +90,7 @@ public class InfinispanHotRodExecutionFactory extends ObjectExecutionFactory {
 	@Override
 	public ProcedureExecution createDirectExecution(List<Argument> arguments,
 			Command command, ExecutionContext executionContext,
-			RuntimeMetadata metadata, ObjectConnection connection)
-			throws TranslatorException {
+			RuntimeMetadata metadata, ObjectConnection connection) {
 		return super.createDirectExecution(arguments, command, executionContext,
 				metadata, connection);
 	}
@@ -174,20 +170,19 @@ public class InfinispanHotRodExecutionFactory extends ObjectExecutionFactory {
 	 * @see org.teiid.translator.ExecutionFactory#initCapabilities(java.lang.Object)
 	 */
 	@Override
-	public void initCapabilities(ObjectConnection connection) throws TranslatorException {
+	public void initCapabilities(ObjectConnection connection)
+			throws TranslatorException {
 		super.initCapabilities(connection);
-		if (connection == null) return;
-		
-		String version = connection.getVersion();
-		
-		if (version != null) {
-			if (version.compareTo(JDG6_6) < 0) {
-				// any version prior to JDG 6.6 the supportCompareCritiaOrdered needs to be set to false;
-			} else {
-				this.supportsCompareCriteriaOrdered = true;
-			}
+		if (connection == null) {
+			return;
 		}
-		
+
+		Version version = connection.getVersion();
+		// with JDG 6.6 supportCompareCriteria no longer needs to be disabled
+		// @see @link https://issues.jboss.org/browse/TEIID-4333
+		if (version != null && version.compareTo(SIX_6) >= 0) {
+			this.supportsCompareCriteriaOrdered = true;
+		}
 	}
 	
 	

--- a/connectors/translator-infinispan-hotrod/src/test/java/org/jboss/as/quickstarts/datagrid/hotrod/query/domain/PersonCacheConnection.java
+++ b/connectors/translator-infinispan-hotrod/src/test/java/org/jboss/as/quickstarts/datagrid/hotrod/query/domain/PersonCacheConnection.java
@@ -21,10 +21,6 @@
  */
 package org.jboss.as.quickstarts.datagrid.hotrod.query.domain;
 
-import java.lang.annotation.Annotation;
-
-import javax.resource.ResourceException;
-
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.protostream.annotations.ProtoField;
 import org.infinispan.protostream.descriptors.Descriptor;
@@ -34,6 +30,7 @@ import org.teiid.translator.infinispan.hotrod.InfinispanHotRodConnection;
 import org.teiid.translator.infinispan.hotrod.TestInfinispanHotRodConnection;
 import org.teiid.translator.object.CacheNameProxy;
 import org.teiid.translator.object.ClassRegistry;
+import org.teiid.translator.object.Version;
 
 /**
  * @author vanhalbert
@@ -44,10 +41,12 @@ public class PersonCacheConnection extends TestInfinispanHotRodConnection {
 	protected Descriptor descriptor;
 	
 
-	public static InfinispanHotRodConnection createConnection(RemoteCache map, boolean useKeyClassType, Descriptor descriptor) {
+	public static InfinispanHotRodConnection createConnection(RemoteCache map, boolean useKeyClassType, Descriptor descriptor, Version version) {
 		CacheNameProxy proxy = new CacheNameProxy(PersonCacheSource.PERSON_CACHE_NAME);
 
-		return new PersonCacheConnection(map, PersonCacheSource.CLASS_REGISTRY, proxy, useKeyClassType, descriptor);
+		PersonCacheConnection conn = new PersonCacheConnection(map, PersonCacheSource.CLASS_REGISTRY, proxy, useKeyClassType, descriptor);
+		conn.setVersion(version);
+		return conn;
 	}
 	
 	/**

--- a/connectors/translator-infinispan-hotrod/src/test/java/org/jboss/as/quickstarts/datagrid/hotrod/query/domain/PersonCacheSource.java
+++ b/connectors/translator-infinispan-hotrod/src/test/java/org/jboss/as/quickstarts/datagrid/hotrod/query/domain/PersonCacheSource.java
@@ -49,6 +49,7 @@ import org.infinispan.protostream.impl.parser.SquareProtoParser;
 import org.infinispan.query.dsl.Query;
 import org.teiid.translator.infinispan.hotrod.InfinispanHotRodConnection;
 import org.teiid.translator.object.ClassRegistry;
+import org.teiid.translator.object.Version;
 
 /**
  * Sample cache of objects
@@ -88,11 +89,14 @@ public class PersonCacheSource<K, V>  implements RemoteCache<K, V>{
 		}
 	}
 	
-	
 	public static InfinispanHotRodConnection createConnection(final boolean useKeyClass) {
+		return createConnection(useKeyClass, Version.getVersion("10.2.1"));
+	}
+	
+	public static InfinispanHotRodConnection createConnection(final boolean useKeyClass, Version version) {
 		final RemoteCache objects = PersonCacheSource.loadCache();
 
-		return PersonCacheConnection.createConnection(objects, useKeyClass, DESCRIPTOR);
+		return PersonCacheConnection.createConnection(objects, useKeyClass, DESCRIPTOR, version);
 
 	}
 	
@@ -111,6 +115,7 @@ public class PersonCacheSource<K, V>  implements RemoteCache<K, V>{
 			}
 			
 			Person p = new Person();
+
 			p.setId(i);
 			p.setName("Person " + i);
 			p.setPhones(pns);

--- a/connectors/translator-infinispan-hotrod/src/test/java/org/jboss/teiid/jdg_remote/pojo/AllTypesCacheSource.java
+++ b/connectors/translator-infinispan-hotrod/src/test/java/org/jboss/teiid/jdg_remote/pojo/AllTypesCacheSource.java
@@ -37,6 +37,9 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.infinispan.client.hotrod.CacheTopologyInfo;
 import org.infinispan.client.hotrod.Flag;
@@ -82,7 +85,7 @@ public class AllTypesCacheSource<K, V>  implements RemoteCache<K, V>{
 	
 	static {
 		try {
-			DESCRIPTOR = (Descriptor) createDescriptor();
+			DESCRIPTOR = createDescriptor();
 
 			CLASS_REGISTRY.registerClass(AllTypes.class);
 
@@ -90,7 +93,6 @@ public class AllTypesCacheSource<K, V>  implements RemoteCache<K, V>{
 			throw new RuntimeException(e);
 		}
 	}
-	
 	
 	public static InfinispanHotRodConnection createConnection() {
 		return createConnection(true);
@@ -103,55 +105,6 @@ public class AllTypesCacheSource<K, V>  implements RemoteCache<K, V>{
 		final RemoteCache objects = AllTypesCacheSource.loadCache();
 		
 		return AllTypeCacheConnection.createConnection(objects, useKeyClassType, DESCRIPTOR);
-//
-//		return new TestInfinispanDSLConnection()   {
-//
-//			@Override
-//			public String getPkField() {
-//				return "intKey";
-//			}
-//
-//			@Override
-//			public Class<?> getCacheKeyClassType() throws TranslatorException {
-//				if (useKeyClassType) {
-//					return Integer.class;
-//				} 
-//				return null;
-//			}
-//			
-//			@Override
-//			public String getCacheName() {
-//				return AllTypesCacheSource.ALLTYPES_CACHE_NAME;
-//			}
-//
-//
-//			@Override
-//			public Class<?> getCacheClassType() throws TranslatorException {
-//				return AllTypes.class;
-//			}
-//
-//
-//			@Override
-//			public Descriptor getDescriptor() throws TranslatorException {
-//				return DESCRIPTOR;
-//			}
-//
-//
-//			@Override
-//			public RemoteCache getCache(String cacheName)  {
-//				return objects;
-//			}
-//			
-//			@Override
-//			public QueryFactory getQueryFactory() throws TranslatorException {
-//				return null;
-//			}
-//
-//			@Override
-//	        public ClassRegistry getClassRegistry() {
-//		        return AllTypesCacheSource.CLASS_REGISTRY;
-//		    }
-//		};
 	}
 	
 	public static void loadCache(Map<Object, Object> cache) {
@@ -1068,7 +1021,5 @@ public class AllTypesCacheSource<K, V>  implements RemoteCache<K, V>{
 			Set<Integer> arg0, int arg1) {
 		return null;
 	}
-	
-	
 	
 }

--- a/connectors/translator-infinispan-hotrod/src/test/java/org/teiid/translator/infinispan/hotrod/TestInfinispanExecution.java
+++ b/connectors/translator-infinispan-hotrod/src/test/java/org/teiid/translator/infinispan/hotrod/TestInfinispanExecution.java
@@ -37,6 +37,7 @@ import org.teiid.language.Select;
 import org.teiid.translator.ExecutionContext;
 import org.teiid.translator.TranslatorException;
 import org.teiid.translator.object.ObjectExecution;
+import org.teiid.translator.object.Version;
 import org.teiid.translator.object.testdata.person.PersonSchemaVDBUtility;
 
 /**
@@ -62,7 +63,7 @@ public class TestInfinispanExecution {
     @BeforeClass
     public static void setUp()  {
         
-		CONNECTION = PersonCacheSource.createConnection(true);
+		CONNECTION = PersonCacheSource.createConnection(true, Version.getVersion("7.2.3"));
 
     }	
 

--- a/connectors/translator-infinispan-hotrod/src/test/java/org/teiid/translator/infinispan/hotrod/TestInfinispanExecutionFactory.java
+++ b/connectors/translator-infinispan-hotrod/src/test/java/org/teiid/translator/infinispan/hotrod/TestInfinispanExecutionFactory.java
@@ -32,6 +32,7 @@ import org.mockito.MockitoAnnotations;
 import org.teiid.language.Select;
 import org.teiid.translator.ExecutionContext;
 import org.teiid.translator.object.ObjectExecution;
+import org.teiid.translator.object.Version;
 import org.teiid.translator.object.testdata.person.PersonSchemaVDBUtility;
 
 @SuppressWarnings("nls")
@@ -54,9 +55,7 @@ public class TestInfinispanExecutionFactory {
     }
 
 	@Test public void testFactory() throws Exception {
-	   	CONNECTION = PersonCacheSource.createConnection(true);
-    	TestInfinispanHotRodConnection conn = (TestInfinispanHotRodConnection) CONNECTION;
-    	conn.setVersion("6.6");
+	   	CONNECTION = PersonCacheSource.createConnection(true, Version.getVersion("6.6"));
     	
         TRANSLATOR = new InfinispanExecutionFactory();
         TRANSLATOR.initCapabilities(CONNECTION);
@@ -71,9 +70,8 @@ public class TestInfinispanExecutionFactory {
 	}	
 	
 	@Test public void testFactoryVersion7() throws Exception {
-	   	CONNECTION = PersonCacheSource.createConnection(true);
-    	TestInfinispanHotRodConnection conn = (TestInfinispanHotRodConnection) CONNECTION;
-    	conn.setVersion("7.2.3");
+	   	CONNECTION = PersonCacheSource.createConnection(true, Version.getVersion("7.2.3"));
+
     	
         TRANSLATOR = new InfinispanExecutionFactory();
         TRANSLATOR.initCapabilities(CONNECTION);
@@ -89,9 +87,8 @@ public class TestInfinispanExecutionFactory {
 	}	
 	
 	@Test public void testFactoryVersion65() throws Exception {
-	   	CONNECTION = PersonCacheSource.createConnection(true);
-    	TestInfinispanHotRodConnection conn = (TestInfinispanHotRodConnection) CONNECTION;
-    	conn.setVersion("6.5");
+	   	CONNECTION = PersonCacheSource.createConnection(true, Version.getVersion("6.5.2"));
+
     	
         TRANSLATOR = new InfinispanExecutionFactory();
         TRANSLATOR.initCapabilities(CONNECTION);

--- a/connectors/translator-infinispan-hotrod/src/test/java/org/teiid/translator/infinispan/hotrod/TestInfinispanHotRodConnection.java
+++ b/connectors/translator-infinispan-hotrod/src/test/java/org/teiid/translator/infinispan/hotrod/TestInfinispanHotRodConnection.java
@@ -32,8 +32,8 @@ import org.teiid.translator.TranslatorException;
 import org.teiid.translator.object.CacheNameProxy;
 import org.teiid.translator.object.ClassRegistry;
 import org.teiid.translator.object.ObjectConnection;
+import org.teiid.translator.object.Version;
 import org.teiid.translator.object.simpleMap.SimpleMapCacheConnection;
-import org.teiid.translator.object.testdata.annotated.TestObjectConnection;
 import org.teiid.translator.object.testdata.annotated.Trade;
 import org.teiid.translator.object.testdata.annotated.TradesAnnotatedCacheSource;
 
@@ -42,12 +42,15 @@ import org.teiid.translator.object.testdata.annotated.TradesAnnotatedCacheSource
  *
  */
 public class TestInfinispanHotRodConnection extends SimpleMapCacheConnection implements InfinispanHotRodConnection {
-	protected String version;
+	protected Version version;
 	
-	public static ObjectConnection createConnection(Map<Object,Object> map) {
+	public static ObjectConnection createConnection(Map<Object,Object> map, Version version) {
 		CacheNameProxy proxy = new CacheNameProxy(TradesAnnotatedCacheSource.TRADES_CACHE_NAME);
 
-		return new TestObjectConnection(map, TradesAnnotatedCacheSource.METHOD_REGISTRY, proxy);
+		TestInfinispanHotRodConnection conn = new TestInfinispanHotRodConnection(map, TradesAnnotatedCacheSource.METHOD_REGISTRY, proxy);
+		conn.setVersion(version);
+				
+		return conn;
 	}
 
 	public TestInfinispanHotRodConnection(Map<Object,Object> map, ClassRegistry registry, CacheNameProxy proxy) {
@@ -56,7 +59,6 @@ public class TestInfinispanHotRodConnection extends SimpleMapCacheConnection imp
 		setPkField("tradeId");
 		setCacheKeyClassType(java.lang.Integer.class);
 		this.setCacheClassType(Trade.class);
-
 	}	
 
 
@@ -95,11 +97,11 @@ public class TestInfinispanHotRodConnection extends SimpleMapCacheConnection imp
 	 * @see org.teiid.translator.object.simpleMap.SimpleMapCacheConnection#getVersion()
 	 */
 	@Override
-	public String getVersion() {
+	public Version getVersion() {
 		return version;
 	}
 	
-	public void setVersion(String v) {
+	public void setVersion(Version v) {
 		this.version = v;
 	}
 }

--- a/connectors/translator-infinispan-hotrod/src/test/java/org/teiid/translator/infinispan/hotrod/metadata/TestAnnotationMetadataProcessor.java
+++ b/connectors/translator-infinispan-hotrod/src/test/java/org/teiid/translator/infinispan/hotrod/metadata/TestAnnotationMetadataProcessor.java
@@ -13,6 +13,7 @@ import org.teiid.query.metadata.SystemMetadata;
 import org.teiid.translator.infinispan.hotrod.InfinispanExecutionFactory;
 import org.teiid.translator.object.ObjectConnection;
 import org.teiid.translator.object.ObjectExecutionFactory;
+import org.teiid.translator.object.Version;
 import org.teiid.translator.object.metadata.JavaBeanMetadataProcessor;
 
 @SuppressWarnings("nls")
@@ -36,7 +37,7 @@ public class TestAnnotationMetadataProcessor {
 				SystemMetadata.getInstance().getRuntimeTypeMap(),
 				new Properties(), null);
 
-		ObjectConnection conn = PersonCacheSource.createConnection(false);
+		ObjectConnection conn = PersonCacheSource.createConnection(false, Version.getVersion("6.6"));
 		
 		JavaBeanMetadataProcessor mp = (JavaBeanMetadataProcessor) TRANSLATOR.getMetadataProcessor();
 		mp.process(mf, conn);
@@ -66,7 +67,7 @@ public class TestAnnotationMetadataProcessor {
 				SystemMetadata.getInstance().getRuntimeTypeMap(),
 				new Properties(), null);
 
-		ObjectConnection conn = PersonCacheSource.createConnection(false);
+		ObjectConnection conn = PersonCacheSource.createConnection(false, Version.getVersion("10.2"));
 		
 		JavaBeanMetadataProcessor mp = (JavaBeanMetadataProcessor) TRANSLATOR.getMetadataProcessor();
 		mp.setClassObjectColumn(true);

--- a/connectors/translator-infinispan-hotrod/src/test/java/org/teiid/translator/infinispan/hotrod/metadata/TestProtobufMetadataProcessor.java
+++ b/connectors/translator-infinispan-hotrod/src/test/java/org/teiid/translator/infinispan/hotrod/metadata/TestProtobufMetadataProcessor.java
@@ -16,6 +16,7 @@ import org.teiid.query.metadata.DDLStringVisitor;
 import org.teiid.query.metadata.SystemMetadata;
 import org.teiid.translator.TranslatorException;
 import org.teiid.translator.infinispan.hotrod.InfinispanHotRodConnection;
+import org.teiid.translator.object.Version;
 import org.teiid.translator.object.metadata.JavaBeanMetadataProcessor;
 import org.teiid.translator.infinispan.hotrod.InfinispanExecutionFactory;
 
@@ -42,7 +43,7 @@ public class TestProtobufMetadataProcessor {
 				SystemMetadata.getInstance().getRuntimeTypeMap(),
 				new Properties(), null);
 
-		InfinispanHotRodConnection conn = PersonCacheSource.createConnection(true);
+		InfinispanHotRodConnection conn = PersonCacheSource.createConnection(true, Version.getVersion("6.6"));
 
 		ProtobufMetadataProcessor mp = (ProtobufMetadataProcessor) TRANSLATOR.getMetadataProcessor();
 		mp.process(mf, conn);
@@ -63,7 +64,7 @@ public class TestProtobufMetadataProcessor {
 				SystemMetadata.getInstance().getRuntimeTypeMap(),
 				new Properties(), null);
 
-		InfinispanHotRodConnection conn = PersonCacheSource.createConnection(true);
+		InfinispanHotRodConnection conn = PersonCacheSource.createConnection(true, Version.getVersion("6.6"));
 
 		ProtobufMetadataProcessor mp = (ProtobufMetadataProcessor) TRANSLATOR.getMetadataProcessor();
 		mp.setClassObjectColumn(true);

--- a/connectors/translator-infinispan-libmode/pom.xml
+++ b/connectors/translator-infinispan-libmode/pom.xml
@@ -17,7 +17,7 @@
             <dependency>
              <groupId>org.infinispan</groupId>
              <artifactId>infinispan-bom</artifactId>
-             <version>${version.org.infinispan.6}</version>
+             <version>${version.org.infinispan.ds}</version>
              <type>pom</type>
              <scope>import</scope>
           </dependency>

--- a/connectors/translator-infinispan-libmode/src/main/java/org/teiid/translator/infinispan/libmode/InfinispanCacheExecutionFactory.java
+++ b/connectors/translator-infinispan-libmode/src/main/java/org/teiid/translator/infinispan/libmode/InfinispanCacheExecutionFactory.java
@@ -21,21 +21,7 @@
  */
 package org.teiid.translator.infinispan.libmode;
 
-import org.teiid.language.Command;
-import org.teiid.language.QueryExpression;
-import org.teiid.metadata.RuntimeMetadata;
-import org.teiid.translator.ExecutionContext;
-import org.teiid.translator.ResultSetExecution;
 import org.teiid.translator.Translator;
-import org.teiid.translator.TranslatorException;
-import org.teiid.translator.TranslatorProperty;
-import org.teiid.translator.UpdateExecution;
-import org.teiid.translator.object.ObjectConnection;
-import org.teiid.translator.object.ObjectExecution;
-import org.teiid.translator.object.ObjectExecutionFactory;
-import org.teiid.translator.object.ObjectUpdateExecution;
-import org.teiid.translator.object.ObjectVisitor;
-import org.teiid.translator.object.simpleMap.SimpleKeyVisitor;
 
 /**
  * InfinispanExecutionFactory is the "infinispan-cache" translator that is used to access an Infinispan cache.

--- a/connectors/translator-infinispan-libmode/src/test/java/org/teiid/translator/infinispan/libmode/TestInfinispanConfigFileKeySearch.java
+++ b/connectors/translator-infinispan-libmode/src/test/java/org/teiid/translator/infinispan/libmode/TestInfinispanConfigFileKeySearch.java
@@ -21,7 +21,8 @@
  */
 package org.teiid.translator.infinispan.libmode;
 
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -29,10 +30,10 @@ import org.junit.BeforeClass;
 import org.teiid.language.Select;
 import org.teiid.translator.ExecutionContext;
 import org.teiid.translator.TranslatorException;
-import org.teiid.translator.infinispan.libmode.InfinispanCacheExecutionFactory;
 import org.teiid.translator.object.BasicSearchTest;
 import org.teiid.translator.object.ObjectConnection;
 import org.teiid.translator.object.ObjectExecution;
+import org.teiid.translator.object.Version;
 import org.teiid.translator.object.testdata.trades.VDBUtility;
 
 @SuppressWarnings("nls")
@@ -48,8 +49,10 @@ public class TestInfinispanConfigFileKeySearch extends BasicSearchTest {
     public static void beforeClass() throws Exception {  
         // Set up the mock JNDI ...
    		context = mock(ExecutionContext.class);
+   		
+   		Version v = Version.getVersion("10.1");
 		
-		conn = TestInfinispanConnectionHelper.createNonAnnotatedConnection("./src/test/resources/infinispan_persistent_indexing_config.xml");
+		conn = TestInfinispanConnectionHelper.createNonAnnotatedConnection("./src/test/resources/infinispan_persistent_indexing_config.xml", v);
 
 	}
 	
@@ -62,10 +65,15 @@ public class TestInfinispanConfigFileKeySearch extends BasicSearchTest {
 	@Before public void beforeEachTest() throws Exception{	
 		factory = new InfinispanCacheExecutionFactory();
 		factory.start();
+		
+		factory.initCapabilities(conn);
     }
 	
 	@Override
 	protected ObjectExecution createExecution(Select command) throws TranslatorException {
+		
+		assertEquals("supportsCompareCriteriaOrdered was not configurred correctly ", factory.supportsCompareCriteriaOrdered(), true); //$NON-NLS-1$
+
 		return (ObjectExecution) factory.createExecution(command, context, VDBUtility.RUNTIME_METADATA, conn);
 	}
 	

--- a/connectors/translator-infinispan-libmode/src/test/java/org/teiid/translator/infinispan/libmode/TestInfinispanConnectionHelper.java
+++ b/connectors/translator-infinispan-libmode/src/test/java/org/teiid/translator/infinispan/libmode/TestInfinispanConnectionHelper.java
@@ -1,10 +1,7 @@
 package org.teiid.translator.infinispan.libmode;
 
-import java.lang.annotation.ElementType;
 import java.util.Properties;
 
-import org.hibernate.search.annotations.Analyze;
-import org.hibernate.search.cfg.SearchMapping;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -15,7 +12,7 @@ import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.transaction.TransactionMode;
 import org.teiid.core.TeiidException;
 import org.teiid.translator.object.ObjectConnection;
-import org.teiid.translator.object.testdata.annotated.Trade;
+import org.teiid.translator.object.Version;
 import org.teiid.translator.object.testdata.annotated.TradesAnnotatedCacheSource;
 import org.teiid.translator.object.testdata.trades.TradesCacheSource;
 
@@ -23,14 +20,14 @@ public class TestInfinispanConnectionHelper  {
 	
 	private static int cnt = 0;
 
-	public static ObjectConnection createNonAnnotatedConnection(String configFile)
+	public static ObjectConnection createNonAnnotatedConnection(String configFile, Version version)
 			throws Exception {
 
 		DefaultCacheManager container = new DefaultCacheManager(configFile);
 		
 		container.startCache(TradesCacheSource.TRADES_CACHE_NAME);
 		TradesCacheSource.loadCache(container.getCache(TradesCacheSource.TRADES_CACHE_NAME));
-		ObjectConnection conn = TradesCacheSource.createConnection(container.getCache(TradesCacheSource.TRADES_CACHE_NAME));
+		ObjectConnection conn = TradesCacheSource.createConnection(container.getCache(TradesCacheSource.TRADES_CACHE_NAME), false, version);
 
 		return conn;  	
 	}

--- a/connectors/translator-infinispan-libmode/src/test/java/org/teiid/translator/infinispan/libmode/TestInfinispanExecutionFactory.java
+++ b/connectors/translator-infinispan-libmode/src/test/java/org/teiid/translator/infinispan/libmode/TestInfinispanExecutionFactory.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
-import org.teiid.translator.infinispan.libmode.InfinispanCacheExecutionFactory;
 import org.teiid.translator.object.ObjectExecution;
 import org.teiid.translator.object.ObjectExecutionFactory;
 import org.teiid.translator.object.TestObjectExecutionFactory;
@@ -55,7 +54,7 @@ public class TestInfinispanExecutionFactory extends TestObjectExecutionFactory {
 	@Test public void testDefaultSearch() throws Exception {
 		InfinispanCacheExecutionFactory f = (InfinispanCacheExecutionFactory) this.factory;
 		factory.start();
-			
+
 		ObjectExecution exec = (ObjectExecution) factory.createExecution(command, context, VDBUtility.RUNTIME_METADATA, conn);
 		
 		assertNotNull(exec);

--- a/connectors/translator-object/src/main/java/org/teiid/translator/object/ObjectConnection.java
+++ b/connectors/translator-object/src/main/java/org/teiid/translator/object/ObjectConnection.java
@@ -35,11 +35,11 @@ import org.teiid.translator.TranslatorException;
 public interface ObjectConnection {
 
 	/**
-	 * Call to get the version of the data source that being used.
-	 * @return String verison
+	 * Call to get the version of the data source that is being accessed.
+	 * @return Version
 	 * @throws TranslatorException
 	 */
-	public String getVersion() throws TranslatorException;
+	public Version getVersion() throws TranslatorException;
 
 	/**
 	 * Call to check the status of the connection

--- a/connectors/translator-object/src/main/java/org/teiid/translator/object/ObjectExecution.java
+++ b/connectors/translator-object/src/main/java/org/teiid/translator/object/ObjectExecution.java
@@ -39,9 +39,7 @@ import org.teiid.core.util.StringUtil;
 import org.teiid.language.ColumnReference;
 import org.teiid.language.Command;
 import org.teiid.language.DerivedColumn;
-import org.teiid.language.NamedTable;
 import org.teiid.language.Select;
-import org.teiid.language.TableReference;
 import org.teiid.logging.LogConstants;
 import org.teiid.logging.LogManager;
 import org.teiid.logging.MessageLevel;
@@ -51,7 +49,6 @@ import org.teiid.translator.DataNotAvailableException;
 import org.teiid.translator.ExecutionContext;
 import org.teiid.translator.ResultSetExecution;
 import org.teiid.translator.TranslatorException;
-import org.teiid.translator.object.metadata.JavaBeanMetadataProcessor;
 import org.teiid.translator.object.util.ObjectUtil;
 
 /**

--- a/connectors/translator-object/src/main/java/org/teiid/translator/object/ObjectExecutionFactory.java
+++ b/connectors/translator-object/src/main/java/org/teiid/translator/object/ObjectExecutionFactory.java
@@ -92,7 +92,7 @@ public abstract class ObjectExecutionFactory extends
 	}
     
 	@Override
-	public ProcedureExecution createDirectExecution(List<Argument> arguments, Command command, ExecutionContext executionContext, RuntimeMetadata metadata, ObjectConnection connection) throws TranslatorException {
+	public ProcedureExecution createDirectExecution(List<Argument> arguments, Command command, ExecutionContext executionContext, RuntimeMetadata metadata, ObjectConnection connection)  {
 		return new ObjectDirectExecution(arguments, command, connection, executionContext, this);
 	}   
 	

--- a/connectors/translator-object/src/main/java/org/teiid/translator/object/Version.java
+++ b/connectors/translator-object/src/main/java/org/teiid/translator/object/Version.java
@@ -1,0 +1,117 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+
+package org.teiid.translator.object;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.teiid.core.util.StringUtil;
+
+/**
+ * Represents a comparable version
+ */
+public class Version implements Comparable<Version> {
+	
+	public static Version DEFAULT_VERSION = new Version(new Integer[] {0}); 
+	private static final Pattern NUMBER_PATTERN = Pattern.compile("(\\d+)"); //$NON-NLS-1$
+
+	private Integer[] parts;
+	
+	public static Version getVersion(String version) {
+		if (version == null) {
+			return null;
+		}
+		String[] parts = version.split("\\."); //$NON-NLS-1$
+		List<Integer> versionParts = new ArrayList<Integer>();
+		for (String part : parts) {
+			Integer val = null;
+			Matcher m = NUMBER_PATTERN.matcher(part);
+			if (!m.find()) {
+				continue;
+			}
+
+			String num = m.group(1);
+			try {
+				val = Integer.parseInt(num);
+			} catch (NumberFormatException e) {
+				
+			}
+			versionParts.add(val == null ? 0 : val);
+		}
+		if (versionParts.isEmpty()) {
+			return DEFAULT_VERSION;
+		}
+		return new Version(versionParts.toArray(new Integer[versionParts.size()]));
+	}
+	
+	Version(Integer[] parts) {
+		this.parts = parts;
+	}
+	
+	@Override
+	public String toString() {
+		return StringUtil.toString(this.parts, ".", false); //$NON-NLS-1$
+	}
+	
+	public int getMajorVersion() {
+		return parts[0];
+	}
+	
+	@Override
+	public int compareTo(Version o) {
+		int length = Math.min(this.parts.length, o.parts.length);
+		for (int i = 0; i < length; i++) {
+			int comp = this.parts[i].compareTo(o.parts[i]);
+			if (comp != 0) {
+				return comp;
+			}
+		}
+		if (this.parts.length > length) {
+			return 1;
+		}
+		if (o.parts.length > length) {
+			return -1;
+		}
+		return 0;
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == this) {
+			return true;
+		}
+		if (!(obj instanceof Version)) {
+			return false;
+		}
+		return this.compareTo((Version)obj) == 0;
+	}
+	
+	@Override
+	public int hashCode() {
+		return Arrays.hashCode(parts);
+	}
+
+}

--- a/connectors/translator-object/src/main/java/org/teiid/translator/object/simpleMap/SimpleMapCacheConnection.java
+++ b/connectors/translator-object/src/main/java/org/teiid/translator/object/simpleMap/SimpleMapCacheConnection.java
@@ -11,8 +11,10 @@ import org.teiid.translator.object.ClassRegistry;
 import org.teiid.translator.object.ObjectConnection;
 import org.teiid.translator.object.DDLHandler;
 import org.teiid.translator.object.SearchType;
+import org.teiid.translator.object.Version;
 
 public class SimpleMapCacheConnection implements ObjectConnection {
+	private Version version = Version.getVersion("0.0.0");
 	private Map<String, Map<Object,Object>> mapCaches = new HashMap<String, Map<Object, Object>>(3);
 	private ClassRegistry registry;
 	private String pkField;
@@ -39,10 +41,14 @@ public class SimpleMapCacheConnection implements ObjectConnection {
 		this.registry = registry;
 		this.proxy = proxy;
 	}
-	
+
 	@Override
-	public String getVersion()  {
-		return "";
+	public Version getVersion()  {
+		return version;
+	}
+	
+	public void setVersion(Version version) {
+		this.version = version;
 	}
 
 	@Override 

--- a/connectors/translator-object/src/test/java/org/teiid/translator/object/testdata/annotated/TestObjectConnection.java
+++ b/connectors/translator-object/src/test/java/org/teiid/translator/object/testdata/annotated/TestObjectConnection.java
@@ -5,15 +5,18 @@ import java.util.Map;
 import org.teiid.translator.object.CacheNameProxy;
 import org.teiid.translator.object.ClassRegistry;
 import org.teiid.translator.object.ObjectConnection;
+import org.teiid.translator.object.Version;
 import org.teiid.translator.object.simpleMap.SimpleMapCacheConnection;
 
 
 public class TestObjectConnection extends SimpleMapCacheConnection {
 
-	public static ObjectConnection createConnection(Map<Object,Object> map) {
+	public static ObjectConnection createConnection(Map<Object,Object> map, Version version) {
 		CacheNameProxy proxy = new CacheNameProxy(TradesAnnotatedCacheSource.TRADES_CACHE_NAME);
 
-		return new TestObjectConnection(map, TradesAnnotatedCacheSource.METHOD_REGISTRY, proxy);
+		TestObjectConnection conn = new TestObjectConnection(map, TradesAnnotatedCacheSource.METHOD_REGISTRY, proxy);
+		conn.setVersion(version);
+		return conn;
 	}
 
 	public TestObjectConnection(Map<Object,Object> map, ClassRegistry registry, CacheNameProxy proxy) {

--- a/connectors/translator-object/src/test/java/org/teiid/translator/object/testdata/annotated/TradesAnnotatedCacheSource.java
+++ b/connectors/translator-object/src/test/java/org/teiid/translator/object/testdata/annotated/TradesAnnotatedCacheSource.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import org.teiid.translator.TranslatorException;
 import org.teiid.translator.object.ClassRegistry;
 import org.teiid.translator.object.ObjectConnection;
+import org.teiid.translator.object.Version;
 
 
 
@@ -68,12 +69,15 @@ public class TradesAnnotatedCacheSource extends HashMap <Object, Object> {
 		}
 	}
 		
-	public static ObjectConnection createConnection() {
+	public static ObjectConnection createConnection(Version version) {
 		Map <Object, Object> objects = TradesAnnotatedCacheSource.loadCache();
 
-		ObjectConnection toc = TestObjectConnection.createConnection(objects);
+		ObjectConnection toc = TestObjectConnection.createConnection(objects, version);
+		return toc;
+	}
+	public static ObjectConnection createConnection() {
 		
-		return toc;		
+		return createConnection(null);		
 		
 	}
 	

--- a/connectors/translator-object/src/test/java/org/teiid/translator/object/testdata/trades/TradeObjectConnection.java
+++ b/connectors/translator-object/src/test/java/org/teiid/translator/object/testdata/trades/TradeObjectConnection.java
@@ -5,11 +5,12 @@ import java.util.Map;
 import org.teiid.translator.object.CacheNameProxy;
 import org.teiid.translator.object.ClassRegistry;
 import org.teiid.translator.object.ObjectConnection;
+import org.teiid.translator.object.Version;
 import org.teiid.translator.object.simpleMap.SimpleMapCacheConnection;
 
 public class TradeObjectConnection extends SimpleMapCacheConnection {
 
-	public static ObjectConnection createConnection(Map<Object,Object> map, boolean staging) {
+	public static ObjectConnection createConnection(Map<Object,Object> map, boolean staging, Version theVersion) {
 		CacheNameProxy proxy = null;
 		
 		if (staging) {
@@ -18,7 +19,9 @@ public class TradeObjectConnection extends SimpleMapCacheConnection {
 			proxy = new CacheNameProxy(TradesCacheSource.TRADES_CACHE_NAME);
 		}
 
-		return new TradeObjectConnection(map, TradesCacheSource.CLASS_REGISTRY, proxy);
+		TradeObjectConnection conn =  new TradeObjectConnection(map, TradesCacheSource.CLASS_REGISTRY, proxy);
+		conn.setVersion(theVersion);
+		return conn;
 	}
 
 	public TradeObjectConnection(Map<Object,Object> map, ClassRegistry registry, CacheNameProxy proxy) {

--- a/connectors/translator-object/src/test/java/org/teiid/translator/object/testdata/trades/TradesCacheSource.java
+++ b/connectors/translator-object/src/test/java/org/teiid/translator/object/testdata/trades/TradesCacheSource.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 import org.teiid.translator.object.ClassRegistry;
 import org.teiid.translator.object.ObjectConnection;
+import org.teiid.translator.object.Version;
 
 
 /**
@@ -85,7 +86,13 @@ public class TradesCacheSource extends HashMap <Object, Object> {
 	}
 	
 	public static ObjectConnection createConnection(Map <Object, Object> cache, boolean staging) {
-		ObjectConnection toc = TradeObjectConnection.createConnection(cache, staging);
+		ObjectConnection toc = TradeObjectConnection.createConnection(cache, staging, null);
+		
+		return toc;
+	}
+	
+	public static ObjectConnection createConnection(Map <Object, Object> cache, boolean staging, Version version) {
+		ObjectConnection toc = TradeObjectConnection.createConnection(cache, staging, version);
 		
 		return toc;
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -29,16 +29,16 @@
 	    <version.commons-codec>1.10</version.commons-codec>
         <version.com.google.guava>18.0</version.com.google.guava>
         <version.dom4j>1.6.1</version.dom4j>
-        <version.org.hibernate.search>5.6.0.Alpha2-redhat-1</version.org.hibernate.search> <!-- 5.5.1.Final -->
-        <version.org.hibernate>5.0.9.Final-redhat-1</version.org.hibernate> <!-- 5.0.7.Final -->
-        <version.org.infinispan.hibernate.search>4.6.3.Final-redhat-1</version.org.infinispan.hibernate.search> 
+        <version.org.hibernate.search>5.6.0.Alpha2</version.org.hibernate.search> <!-- 5.5.1.Final -->
+        <version.org.hibernate>5.0.9.Final</version.org.hibernate> <!-- 5.0.7.Final -->
+        <version.org.infinispan.hibernate.search>4.6.3.Final</version.org.infinispan.hibernate.search> 
         
         <!--  with wildfly parent version 2.5.4 the build is failing -->
         <version.bundle.plugin>2.5.0</version.bundle.plugin>
 
         <!-- JDG module slot to use  -->
         <jdg.slot>jdg-7.0</jdg.slot>  
-        <version.org.infinispan.6>8.2.4.Final</version.org.infinispan.6> 
+        <version.org.infinispan.ds>8.2.4.Final</version.org.infinispan.ds> 
         <version.org.apache.lucene.infinispan>5.5.0</version.org.apache.lucene.infinispan> <!--  8.2.4.Final -->
 
         <version.com.squareup.protoparser>3.1.5</version.com.squareup.protoparser>
@@ -1345,7 +1345,7 @@
             <!--dependency>
               <groupId>org.infinispan</groupId>
               <artifactId>infinispan-query</artifactId>
-              <version>${version.org.infinispan.6}</version-->
+              <version>${version.org.infinispan.ds}</version-->
               <!-- 
                 <exclusions>                
                     <exclusion>
@@ -1413,7 +1413,7 @@
             <!--dependency>
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-client-hotrod</artifactId>
-                <version>${version.org.infinispan.6}</version>
+                <version>${version.org.infinispan.ds}</version>
             </dependency-->
             <dependency>
               <groupId>org.mongodb</groupId>


### PR DESCRIPTION
TEIID-4333 changed to use a Version comparable pattern and updated pom.xml to use version.org.infinispan.ds environment variable for the infinidipan version dependencies.

Also updated the infinispan dependencies to change from using the -redhat-x versions.