### PR TITLE
TEIID-4682: fix prestodb could not commit transaction

### DIFF
--- a/connectors/jdbc/translator-prestodb/src/main/java/org/teiid/translator/prestodb/PrestoDBExecutionFactory.java
+++ b/connectors/jdbc/translator-prestodb/src/main/java/org/teiid/translator/prestodb/PrestoDBExecutionFactory.java
@@ -61,6 +61,7 @@ public class PrestoDBExecutionFactory extends JDBCExecutionFactory {
         setSupportsOuterJoins(true);
         setSupportsFullOuterJoins(true);
         setUseBindVariables(false);
+        setTransactionSupport(TransactionSupport.NONE);
     }
     
     @Override


### PR DESCRIPTION
* [TEIID-4682](https://issues.jboss.org/browse/TEIID-4682) - prestodb driver not support commit or set autocommit, if any of transactions related functions be invoked, a exception will through. 