### PR TITLE
TEIID-5058: relaxing the registration of the .proto files when the vd…

### DIFF
--- a/connectors/infinispan/connector-infinispan-hotrod/src/main/resources/org/teiid/resource/adapter/infinispan/hotrod/i18n.properties
+++ b/connectors/infinispan/connector-infinispan-hotrod/src/main/resources/org/teiid/resource/adapter/infinispan/hotrod/i18n.properties
@@ -25,3 +25,4 @@ no_keystore="EXTERNAL" SASL Mechanism enabled, however no Keystore information p
 no_truststore="EXTERNAL" SASL Mechanism enabled, however no Truststore information provided for SSL
 no_truststore_pass=No Truststore password defined
 no_keystore_pass=No Keystore password defined 
+no_protobuf=No protobuf supplied to register


### PR DESCRIPTION
…b is redeployed to overwrite the previous definition