### PR TITLE
OData: Add support for servers not handling comparisons for boolean functions.

### DIFF
--- a/connectors/translator-odata/src/main/java/org/teiid/translator/odata/ODataExecutionFactory.java
+++ b/connectors/translator-odata/src/main/java/org/teiid/translator/odata/ODataExecutionFactory.java
@@ -75,6 +75,7 @@ public class ODataExecutionFactory extends ExecutionFactory<ConnectionFactory, W
 	private boolean supportsOdataCount;
 	private boolean supportsOdataSkip;
 	private boolean supportsOdataTop;
+	private boolean supportsOdataBooleanFunctionsWithComparison;
 
 	public ODataExecutionFactory() {
 		setSourceRequiredForMetadata(true);
@@ -85,6 +86,8 @@ public class ODataExecutionFactory extends ExecutionFactory<ConnectionFactory, W
 		setSupportsOdataOrderBy(true);
 		setSupportsOdataSkip(true);
 		setSupportsOdataTop(true);
+		setSupportsOdataBooleanFunctionsWithComparison(true);
+		
 		setTransactionSupport(TransactionSupport.NONE);
 		registerFunctionModifier(SourceSystemFunctions.CONVERT, new AliasModifier("cast")); //$NON-NLS-1$
 		registerFunctionModifier(SourceSystemFunctions.LOCATE, new AliasModifier("indexof")); //$NON-NLS-1$
@@ -240,6 +243,16 @@ public class ODataExecutionFactory extends ExecutionFactory<ConnectionFactory, W
 	
 	public void setSupportsOdataTop(boolean supports) {
 		this.supportsOdataTop = supports;
+	}
+	
+	@TranslatorProperty(display="Supports boolean functions with comparison", 
+			description="True, you can use 'substringsof(a, b) eq true' for instance", advanced=true)
+    public boolean supportsOdataBooleanFunctionsWithComparison() {
+    	return supportsOdataBooleanFunctionsWithComparison;
+    }
+	
+	public void setSupportsOdataBooleanFunctionsWithComparison(boolean supports) {
+		this.supportsOdataBooleanFunctionsWithComparison = supports;
 	}	
 	
 	@Override

--- a/connectors/translator-odata/src/main/java/org/teiid/translator/odata/ODataPlugin.java
+++ b/connectors/translator-odata/src/main/java/org/teiid/translator/odata/ODataPlugin.java
@@ -51,6 +51,7 @@ public class ODataPlugin {
 		TEIID17014,
 		TEIID17015,
 		TEIID17016,
-		TEIID17017
+		TEIID17017,
+		TEIID17018
 	}
 }

--- a/connectors/translator-odata/src/main/resources/org/teiid/translator/odata/i18n.properties
+++ b/connectors/translator-odata/src/main/resources/org/teiid/translator/odata/i18n.properties
@@ -37,3 +37,4 @@ TEIID17014=OData translator does not support "native" queries; use the "WS" tran
 TEIID17015=Foreign Key "{0}" on {1} table, which refers to {2} not created due to key mis-match.  
 TEIID17016=Could not derive the complex name {0}
 TEIID17017=Table ''{0}'' not included in metadata, due to lack of primary keys or unique keys
+TEIID17018=Can only use equality test for boolean function ''{0}''


### PR DESCRIPTION
In OData, some old servers choke on "startswith('a', 'b') eq true"
whereas "startswith('a', 'b')" is fine (same for all the functions returning a boolean). This patch adds a configuration option to handle those cases, if the option is unset the previous behavior is unchanged.

The diff view in GitHub seems broken, what did I do wrong?