### PR TITLE
Backport of TEIID-4976: criteria duplicated when criteria includes the same colums

### DIFF
--- a/build/kits/jboss-as7/overlay/docs/teiid/teiid-releasenotes.html
+++ b/build/kits/jboss-as7/overlay/docs/teiid/teiid-releasenotes.html
@@ -227,6 +227,16 @@ You can use the system property org.teiid.pgVersion to control this further.</p>
 <ul>
 	<li/>
 	<p style="margin-bottom: 0in">
+<a href='https://issues.jboss.org/browse/TEIID-4947'>TEIID-4947</a> - Error with Salesforce translator if criteria on outer join on a custom table is from the right side table (fixing the handling of custom relationships)
+	<li/>
+	<p style="margin-bottom: 0in">
+<a href='https://issues.jboss.org/browse/TEIID-4976'>TEIID-4976</a> - criteria duplicated when criteria includes the same columns as dependent join criteria (removing duplicate criteria)
+</ul>
+
+<h4 class="western">from 8.12.11.6_3</h4>
+<ul>
+	<li/>
+	<p style="margin-bottom: 0in">
 <a href='https://issues.jboss.org/browse/TEIID-4446'>TEIID-4446</a> - Rationalize precision/scale
         <li/>
         <p style="margin-bottom: 0in">

--- a/engine/src/main/java/org/teiid/query/processor/relational/DependentCriteriaProcessor.java
+++ b/engine/src/main/java/org/teiid/query/processor/relational/DependentCriteriaProcessor.java
@@ -315,7 +315,7 @@ public class DependentCriteriaProcessor {
 
         replaceDependentValueIterators();
         
-        LinkedList<Criteria> crits = new LinkedList<Criteria>();
+        LinkedHashSet<Criteria> crits = new LinkedHashSet<Criteria>();
         
         for (int i = 0; i < queryCriteria.size(); i++) {
         	SetState state = this.setStates.get(i);
@@ -333,9 +333,9 @@ public class DependentCriteriaProcessor {
         }
         
         if (crits.size() == 1) {
-        	return crits.get(0);
+        	return crits.iterator().next();
         }
-        return new CompoundCriteria(CompoundCriteria.AND, crits);
+        return new CompoundCriteria(CompoundCriteria.AND, new ArrayList<Criteria>(crits));
     }
     
     public void consumedCriteria() {

--- a/engine/src/test/java/org/teiid/query/processor/TestDependentJoins.java
+++ b/engine/src/test/java/org/teiid/query/processor/TestDependentJoins.java
@@ -1530,4 +1530,28 @@ public class TestDependentJoins {
         TestProcessor.helpProcess(plan, dataManager, expected);
     }
     
+    @Test public void testDupliciatePredicate() { 
+        // Create query 
+        String sql = "SELECT pm1.g1.e1 FROM pm1.g1, pm2.g1 WHERE pm1.g1.e1=pm2.g1.e1 and pm1.g1.e1 IN ('a','b','c') option makedep pm1.g1"; //$NON-NLS-1$
+        
+        // Create expected results
+        List[] expected = new List[] { 
+            Arrays.asList(new Object[] { "a" }), //$NON-NLS-1$
+        };    
+        
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        dataManager.setBlockOnce(true);
+        dataManager.addData("SELECT g_0.e1 AS c_0 FROM pm2.g1 AS g_0 WHERE g_0.e1 IN ('a', 'b', 'c') ORDER BY c_0", Arrays.asList("a"), Arrays.asList("b"), Arrays.asList("c"));
+        dataManager.addData("SELECT g_0.e1 FROM pm1.g1 AS g_0 WHERE g_0.e1 IN ('a', 'b', 'c')", Arrays.asList("a"));
+        
+        BasicSourceCapabilities bsc = TestOptimizer.getTypicalCapabilities();
+        bsc.setSourceProperty(Capability.MAX_IN_CRITERIA_SIZE, 5);
+        bsc.setSourceProperty(Capability.MAX_DEPENDENT_PREDICATES, 2);
+        
+        DefaultCapabilitiesFinder dcf = new DefaultCapabilitiesFinder(bsc);
+        ProcessorPlan plan = TestProcessor.helpGetPlan(sql, RealMetadataFactory.example1Cached(), dcf);
+
+        TestProcessor.helpProcess(plan, dataManager, expected);
+    }
+    
 }


### PR DESCRIPTION
TEIID-4976: criteria duplicated when criteria includes the same columns as dependent join criteria (removing duplicate criteria)