### PR TITLE
TEIID-4476: Upgrade Cassandra Client library

### DIFF
--- a/connectors/cassandra/connector-cassandra/src/main/java/org/teiid/resource/adapter/cassandra/CassandraConnectionImpl.java
+++ b/connectors/cassandra/connector-cassandra/src/main/java/org/teiid/resource/adapter/cassandra/CassandraConnectionImpl.java
@@ -67,7 +67,7 @@ public class CassandraConnectionImpl extends BasicConnection implements Cassandr
 		
 		this.session = cluster.connect(config.getKeyspace());
 		
-		this.version = this.session.getCluster().getConfiguration().getProtocolOptions().getProtocolVersionEnum();
+		this.version = this.session.getCluster().getConfiguration().getProtocolOptions().getProtocolVersion();
 	}
 
 	@Override

--- a/connectors/cassandra/feature-pack-cassandra/src/main/resources/modules/system/layers/dv/com/datastax/cassandra/driver/core/main/module.xml
+++ b/connectors/cassandra/feature-pack-cassandra/src/main/resources/modules/system/layers/dv/com/datastax/cassandra/driver/core/main/module.xml
@@ -6,8 +6,7 @@
     
     <resources>
         <artifact name="${com.datastax.cassandra:cassandra-driver-core}"/>
-        <artifact name="${com.codahale.metrics:metrics-core}"/>
-        <artifact name="${com.google.guava:guava}"/>
+        <artifact name="${io.dropwizard.metrics:metrics-core}"/>
     </resources>
 
     <dependencies>
@@ -15,10 +14,7 @@
         <module name="sun.jdk" />
         <module name="org.slf4j" />
         <module name="io.netty"/>
-        <module name="org.codehaus.jackson.jackson-core-asl"/>
-        <module name="org.codehaus.jackson.jackson-mapper-asl"/>
-        <module name="org.apache.thrift"/>
-        <module name="org.apache.httpcomponents"/>
+        <module name="com.google.guava"/>
     </dependencies>
 
 </module>

--- a/connectors/cassandra/translator-cassandra/src/main/java/org/teiid/translator/cassandra/CassandraMetadataProcessor.java
+++ b/connectors/cassandra/translator-cassandra/src/main/java/org/teiid/translator/cassandra/CassandraMetadataProcessor.java
@@ -22,6 +22,7 @@
 
 package org.teiid.translator.cassandra;
 
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,6 +38,7 @@ import org.teiid.translator.TypeFacility;
 import org.teiid.translator.cassandra.CassandraExecutionFactory.Event;
 
 import com.datastax.driver.core.ColumnMetadata;
