### PR TITLE
TEIID-4588 and TEIID-4590 

### DIFF
--- a/connectors/connector-infinispan-dsl/src/main/java/org/teiid/resource/adapter/infinispan/dsl/DSLSearch.java
+++ b/connectors/connector-infinispan-dsl/src/main/java/org/teiid/resource/adapter/infinispan/dsl/DSLSearch.java
@@ -101,6 +101,19 @@ public final class DSLSearch implements SearchType  {
 		}
 	}
 	
+	public List<Object> getAll() throws TranslatorException  {	
+		QueryBuilder qb = getQueryBuilder(conn);
+		
+		Query query = qb.build();
+		List<Object> results = query.list();
+		if (results == null) {
+               return Collections.emptyList();
+		}
+
+		return results;
+	}
+	
+	
 	private Object performSearch(String columnNameInSource,
 			Object value)  throws TranslatorException  {	
 		
@@ -172,23 +185,12 @@ public final class DSLSearch implements SearchType  {
 				return Collections.emptyList();
 			}
 			
-		} else if (orderby != null || visitor.getLimit() > 0) {
-		   query = qb.build();
-           results = query.list();
-           if (results == null) {
-                   return Collections.emptyList();
-           }
-
 		} else {
-			results = new ArrayList<Object>();
-			Collection<Object> all = conn.getAll();
-			results.addAll(all);
-			return results;			
-//		    results = new ArrayList<Object>();
-//			RemoteCache<?, Object> c = (RemoteCache<?, Object>) conn.getCache();
-//		    for (Object id : c.keySet()) {
-//		          results. add(c.get(id));
-//		    }
+			   query = qb.build();
+	           results = query.list();
+	           if (results == null) {
+	                   return Collections.emptyList();
+	           }			
 		}
 
 		return results;

