### PR TITLE
TEIID-4603

### DIFF
--- a/connectors/infinispan/translator-object/src/main/java/org/teiid/translator/object/ObjectUpdateExecution.java
+++ b/connectors/infinispan/translator-object/src/main/java/org/teiid/translator/object/ObjectUpdateExecution.java
@@ -214,8 +214,8 @@ public class ObjectUpdateExecution extends ObjectBaseExecution implements Update
 		
 		//TODO: for 1.8 use putIfAbsent
 		
-		Object rootObject = connection.getSearchType().performKeySearch(ObjectUtil.getRecordName(keyCol), keyValue, executionContext) ;
-				//env.performKeySearch(ObjectUtil.getRecordName(keyCol), keyValue, connection, executionContext);
+		//TEIID-4603 dont use DSLSearch, but use the direct key to the cache to lookup the object
+		Object rootObject = connection.get(keyValue);
 
 		if (rootObject != null) {
 			throw new TranslatorException(ObjectPlugin.Util.gs(ObjectPlugin.Event.TEIID21007, new Object[] {insert.getTable().getName(), keyValue}));
@@ -275,8 +275,9 @@ public class ObjectUpdateExecution extends ObjectBaseExecution implements Update
 		
 		fkeyValue = convertKeyValue(fkeyValue, visitor.getPrimaryKeyCol());
 
-		// don't perform a search when doing inserts for materialization
-						
+		// dont get the object based on key to the cache, do the DSL search so that its ensured the object
+		// exist for this root object type.  Using the get(key) could return an invalid object type if 
+		// keys overlap, so the exception thrown here will alert to a possible issue
 		Object rootObject = connection.getSearchType().performKeySearch(fkeyRefColumnName, fkeyValue, executionContext) ; 
 
 		if (rootObject == null) {

--- a/connectors/infinispan/translator-object/src/test/java/org/teiid/translator/object/TestObjectUpdateExecution.java
+++ b/connectors/infinispan/translator-object/src/test/java/org/teiid/translator/object/TestObjectUpdateExecution.java
@@ -41,21 +41,7 @@ public class TestObjectUpdateExecution {
 		
 		// pre-test of the object connection 
 		CONNECTION = TradesCacheSource.createConnection();
-		
-//		Object p = CONNECTION.get(new Long(1).longValue());
-//
-//		assertNotNull(p);
-//		
-//		Object o = CONNECTION.remove(new Long(1).longValue());
-//		assertNotNull(o);
-//		assertTrue(p == o);
-//		
-//		Object p2 = CONNECTION.get(new Long(1).longValue());
-//
-//		assertNull(p2);
-		
-		 
-		
+
     }
 	
 
@@ -81,6 +67,20 @@ public class TestObjectUpdateExecution {
 		assertTrue(p.getTradeId() == 99);
 		assertTrue(p.isSettled());
 	
+	}
+	
+	@Test( expected = TranslatorException.class )
+	public void testInsertOfDuplicateRootObject() throws Exception {
+		Object o = CONNECTION.get(new Long(2).longValue());
+		assertNotNull(o);
+		Command command = translationUtility
+				.parseCommand("Insert into Trade_Mat.Trade_Mat.Trade (tradeId, TradeName, settled) VALUES (2, 'Duplicate 2', 'true')");
+		// no search required by the UpdateExecution logic
+		@SuppressWarnings("unchecked")
+		ObjectUpdateExecution ie = createExecution(command, Collections.EMPTY_LIST);
+
+		ie.execute();
+
 	}
 	
 	@Test
@@ -110,16 +110,6 @@ public class TestObjectUpdateExecution {
 	@Test
 	public void testInsertChildClass() throws Exception {
 		CONNECTION = TradesCacheSource.createConnection();
-		insertChildClass();
-	}
-//
-//	@Test
-//	public void testInsertChildClassNoClassTypeDefined() throws Exception {
-//		CONNECTION = TradesCacheSource.createConnection();
-//		insertChildClass();
-//	}
-		
-	private void insertChildClass() throws Exception {
 		assertNotNull(CONNECTION.get((new Long(2).longValue())));
 
 		Command command = translationUtility


### PR DESCRIPTION
TEIID-4603 Changing the logic so that when an insert of the root object is to be done, the get(key) method is called, instead of using the DSL searching. This will ensure an object is returned and an exception is thrown due to a duplicate object with this key already exist.