### PR TITLE
TEIID-4510 fix the method getMaxFromGroups()to return 1

### DIFF
--- a/connectors/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/InfinispanHotRodExecutionFactory.java
+++ b/connectors/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/InfinispanHotRodExecutionFactory.java
@@ -79,7 +79,7 @@ public class InfinispanHotRodExecutionFactory extends ObjectExecutionFactory {
 
 	@Override
 	public int getMaxFromGroups() {
-		return 2;
+		return 1;
 	}
 	
 	@Override

--- a/connectors/translator-infinispan-libmode/src/main/java/org/teiid/translator/infinispan/libmode/InfinispanLibModeExecutionFactory.java
+++ b/connectors/translator-infinispan-libmode/src/main/java/org/teiid/translator/infinispan/libmode/InfinispanLibModeExecutionFactory.java
@@ -83,6 +83,11 @@ public class InfinispanLibModeExecutionFactory extends ObjectExecutionFactory {
 
 	} 
 	
+	@Override
+	public int getMaxFromGroups() {
+		return 1;
+	}
+	
 	public boolean isFullQuerySupported() {
 		return this.supportsDSLSearching ;
 	}


### PR DESCRIPTION
TEIID-4510 fix the method getMaxFromGroups()to return 1, so that each table is independently queried and the results are joined in the teiid engine