### PR TITLE
TEIID-4409 the option to determine if configured to use annotations 

### DIFF
--- a/connectors/connector-infinispan-hotrod/src/main/java/org/teiid/resource/adapter/infinispan/hotrod/AbstractInfinispanManagedConnectionFactory.java
+++ b/connectors/connector-infinispan-hotrod/src/main/java/org/teiid/resource/adapter/infinispan/hotrod/AbstractInfinispanManagedConnectionFactory.java
@@ -86,9 +86,6 @@ public abstract class AbstractInfinispanManagedConnectionFactory extends
 	private String module;
 	private ClassLoader cl;
 	private CacheNameProxy cacheNameProxy;
-	private Version version = null;
-
-
 
 	@Override
 	public BasicConnectionFactory<InfinispanConnectionImpl> createConnectionFactory()
@@ -432,6 +429,10 @@ public abstract class AbstractInfinispanManagedConnectionFactory extends
 	public CacheNameProxy getCacheNameProxy() {
 		return cacheNameProxy;
 	}
+	
+    public boolean configuredUsingAnnotations() {
+    	return this.usingAnnotations;
+    }
 
 	public boolean isAlive() {
 		return this.cacheContainer != null;

--- a/connectors/connector-infinispan-hotrod/src/main/java/org/teiid/resource/adapter/infinispan/hotrod/InfinispanConnectionImpl.java
+++ b/connectors/connector-infinispan-hotrod/src/main/java/org/teiid/resource/adapter/infinispan/hotrod/InfinispanConnectionImpl.java
@@ -274,5 +274,16 @@ public class InfinispanConnectionImpl extends BasicConnection implements Infinis
 	public SearchType getSearchType() {
 		return new DSLSearch(this);
 	}
+	
+	/**
+	* Call to determine if the JDG cache is configured using annotation (or using protobuf and marsharllers).
+	* @return true if annotations are used
+	*/
+
+	@Override
+	 public boolean configuredUsingAnnotations() {
+	        return config.configuredUsingAnnotations();
+	}
+
 
 }

--- a/connectors/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/InfinispanHotRodConnection.java
+++ b/connectors/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/InfinispanHotRodConnection.java
@@ -49,5 +49,11 @@ public interface InfinispanHotRodConnection extends ObjectConnection {
 	 */
 	public Descriptor getDescriptor()  throws TranslatorException;
 	
+	/**
+	* Call to determine if the JDG cache is configured using annotation (or using protobuf and marsharllers).
+	* @return true if annotations are used
+	*/ 
+	public boolean configuredUsingAnnotations();
+	
 }
 

--- a/connectors/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/InfinispanHotRodExecutionFactory.java
+++ b/connectors/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/InfinispanHotRodExecutionFactory.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.teiid.language.Argument;
 import org.teiid.language.Command;
+import org.teiid.metadata.MetadataFactory;
 import org.teiid.metadata.RuntimeMetadata;
 import org.teiid.translator.ExecutionContext;
 import org.teiid.translator.MetadataProcessor;
