### PR TITLE
#TEIID-4613 Add support for servers not handling comparisons for boolean functions

### DIFF
--- a/connectors/odata/translator-odata/src/main/java/org/teiid/translator/odata/ODataExecutionFactory.java
+++ b/connectors/odata/translator-odata/src/main/java/org/teiid/translator/odata/ODataExecutionFactory.java
@@ -75,6 +75,7 @@ public class ODataExecutionFactory extends ExecutionFactory<ConnectionFactory, W
 	private boolean supportsOdataCount;
 	private boolean supportsOdataSkip;
 	private boolean supportsOdataTop;
+	private boolean supportsOdataBooleanFunctionsWithComparison;
 
 	public ODataExecutionFactory() {
 		setSourceRequiredForMetadata(true);
@@ -85,6 +86,8 @@ public class ODataExecutionFactory extends ExecutionFactory<ConnectionFactory, W
 		setSupportsOdataOrderBy(true);
 		setSupportsOdataSkip(true);
 		setSupportsOdataTop(true);
+		setSupportsOdataBooleanFunctionsWithComparison(true);
+		
 		setTransactionSupport(TransactionSupport.NONE);
 		registerFunctionModifier(SourceSystemFunctions.CONVERT, new AliasModifier("cast")); //$NON-NLS-1$
 		registerFunctionModifier(SourceSystemFunctions.LOCATE, new AliasModifier("indexof")); //$NON-NLS-1$
@@ -240,6 +243,16 @@ public class ODataExecutionFactory extends ExecutionFactory<ConnectionFactory, W
 	
 	public void setSupportsOdataTop(boolean supports) {
 		this.supportsOdataTop = supports;
+	}
+	
+	@TranslatorProperty(display="Supports boolean functions with comparison", 
+			description="True, you can use 'substringsof(a, b) eq true' for instance", advanced=true)
+    public boolean supportsOdataBooleanFunctionsWithComparison() {
+    	return supportsOdataBooleanFunctionsWithComparison;
+    }
+	
+	public void setSupportsOdataBooleanFunctionsWithComparison(boolean supports) {
+		this.supportsOdataBooleanFunctionsWithComparison = supports;
 	}	
 	
 	@Override

--- a/connectors/odata/translator-odata/src/main/java/org/teiid/translator/odata/ODataPlugin.java
+++ b/connectors/odata/translator-odata/src/main/java/org/teiid/translator/odata/ODataPlugin.java
@@ -51,6 +51,7 @@ public class ODataPlugin {
 		TEIID17014,
 		TEIID17015,
 		TEIID17016,
-		TEIID17017
+		TEIID17017,
+		TEIID17018
 	}
 }

--- a/connectors/odata/translator-odata/src/main/resources/org/teiid/translator/odata/i18n.properties
+++ b/connectors/odata/translator-odata/src/main/resources/org/teiid/translator/odata/i18n.properties
@@ -37,3 +37,4 @@ TEIID17014=OData translator does not support "native" queries; use the "WS" tran
 TEIID17015=Foreign Key "{0}" on {1} table, which refers to {2} not created due to key mis-match.  
 TEIID17016=Could not derive the complex name {0}
 TEIID17017=Table ''{0}'' not included in metadata, due to lack of primary keys or unique keys
+TEIID17018=Can only use equality test for boolean function ''{0}''

--- a/connectors/odata/translator-odata/src/test/java/org/teiid/translator/odata/TestODataSQLVistor.java
+++ b/connectors/odata/translator-odata/src/test/java/org/teiid/translator/odata/TestODataSQLVistor.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.*;
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.net.URLDecoder;
+import java.util.ArrayList;
 import java.util.Properties;
 
 import org.junit.Before;
@@ -79,12 +80,13 @@ public class TestODataSQLVistor {
     	utility = new TranslationUtility(metadata);
     }
     
-    private void helpExecute(String query, String expected) throws Exception {
+    private ArrayList<TranslatorException> helpExecute(String query, String expected) throws Exception {
     	Select cmd = (Select)this.utility.parseCommand(query);
     	ODataSQLVisitor visitor = new ODataSQLVisitor(this.translator, utility.createRuntimeMetadata());
     	visitor.visitNode(cmd); 
     	String actual = URLDecoder.decode(visitor.buildURL(), "UTF-8");
     	assertEquals(expected, actual);
+    	return visitor.exceptions;
     }
 
     @Test
@@ -150,6 +152,28 @@ public class TestODataSQLVistor {
     @Test
     public void testFunction() throws Exception {
     	helpExecute("SELECT ContactName FROM Customers WHERE odata.startswith(CompanyName, 'CN')", "Customers?$filter=startswith(CompanyName,'CN') eq true&$select=ContactName");
+    }
+    
+    @Test
+    public void testBooleanFunction() throws Exception {
+    	this.translator.setSupportsOdataBooleanFunctionsWithComparison(false);
+    	try {
+    		helpExecute("SELECT ContactName FROM Customers WHERE odata.startswith(CompanyName, 'CN')", "Customers?$filter=startswith(CompanyName,'CN')&$select=ContactName");
+    		helpExecute("SELECT ContactName FROM Customers WHERE odata.startswith(CompanyName, 'CN') = 0", "Customers?$filter=NOT (startswith(CompanyName,'CN'))&$select=ContactName");
+    		helpExecute("SELECT ContactName FROM Customers WHERE odata.startswith(CompanyName, 'CN') <> 1", "Customers?$filter=NOT (startswith(CompanyName,'CN'))&$select=ContactName");
+    		helpExecute("SELECT ContactName FROM Customers WHERE odata.startswith(CompanyName, 'CN') <> 0", "Customers?$filter=startswith(CompanyName,'CN')&$select=ContactName");
+    		
+    		helpExecute("SELECT ContactName FROM Customers WHERE endswith('CN', CompanyName)", "Customers?$filter=endswith(CompanyName,'CN')&$select=ContactName");
+    		helpExecute("SELECT ContactName FROM Customers WHERE odata.substringof(CompanyName, 'CN')", "Customers?$filter=substringof(CompanyName,'CN')&$select=ContactName");
+    		
+    		
+    		ArrayList<TranslatorException> exceptions = 
+    				helpExecute("SELECT ContactName FROM Customers WHERE odata.startswith(CompanyName, 'CN') < 1", "Customers?$filter=startswith(CompanyName,'CN')&$select=ContactName");
+    		assertTrue(!exceptions.isEmpty());
+    		assertTrue(exceptions.get(0).getMessage().contains(ODataPlugin.Event.TEIID17018.name()));    		
+    	} finally {
+    		this.translator.setSupportsOdataBooleanFunctionsWithComparison(true);
+    	}
     }
     
     @Test
@@ -276,5 +300,3 @@ public class TestODataSQLVistor {
     	helpUpdateExecute("UPDATE Regions SET RegionID=10 WHERE RegionDescription='foo'", "Regions(10)", "PATCH", true);
     }    
 }
-
-


### PR DESCRIPTION
For instance, some servers choke on "startswith('a', 'b') eq true"
whereas "startswith('a', 'b')" is fine.