### PR TITLE
TEIID-4611 fixed the logic that was failing on deletes.

### DIFF
--- a/connectors/infinispan/translator-object/src/main/java/org/teiid/translator/object/ObjectUpdateExecution.java
+++ b/connectors/infinispan/translator-object/src/main/java/org/teiid/translator/object/ObjectUpdateExecution.java
@@ -373,14 +373,7 @@ public class ObjectUpdateExecution extends ObjectBaseExecution implements Update
 				Object v = cs.eval(sc);
 
 				v = convertKeyValue(v, keyCol);
-				Object removed = connection.remove(v);
-				if (removed == null) {
-					if (connection.get(v) == null) {
-						LogManager.logWarning(LogConstants.CTX_CONNECTOR, ObjectPlugin.Util.gs(ObjectPlugin.Event.TEIID21013, new Object[] {visitor.getTableName(), v}));
-					} 
-					throw new TranslatorException(ObjectPlugin.Util.gs(ObjectPlugin.Event.TEIID21012, new Object[] {visitor.getTableName(), v}));
-						
-				}
+				connection.remove(v);
 				++cnt;
 
 			}

--- a/connectors/infinispan/translator-object/src/test/java/org/teiid/translator/object/TestObjectUpdateExecution.java
+++ b/connectors/infinispan/translator-object/src/test/java/org/teiid/translator/object/TestObjectUpdateExecution.java
@@ -1,13 +1,15 @@
 package org.teiid.translator.object;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -36,7 +38,7 @@ public class TestObjectUpdateExecution {
 		MockitoAnnotations.initMocks(this);
 	}
 
-	@BeforeClass public static void init() throws Exception{
+	@Before public void init() throws Exception{
 		
 		
 		// pre-test of the object connection 
@@ -175,6 +177,26 @@ public class TestObjectUpdateExecution {
 
 		ie.execute();
 		assertNull(CONNECTION.get(new Long(1).longValue()));
+
+	}
+	
+	@Test
+	public void testDeleteAll() throws Exception {
+		
+		Object o = CONNECTION.get(new Long(1).longValue());
+		assertNotNull(o);
+
+		Command command = translationUtility
+				.parseCommand("Delete From Trade_Object.Trade");
+
+		List<Object> rows = new ArrayList<Object>();
+
+		ObjectUpdateExecution ie = createExecution(command, rows);
+
+		ie.execute();
+		
+		Collection<Object> all = CONNECTION.getAll();
+		assertTrue(all.size() == 0);
 
 	}
 


### PR DESCRIPTION
TEIID-4611 fixed the logic that was failing on deletes.  First, missed a return after the log message, which then threw the error message, but didn't really need the additional logic to recheck for the deleted object, so removed that extra check.