### PR TITLE
TEIID-4731: changing the default of authentication scheme used for Mo…

### DIFF
--- a/connectors/mongodb/connector-mongodb/src/main/java/org/teiid/resource/adapter/mongodb/MongoDBManagedConnectionFactory.java
+++ b/connectors/mongodb/connector-mongodb/src/main/java/org/teiid/resource/adapter/mongodb/MongoDBManagedConnectionFactory.java
@@ -49,7 +49,7 @@ public class MongoDBManagedConnectionFactory extends BasicManagedConnectionFacto
 	private String username;
 	private String password;
 	private String database;
-	private String securityType = SecurityType.None.name();
+	private String securityType = SecurityType.SCRAM_SHA_1.name();
 	private String authDatabase;
 	private Boolean ssl;
 

--- a/connectors/mongodb/feature-pack-mongodb/src/main/resources/modules/system/layers/dv/org/jboss/teiid/resource-adapter/mongodb/main/META-INF/ra.xml
+++ b/connectors/mongodb/feature-pack-mongodb/src/main/resources/modules/system/layers/dv/org/jboss/teiid/resource-adapter/mongodb/main/META-INF/ra.xml
@@ -64,6 +64,7 @@
                 <description>{$display:"Authentication Mechanism",$allowed:["None","SCRAM_SHA_1","MONGODB_CR", "Kerberos","X509"], $description:"Type of Authentication to used", $required:"false"}</description>
                 <config-property-name>SecurityType</config-property-name>
                 <config-property-type>java.lang.String</config-property-type>
+                <config-property-value>SCRAM_SHA_1</config-property-value>
             </config-property> 
             
             <config-property>

--- a/teiid-feature-pack/wildfly-integration-feature-pack/src/main/resources/content/docs/teiid/teiid-releasenotes.html
+++ b/teiid-feature-pack/wildfly-integration-feature-pack/src/main/resources/content/docs/teiid/teiid-releasenotes.html
@@ -45,7 +45,8 @@
   <li><a href="https://issues.jboss.org/browse/TEIID-4205">TEIID-4205</a> By default, the wrapping begin/commit of a UseDeclareFetch cursor will be ignored as Teiid does not require a transaction.  Set the org.teiid.honorDeclareFetchTxn system property to false to revert to the old behavior which honored the transaction.</li>
   <li><a href="https://issues.jboss.org/browse/TEIID-4240">TEIID-4240</a> The usage of ; delimited statements for materialization scripts has been deprecated.  An anonymous procedure block should be used instead if multiple statements are needed.</li>
   <li><a href="https://issues.jboss.org/browse/TEIID-4228">TEIID-4228</a> Precision and scale values greater than 32767 are deprecated.</li>
-  <li><a href="https://issues.jboss.org/browse/TEIID-4228">TEIID-4228</a> Not using a semicolon delimiter between statements is deprecated and should only be relied on for backwards compatibility.  
+  <li><a href="https://issues.jboss.org/browse/TEIID-4228">TEIID-4228</a> Not using a semicolon delimiter between statements is deprecated and should only be relied on for backwards compatibility.
+  <li><a href="https://issues.jboss.org/browse/TEIID-4731">TEIID-4731</a> The default authentication scheme for MongoDB resource adapter has been changed to SCRAM_SHA_1 to match with latest versions of MongoDB. If using MongoDB version less than 3.0, to restore previous functionality change/add SecurityType to 'None' in the resource adapter configuration.
 </ul>
 
 <h4>from 9.2</h4>


### PR DESCRIPTION
…ngoDB to SCRAM_SHA_1 as MongoDB >= 3.0 uses this auth scheme