### PR TITLE
TEIID-4687: disable corelated subquery in translator

### DIFF
--- a/connectors/jdbc/translator-prestodb/src/main/java/org/teiid/translator/prestodb/PrestoDBExecutionFactory.java
+++ b/connectors/jdbc/translator-prestodb/src/main/java/org/teiid/translator/prestodb/PrestoDBExecutionFactory.java
@@ -381,5 +381,10 @@ public class PrestoDBExecutionFactory extends JDBCExecutionFactory {
     @Override
     public boolean supportsArrayType() {
         return true;
+    }
+
+    @Override
+    public boolean supportsCorrelatedSubqueries() {
+        return false;
     }    
 }


### PR DESCRIPTION
As per prestodb document [1], "Support for correlated subqueries is limited. Not every standard form is supported." So set disable corelated subquery in translator

[1] https://prestodb.io/docs/current/sql/select.html