### PR TITLE
Backport

### DIFF
--- a/connectors/translator-google/src/main/java/org/teiid/translator/google/visitor/SpreadsheetCriteriaVisitor.java
+++ b/connectors/translator-google/src/main/java/org/teiid/translator/google/visitor/SpreadsheetCriteriaVisitor.java
@@ -114,6 +114,15 @@ public class SpreadsheetCriteriaVisitor extends SQLStringVisitor {
 	public void setCriteriaQuery(String criteriaQuery) {
 		this.criteriaQuery = criteriaQuery;
 	}
+	public void translateWhere(Condition condition) {
+	    if (condition != null) {
+	        StringBuilder temp = this.buffer;
+	        this.buffer = new StringBuilder();
+	        append(condition);
+	        criteriaQuery = buffer.toString();
+	        this.buffer = temp;
+	    }
+	}
 	
 	public boolean isHeaderEnabled() {
 		return headerEnabled;
@@ -125,16 +134,6 @@ public class SpreadsheetCriteriaVisitor extends SQLStringVisitor {
 
 	public String getWorksheetTitle() {
 		return worksheetTitle;
-	}
-	
-	public void translateWhere(Condition condition) {
-	    if (condition != null) {
-	        StringBuilder temp = this.buffer;
-	        this.buffer = new StringBuilder();
-	        append(condition);
-	        criteriaQuery = buffer.toString();
-	        this.buffer = temp;
-	    }
 	}
 	
 	public void visit(Comparison obj) {

--- a/connectors/translator-google/src/test/java/org/teiid/translator/google/TestSQLtoSpreadsheetQuery.java
+++ b/connectors/translator-google/src/test/java/org/teiid/translator/google/TestSQLtoSpreadsheetQuery.java
@@ -222,7 +222,8 @@ public class TestSQLtoSpreadsheetQuery {
 	
 	@Test
 	public void testUpdateVisitor() throws Exception {
-		String sql="UPDATE PeopleList set A = 'String,String', C = 1.5";
+		//String sql="UPDATE PeopleList set A = 'String,String', C = 1.5";
+		String sql="UPDATE PeopleList set A = 'String,String', C = 1.5 where A='Str,Str'";
         SpreadsheetUpdateVisitor visitor=new SpreadsheetUpdateVisitor(people);
         visitor.visit((Update)getCommand(sql));
         assertEquals(2,visitor.getChanges().size());
@@ -230,7 +231,7 @@ public class TestSQLtoSpreadsheetQuery {
         assertEquals("'String,String", visitor.getChanges().get(0).getValue());
         assertEquals("C", visitor.getChanges().get(1).getColumnID());
         assertEquals("1.5", visitor.getChanges().get(1).getValue());
-        assertNull(visitor.getCriteriaQuery());
+        assertEquals("a = \"Str,Str\"", visitor.getCriteriaQuery());
 	}
 	
     @Test

--- a/engine/src/main/java/org/teiid/query/rewriter/QueryRewriter.java
+++ b/engine/src/main/java/org/teiid/query/rewriter/QueryRewriter.java
@@ -2333,19 +2333,12 @@ public class QueryRewriter {
             } else if ((DataTypeManager.DefaultDataTypes.DATE.equalsIgnoreCase(type) 
                     || DataTypeManager.DefaultDataTypes.TIME.equalsIgnoreCase(type)) && function.getArg(1) instanceof Constant) {
                 String format = "yyyy-MM-dd"; //$NON-NLS-1$
-                int length = 10;
                 if (DataTypeManager.DefaultDataTypes.TIME.equalsIgnoreCase(type)) {
                     format = "hh:mm:ss"; //$NON-NLS-1$
-                    length = 8;
                 } 
                 Constant c = (Constant) function.getArg(1);
                 if (format.equals(c.getValue())) {
-                    Expression arg = function.getArg(0);
-                    if ((arg instanceof Function) 
-                            && FunctionLibrary.isConvert((Function)arg) 
-                            && java.util.Date.class.isAssignableFrom(((Function)arg).getArg(0).getType())) {
-                        return rewriteExpressionDirect(ResolverUtil.getConversion(arg, DataTypeManager.DefaultDataTypes.STRING, type, false, metadata.getFunctionLibrary()));
-                    }
+                    return rewriteExpressionDirect(ResolverUtil.getConversion(function.getArg(0), DataTypeManager.getDataTypeName(function.getArg(0).getType()), type, false, metadata.getFunctionLibrary()));
                 }
             }
         } else if(StringUtil.startsWithIgnoreCase(functionName, "format")) { //$NON-NLS-1$

--- a/engine/src/test/java/org/teiid/query/rewriter/TestQueryRewriter.java
+++ b/engine/src/test/java/org/teiid/query/rewriter/TestQueryRewriter.java
@@ -496,7 +496,7 @@ public class TestQueryRewriter {
     
     @Test public void testRewriteParseDateCastString() {
         helpTestRewriteCriteria("PARSEDATE(bqt1.smalla.stringkey, 'yyyy-MM-dd') = {d'2011-01-10'}", //$NON-NLS-1$
-                                "convert(parsetimestamp(bqt1.smalla.stringkey, 'yyyy-MM-dd'), date) = {d'2011-01-10'}", RealMetadataFactory.exampleBQTCached() );         //$NON-NLS-1$
+                                "convert(bqt1.smalla.stringkey, DATE) = {d'2011-01-10'}", RealMetadataFactory.exampleBQTCached() );         //$NON-NLS-1$
     }
     
     @Test public void testRewriteParseTimeCast() {


### PR DESCRIPTION
TEIID-4666: Google translator throws SpreadsheetOperationException for query DELETE FROM table (allowing delete/update to work with no predicate).  Also addreses regressions on TEIID-4656, TEIID-4543, TEIID-4667