+import com.datastax.driver.core.DataType.Name;
 import com.datastax.driver.core.TableMetadata;
 
 public class CassandraMetadataProcessor implements MetadataProcessor<CassandraConnection>{
@@ -89,26 +91,70 @@ public class CassandraMetadataProcessor implements MetadataProcessor<CassandraCo
 	 */
 	private void addColumnsToTable(MetadataFactory factory, Table table, TableMetadata columnFamily) {
 		for (ColumnMetadata column : columnFamily.getColumns()){
-
-			Class<?> cqlTypeToJavaClass = column.getType().asJavaClass();
-			Class<?> teiidRuntimeTypeFromJavaClass = TypeFacility.getRuntimeType(cqlTypeToJavaClass);
-			String type = TypeFacility.getDataTypeName(teiidRuntimeTypeFromJavaClass);
-			
-			if (column.getType().getName().equals(com.datastax.driver.core.DataType.Name.TIMESTAMP)) {
-				type = TypeFacility.RUNTIME_NAMES.TIMESTAMP;
-			} else if (column.getType().getName().equals(com.datastax.driver.core.DataType.Name.CUSTOM)
-					|| column.getType().getName().equals(com.datastax.driver.core.DataType.Name.BLOB)) {
-				type = TypeFacility.RUNTIME_NAMES.BLOB;
-			}
-			
+		    String type = asTeiidRuntimeType(column.getType().getName());
 			Column c = factory.addColumn(column.getName(), type, table);
 			c.setUpdatable(true);
-			if (column.getIndex() != null) {
-				c.setSearchType(SearchType.Searchable);
-			}
-			else {
-				c.setSearchType(SearchType.Unsearchable);
-			}
+			c.setSearchType(SearchType.Unsearchable);
 		}
 	}
+
+    private String asTeiidRuntimeType(Name name) {
+        
+        switch(name) {
+            case ASCII:
+                return TypeFacility.RUNTIME_NAMES.STRING;
+            case BIGINT:
+                return TypeFacility.RUNTIME_NAMES.LONG;
+            case BLOB:
+                return TypeFacility.RUNTIME_NAMES.BLOB;
+            case BOOLEAN:
+                return TypeFacility.RUNTIME_NAMES.BOOLEAN;
+            case COUNTER:
+                return TypeFacility.RUNTIME_NAMES.LONG;
+            case DECIMAL:
+                return TypeFacility.RUNTIME_NAMES.BIG_DECIMAL;
+            case DOUBLE:
+                return TypeFacility.RUNTIME_NAMES.DOUBLE;
+            case FLOAT:
+                return TypeFacility.RUNTIME_NAMES.FLOAT;
+            case INET:
+                return TypeFacility.RUNTIME_NAMES.OBJECT;
+            case INT:
+                return TypeFacility.RUNTIME_NAMES.INTEGER;
+            case TEXT:
+                return TypeFacility.RUNTIME_NAMES.STRING;
+            case UUID:
+                return TypeFacility.RUNTIME_NAMES.OBJECT;
+            case VARCHAR:
+                return TypeFacility.RUNTIME_NAMES.STRING;
+            case VARINT:
+                return TypeFacility.RUNTIME_NAMES.BIG_INTEGER;
+            case LIST:
+                return TypeFacility.RUNTIME_NAMES.OBJECT;
+            case SET:
+                return TypeFacility.RUNTIME_NAMES.OBJECT;
+            case MAP:
+                return TypeFacility.RUNTIME_NAMES.OBJECT;
+            case CUSTOM:
+                return TypeFacility.RUNTIME_NAMES.BLOB;
+            case UDT:
+                return TypeFacility.RUNTIME_NAMES.OBJECT;
+            case TUPLE:
+                return TypeFacility.RUNTIME_NAMES.OBJECT;
+            case SMALLINT:
+                return TypeFacility.RUNTIME_NAMES.SHORT;
+            case TINYINT:
+                return TypeFacility.RUNTIME_NAMES.BYTE;
+            case TIMEUUID:
+                return TypeFacility.RUNTIME_NAMES.OBJECT;
+            case TIMESTAMP:
+                return TypeFacility.RUNTIME_NAMES.TIMESTAMP;
+            case DATE:
+                return TypeFacility.RUNTIME_NAMES.DATE;
+            case TIME:
+                return TypeFacility.RUNTIME_NAMES.TIME;
+            default:
+                return TypeFacility.RUNTIME_NAMES.OBJECT;
+        }
+    }
 }

--- a/connectors/cassandra/translator-cassandra/src/main/java/org/teiid/translator/cassandra/CassandraQueryExecution.java
+++ b/connectors/cassandra/translator-cassandra/src/main/java/org/teiid/translator/cassandra/CassandraQueryExecution.java
@@ -150,14 +150,13 @@ public class CassandraQueryExecution implements ResultSetExecution {
 				values.add(Integer.valueOf(row.getInt(i)));
 				break;
 			case LIST:
-				values.add(row.getList(i, columnDefinitions.getType(i).getTypeArguments().get(0).asJavaClass()));
+				values.add(row.getList(i, Object.class));
 				break;
 			case MAP:
-				values.add(row.getMap(i, columnDefinitions.getType(i).getTypeArguments().get(0).asJavaClass(),
-										 columnDefinitions.getType(i).getTypeArguments().get(1).asJavaClass()));
+				values.add(row.getMap(i, Object.class, Object.class));
 				break;
 			case SET:
-				values.add(row.getSet(i, columnDefinitions.getType(i).getTypeArguments().get(0).asJavaClass()));
+				values.add(row.getSet(i, Object.class));
 				break;
 			case TEXT:
 				values.add(row.getString(i));

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.solr>4.6.0</version.solr>
         <version.noggit>0.5</version.noggit>
         <version.aws-java-sdk>1.11.0</version.aws-java-sdk>
-        <version.cassandra-driver-core>2.1.3</version.cassandra-driver-core>
+        <version.cassandra-driver-core>3.1.3</version.cassandra-driver-core>
         <version.org.jboss.resteasy.tjws>3.0.11.Final</version.org.jboss.resteasy.tjws>        
         <version.postgresql>9.2-1004-jdbc4</version.postgresql>
         <derby.version>10.2.1.6</derby.version>


### PR DESCRIPTION
Upgrade datastax cassandra driver from version 2.1.3 to 3.1.3, including some api change:
* get version api has a tiny change
* datatype name enum remove the java class type