@@ -81,6 +82,11 @@ public class InfinispanHotRodExecutionFactory extends ObjectExecutionFactory {
 	public int getMaxFromGroups() {
 		return 2;
 	}
+	
+	@Override
+	public boolean isSourceRequiredForCapabilities() {
+		return true;
+	}
 
 	/**
 	 * {@inheritDoc}
@@ -94,7 +100,6 @@ public class InfinispanHotRodExecutionFactory extends ObjectExecutionFactory {
 		return super.createDirectExecution(arguments, command, executionContext,
 				metadata, connection);
 	}
-    
 
 	@Override
     public boolean supportsAliasedTable() {
@@ -156,6 +161,20 @@ public class InfinispanHotRodExecutionFactory extends ObjectExecutionFactory {
 		return Boolean.FALSE.booleanValue();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see org.teiid.translator.ExecutionFactory#getMetadata(org.teiid.metadata.MetadataFactory,
+	 *      java.lang.Object)
+	 */
+//	@Override
+//	public void getMetadata(MetadataFactory metadataFactory, ObjectConnection conn) throws TranslatorException {
+//		InfinispanHotRodConnection dsl = (InfinispanHotRodConnection) conn;
+//		this.setSupportsSearchabilityUsingAnnotations(dsl.configuredUsingAnnotations());
+//
+//		super.getMetadata(metadataFactory, conn);
+//	}
+
 	@Override
     public MetadataProcessor<ObjectConnection> getMetadataProcessor(){
 		if (this.supportsSearchabilityUsingAnnotations()) {
@@ -176,6 +195,10 @@ public class InfinispanHotRodExecutionFactory extends ObjectExecutionFactory {
 		if (connection == null) {
 			return;
 		}
+		
+		InfinispanHotRodConnection dsl = (InfinispanHotRodConnection) connection;
+		this.setSupportsSearchabilityUsingAnnotations(dsl.configuredUsingAnnotations());
+
 
 		Version version = connection.getVersion();
 		// with JDG 6.6 supportCompareCriteria no longer needs to be disabled

--- a/connectors/translator-infinispan-hotrod/src/test/java/org/teiid/translator/infinispan/hotrod/TestInfinispanHotRodConnection.java
+++ b/connectors/translator-infinispan-hotrod/src/test/java/org/teiid/translator/infinispan/hotrod/TestInfinispanHotRodConnection.java
@@ -43,12 +43,14 @@ import org.teiid.translator.object.testdata.annotated.TradesAnnotatedCacheSource
  */
 public class TestInfinispanHotRodConnection extends SimpleMapCacheConnection implements InfinispanHotRodConnection {
 	protected Version version;
+	protected boolean useAnnotations;
 	
 	public static ObjectConnection createConnection(Map<Object,Object> map, Version version) {
 		CacheNameProxy proxy = new CacheNameProxy(TradesAnnotatedCacheSource.TRADES_CACHE_NAME);
 
 		TestInfinispanHotRodConnection conn = new TestInfinispanHotRodConnection(map, TradesAnnotatedCacheSource.METHOD_REGISTRY, proxy);
 		conn.setVersion(version);
+		conn.setConfiguredUsingAnnotations(true);
 				
 		return conn;
 	}
@@ -103,5 +105,19 @@ public class TestInfinispanHotRodConnection extends SimpleMapCacheConnection imp
 	
 	public void setVersion(Version v) {
 		this.version = v;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see org.teiid.translator.infinispan.hotrod.InfinispanHotRodConnection#configuredUsingAnnotations()
+	 */
+	@Override
+	public boolean configuredUsingAnnotations() {
+		return useAnnotations;
+	}
+	
+	public void setConfiguredUsingAnnotations(boolean useAnnotations) {
+		this.useAnnotations = useAnnotations;
 	}
 }

--- a/connectors/translator-infinispan-hotrod/src/test/resources/allTypesMetadata.ddl
+++ b/connectors/translator-infinispan-hotrod/src/test/resources/allTypesMetadata.ddl
@@ -1,7 +1,7 @@
 CREATE FOREIGN TABLE AllTypes (
 	intKey integer NOT NULL OPTIONS (NAMEINSOURCE 'intKey', SEARCHABLE 'Searchable', NATIVE_TYPE 'int'),
 	stringNum string OPTIONS (NAMEINSOURCE 'stringNum', SEARCHABLE 'Searchable', NATIVE_TYPE 'java.lang.String'),
-	stringKey string OPTIONS (NAMEINSOURCE 'stringKey', SEARCHABLE 'Unsearchable', NATIVE_TYPE 'java.lang.String'),
+	stringKey string NOT NULL OPTIONS (NAMEINSOURCE 'stringKey', SEARCHABLE 'Unsearchable', NATIVE_TYPE 'java.lang.String'),
 	floatNum float OPTIONS (NAMEINSOURCE 'floatNum', SEARCHABLE 'Unsearchable', NATIVE_TYPE 'float'),
 	bigIntegerValue biginteger OPTIONS (NAMEINSOURCE 'bigIntegerValue', SEARCHABLE 'Unsearchable', NATIVE_TYPE 'long'),
 	shortValue short OPTIONS (NAMEINSOURCE 'shortValue', SEARCHABLE 'Unsearchable', NATIVE_TYPE 'int'),

--- a/connectors/translator-infinispan-hotrod/src/test/resources/personMetadata.ddl
+++ b/connectors/translator-infinispan-hotrod/src/test/resources/personMetadata.ddl
@@ -1,14 +1,14 @@
 CREATE FOREIGN TABLE Person (
 	PersonObject object OPTIONS (NAMEINSOURCE 'this', SELECTABLE FALSE, UPDATABLE FALSE, SEARCHABLE 'Unsearchable', NATIVE_TYPE 'org.jboss.as.quickstarts.datagrid.hotrod.query.domain.Person'),
-	name string OPTIONS (NAMEINSOURCE 'name', SEARCHABLE 'Searchable', NATIVE_TYPE 'java.lang.String'),
+	name string NOT NULL OPTIONS (NAMEINSOURCE 'name', SEARCHABLE 'Searchable', NATIVE_TYPE 'java.lang.String'),
 	id integer NOT NULL OPTIONS (NAMEINSOURCE 'id', SEARCHABLE 'Searchable', NATIVE_TYPE 'int'),
 	email string OPTIONS (NAMEINSOURCE 'email', SEARCHABLE 'Unsearchable', NATIVE_TYPE 'java.lang.String'),
 	CONSTRAINT PK_ID PRIMARY KEY(id)
 ) OPTIONS (UPDATABLE TRUE);
 
 CREATE FOREIGN TABLE PhoneNumber (
-	number string OPTIONS (NAMEINSOURCE 'phone.number', SEARCHABLE 'Searchable', NATIVE_TYPE 'java.lang.String'),
+	number string NOT NULL OPTIONS (NAMEINSOURCE 'phone.number', SEARCHABLE 'Searchable', NATIVE_TYPE 'java.lang.String'),
 	type string OPTIONS (NAMEINSOURCE 'phone.type', SEARCHABLE 'Unsearchable', NATIVE_TYPE 'java.lang.Enum'),
-	id integer NOT NULL OPTIONS (NAMEINSOURCE 'id', SELECTABLE FALSE, UPDATABLE FALSE, SEARCHABLE 'Searchable', NATIVE_TYPE 'int'),
+	id integer NOT NULL OPTIONS (NAMEINSOURCE 'id', SEARCHABLE 'Searchable', NATIVE_TYPE 'int'),
 	CONSTRAINT FK_PERSON FOREIGN KEY(id) REFERENCES Person (id) OPTIONS (NAMEINSOURCE 'phones')
 ) OPTIONS (UPDATABLE TRUE);

--- a/connectors/translator-infinispan-hotrod/src/test/resources/personMetadataNoObject.ddl
+++ b/connectors/translator-infinispan-hotrod/src/test/resources/personMetadataNoObject.ddl
@@ -1,13 +1,13 @@
 CREATE FOREIGN TABLE Person (
-	name string OPTIONS (NAMEINSOURCE 'name', SEARCHABLE 'Searchable', NATIVE_TYPE 'java.lang.String'),
+	name string NOT NULL OPTIONS (NAMEINSOURCE 'name', SEARCHABLE 'Searchable', NATIVE_TYPE 'java.lang.String'),
 	id integer NOT NULL OPTIONS (NAMEINSOURCE 'id', SEARCHABLE 'Searchable', NATIVE_TYPE 'int'),
 	email string OPTIONS (NAMEINSOURCE 'email', SEARCHABLE 'Unsearchable', NATIVE_TYPE 'java.lang.String'),
 	CONSTRAINT PK_ID PRIMARY KEY(id)
 ) OPTIONS (UPDATABLE TRUE);
 
 CREATE FOREIGN TABLE PhoneNumber (
-	number string OPTIONS (NAMEINSOURCE 'phone.number', SEARCHABLE 'Searchable', NATIVE_TYPE 'java.lang.String'),
+	number string NOT NULL OPTIONS (NAMEINSOURCE 'phone.number', SEARCHABLE 'Searchable', NATIVE_TYPE 'java.lang.String'),
 	type string OPTIONS (NAMEINSOURCE 'phone.type', SEARCHABLE 'Unsearchable', NATIVE_TYPE 'java.lang.Enum'),
-	id integer NOT NULL OPTIONS (NAMEINSOURCE 'id', SELECTABLE FALSE, UPDATABLE FALSE, SEARCHABLE 'Searchable', NATIVE_TYPE 'int'),
+	id integer NOT NULL OPTIONS (NAMEINSOURCE 'id', SEARCHABLE 'Searchable', NATIVE_TYPE 'int'),
 	CONSTRAINT FK_PERSON FOREIGN KEY(id) REFERENCES Person (id) OPTIONS (NAMEINSOURCE 'phones')
 ) OPTIONS (UPDATABLE TRUE);

--- a/connectors/translator-object/src/main/java/org/teiid/translator/object/ObjectExecutionFactory.java
+++ b/connectors/translator-object/src/main/java/org/teiid/translator/object/ObjectExecutionFactory.java
@@ -36,7 +36,6 @@ import org.teiid.translator.MetadataProcessor;
 import org.teiid.translator.ProcedureExecution;
 import org.teiid.translator.ResultSetExecution;
 import org.teiid.translator.TranslatorException;
-import org.teiid.translator.TranslatorProperty;
 import org.teiid.translator.UpdateExecution;
 import org.teiid.translator.object.metadata.JavaBeanMetadataProcessor;
 
@@ -52,7 +51,7 @@ public abstract class ObjectExecutionFactory extends
 		ExecutionFactory<ConnectionFactory, ObjectConnection> {
 
 	public static final int MAX_SET_SIZE = 10000;
-	private boolean searchabilityBasedOnAnnotations = true;
+	private boolean searchabilityBasedOnAnnotations = false;
 	
 	public ObjectExecutionFactory() {
 		setSourceRequiredForMetadata(false);
@@ -96,7 +95,6 @@ public abstract class ObjectExecutionFactory extends
 		return new ObjectDirectExecution(arguments, command, connection, executionContext, this);
 	}   
 	
-	@TranslatorProperty(display="SearchabilityBasedOnAnnotations", description="If false, will turn off determining column searchability based on hibernate annotations", advanced=true)
 	public boolean supportsSearchabilityUsingAnnotations() {
 		return searchabilityBasedOnAnnotations;
 	}	

--- a/connectors/translator-object/src/test/java/org/teiid/translator/object/metadata/TestAnnotationMetadataProcessor.java
+++ b/connectors/translator-object/src/test/java/org/teiid/translator/object/metadata/TestAnnotationMetadataProcessor.java
@@ -23,11 +23,12 @@ public class TestAnnotationMetadataProcessor {
 	@Before public void beforeEach() throws Exception{	
 		 
 		TRANSLATOR = new SimpleMapCacheExecutionFactory();
+		TRANSLATOR.setSupportsSearchabilityUsingAnnotations(true);
+
     }
 	
 	@Test
 	public void testPersonMetadata() throws Exception {
-		
 		TRANSLATOR.start();
 
 


### PR DESCRIPTION
TEIID-4409 the option to determine if configured to use annotations can now be determined from the connection, so this can be automatic, without a translator override