--- a/connectors/connector-infinispan-dsl/src/main/java/org/teiid/resource/adapter/infinispan/dsl/InfinispanConnectionImpl.java
+++ b/connectors/connector-infinispan-dsl/src/main/java/org/teiid/resource/adapter/infinispan/dsl/InfinispanConnectionImpl.java
@@ -206,18 +206,9 @@ public class InfinispanConnectionImpl extends BasicConnection implements Infinis
 	 */
 	@Override
 	public Collection<Object> getAll() throws TranslatorException {
-		@SuppressWarnings("rawtypes")
-		RemoteCache cache = getCache(getTargetCache());
-
-		Map<Object, Object> c = cache.getBulk();
-		List<Object> results = new ArrayList<Object>();
-		for (Object k:c.keySet()) {
-			Object v = cache.get(k);
-			results.add(v);
-			
-		}
-
-		return results;
+		DSLSearch s = (DSLSearch) getSearchType();
+		
+		return s.getAll();
 	}
 
 	/**
@@ -292,6 +283,6 @@ public class InfinispanConnectionImpl extends BasicConnection implements Infinis
 
 	@Override
 	public boolean configuredForMaterialization() {
-		return (getDDLHandler().isStagingTarget());
+		return (config.getStagingCacheName() != null);
 	}
 }

--- a/connectors/connector-infinispan.6/src/main/java/org/teiid/resource/adapter/infinispan/DSLSearch.java
+++ b/connectors/connector-infinispan.6/src/main/java/org/teiid/resource/adapter/infinispan/DSLSearch.java
@@ -134,6 +134,17 @@ public final class DSLSearch implements SearchType   {
 		
 	}
 
+	public List<Object> getAll() throws TranslatorException  {	
+		QueryBuilder qb = getQueryBuilder(conn);
+		
+		Query query = qb.build();
+		List<Object> results = query.list();
+		if (results == null) {
+               return Collections.emptyList();
+		}
+
+		return results;
+	}
 	
 	private List<Object> performSearch(ObjectVisitor visitor) throws TranslatorException {
 		
@@ -171,17 +182,12 @@ public final class DSLSearch implements SearchType   {
 			if (results == null) {
 				return Collections.emptyList();
 			}
-		} else if (orderby != null || visitor.getLimit() > 0) {
+		} else  {
 			   query = qb.build();
 	           results = query.list();
 	           if (results == null) {
 	                   return Collections.emptyList();
 	           }			
-		} else {
-			results = new ArrayList<Object>();
-			Collection<Object> all = conn.getAll();
-			results.addAll(all);
-			return results;
 		}
 
 		return results;

--- a/connectors/translator-infinispan-dsl/src/main/java/org/teiid/translator/infinispan/dsl/metadata/ProtobufMetadataProcessor.java
+++ b/connectors/translator-infinispan-dsl/src/main/java/org/teiid/translator/infinispan/dsl/metadata/ProtobufMetadataProcessor.java
@@ -84,6 +84,8 @@ public class ProtobufMetadataProcessor implements MetadataProcessor<ObjectConnec
 	private Method pkMethod = null;
 	private Map<String, FieldDescriptor> descriptorMap = new HashMap<String, FieldDescriptor>();
 	protected boolean classObjectColumn = false;
+	private boolean materialized = false;
+	private Table stagingTable = null;
 	
 	@TranslatorProperty(display = "Class Object As Column", category = PropertyType.IMPORT, description = "If true, and when the translator provides the metadata, a column of object data type will be created that represents the stored object in the cache", advanced = true)
 	public boolean isClassObjectColumn() {
@@ -98,23 +100,13 @@ public class ProtobufMetadataProcessor implements MetadataProcessor<ObjectConnec
 	public void process(MetadataFactory metadataFactory, ObjectConnection connection) throws TranslatorException {
 		InfinispanDSLConnection conn = (InfinispanDSLConnection) connection;		
 
+		materialized = conn.configuredForMaterialization();
 		createRootTable(metadataFactory, conn.getCacheClassType(), conn.getDescriptor(), conn.getCacheName() ,conn);
 
-		boolean materializied = conn.getDDLHandler().isStagingTarget();
-		if (materializied) {
-										
-			Table stageTable = addTable(metadataFactory, conn.getCacheClassType(), true, true);
-						
-			stageTable.setColumns(rootTable.getColumns());
-			stageTable.setForiegnKeys(rootTable.getForeignKeys());
-			stageTable.setFunctionBasedIndexes(rootTable.getFunctionBasedIndexes());
-			stageTable.setIndexes(rootTable.getIndexes());
-			stageTable.setParent(rootTable.getParent());
-			stageTable.setSupportsUpdate(true);
-			stageTable.setUniqueKeys(rootTable.getUniqueKeys());
-			stageTable.setPrimaryKey(rootTable.getPrimaryKey());
-			stageTable.setProperty(JavaBeanMetadataProcessor.PRIMARY_TABLE_PROPERTY, rootTable.getFullName());	
-			
+		if (materialized) {
+				stagingTable.setParent(rootTable.getParent());
+				stagingTable.setSupportsUpdate(true);
+				stagingTable.setProperty(JavaBeanMetadataProcessor.PRIMARY_TABLE_PROPERTY, rootTable.getFullName());	
 		}
 
 	}
@@ -123,11 +115,14 @@ public class ProtobufMetadataProcessor implements MetadataProcessor<ObjectConnec
 	private void createRootTable(MetadataFactory mf, Class<?> entity, Descriptor descriptor, String cacheName, InfinispanDSLConnection conn) throws TranslatorException {
 			
 		String pkField = conn.getPkField();
-		boolean updatable = (pkField != null ? true : false);
+		boolean updatable = (materialized ? true : (pkField != null ? true : false));
 		
 		rootTable = addTable(mf, entity, updatable, false);
+		if (materialized) {
+			stagingTable = addTable(mf, entity, true, true);
+		}
 		
-		if (classObjectColumn) {
+		if (classObjectColumn && !materialized) {
 	    // add column for cache Object, set to non-selectable by default so that select * queries don't fail by default
 			addRootColumn(mf, Object.class, entity, null, null, SearchType.Unsearchable, rootTable.getName(), rootTable, false, false, NullType.Nullable); //$NON-NLS-1$	
 		}
@@ -171,6 +166,10 @@ public class ProtobufMetadataProcessor implements MetadataProcessor<ObjectConnec
 				}
 				// dont make primary key updatable, the object must be deleted and readded in order to change the key
 				addRootColumn(mf, returnType, getProtobufNativeType(fd), fd.getFullName(), fd.getName(), st, rootTable.getName(), rootTable, true, true, nt);	
+				if (materialized) {
+					addRootColumn(mf, returnType, getProtobufNativeType(fd), fd.getFullName(), fd.getName(), st, stagingTable.getName(), stagingTable, true, true, nt);	
+					
+				}
 		}
 			
 		if (pkMethod != null) {
@@ -178,7 +177,10 @@ public class ProtobufMetadataProcessor implements MetadataProcessor<ObjectConnec
 			String pkName = "PK_" + pkField.toUpperCase(); //$NON-NLS-1$
 	        ArrayList<String> x = new ArrayList<String>(1) ;
 	        x.add(pkField);
-	        mf.addPrimaryKey(pkName, x , rootTable);		    
+	        mf.addPrimaryKey(pkName, x , rootTable);	
+			if (materialized) {
+		        mf.addPrimaryKey(pkName, x , stagingTable);
+			}
 
 		}
 	
@@ -210,6 +212,18 @@ public class ProtobufMetadataProcessor implements MetadataProcessor<ObjectConnec
 
 		return t;
 		
+	}
+	
+	private  boolean doesStagingTableExist(MetadataFactory mf, Class<?> entity) {
+		String tName = entity.getSimpleName();
+		tName = "ST_" + tName; //$NON-NLS-1$
+		Table t = mf.getSchema().getTable(tName);
+		if (t != null) {
+			//already loaded
+			return true;
+		}
+		return false;
+
 	}
 	
     private static Method findMethod(String className, String methodName, InfinispanDSLConnection conn) throws TranslatorException {
@@ -388,7 +402,7 @@ public class ProtobufMetadataProcessor implements MetadataProcessor<ObjectConnec
 	
 	private Column addColumn(MetadataFactory mf, Class<?> type, Class<?> nativeType,  String attributeName, String nis, SearchType searchType, Table rootTable, boolean selectable, boolean updateable, NullType nt) {
 		if (rootTable.getColumnByName(attributeName) != null) return rootTable.getColumnByName(attributeName);
-		
+	
 		boolean isEnum = false;
 		Class<?> datatype = type;
 		if (type.isEnum()) {
@@ -400,7 +414,7 @@ public class ProtobufMetadataProcessor implements MetadataProcessor<ObjectConnec
 		}
 		
 		Column c = mf.addColumn(attributeName, TypeFacility.getDataTypeName(datatype), rootTable);
-		
+
 		if (nis != null) {
 			c.setNameInSource(nis);
 		}

--- a/connectors/translator-object/src/test/resources/tradeMatMetadataFromVDB.ddl
+++ b/connectors/translator-object/src/test/resources/tradeMatMetadataFromVDB.ddl
@@ -1,7 +1,6 @@
 SET NAMESPACE 'http://www.teiid.org/translator/object/2016' AS n0;
 
 CREATE FOREIGN TABLE ST_Trade (
-	TradeObject object OPTIONS (NAMEINSOURCE 'this', SELECTABLE FALSE, UPDATABLE FALSE, SEARCHABLE 'Unsearchable', NATIVE_TYPE 'org.teiid.translator.object.testdata.trades.Trade'),
 	tradeId long NOT NULL OPTIONS (NAMEINSOURCE 'tradeId', SEARCHABLE 'Searchable', NATIVE_TYPE 'long'),
 	name string OPTIONS (NAMEINSOURCE 'name', SEARCHABLE 'Unsearchable', NATIVE_TYPE 'java.lang.String'),
 	settled boolean OPTIONS (NAMEINSOURCE 'settled', SEARCHABLE 'Unsearchable', NATIVE_TYPE 'boolean'),
@@ -10,7 +9,6 @@ CREATE FOREIGN TABLE ST_Trade (
 ) OPTIONS (UPDATABLE TRUE, "n0:primary_table" 'ObjectSchema.Trade');
 
 CREATE FOREIGN TABLE Trade (
-	TradeObject object OPTIONS (NAMEINSOURCE 'this', SELECTABLE FALSE, UPDATABLE FALSE, SEARCHABLE 'Unsearchable', NATIVE_TYPE 'org.teiid.translator.object.testdata.trades.Trade'),
 	tradeId long NOT NULL OPTIONS (NAMEINSOURCE 'tradeId', SEARCHABLE 'Searchable', NATIVE_TYPE 'long'),
 	name string OPTIONS (NAMEINSOURCE 'name', SEARCHABLE 'Unsearchable', NATIVE_TYPE 'java.lang.String'),
 	settled boolean OPTIONS (NAMEINSOURCE 'settled', SEARCHABLE 'Unsearchable', NATIVE_TYPE 'boolean'),


### PR DESCRIPTION
TEIID-4588 changes the metadata processor to create unique tables and columns for the staging table, TEIID-4590 changed select ALL logic to so that a single cache can contain multiple root pojo's that can separate resource-adapters for access the data