### PR TITLE
TEIID-5088, TEIID-5089: restricting the search of columns to native t…

### DIFF
--- a/connectors/infinispan/translator-infinispan-hotrod/src/test/java/org/teiid/translator/infinispan/hotrod/TestProtobufMetadataProcessor.java
+++ b/connectors/infinispan/translator-infinispan-hotrod/src/test/java/org/teiid/translator/infinispan/hotrod/TestProtobufMetadataProcessor.java
@@ -67,7 +67,7 @@ public class TestProtobufMetadataProcessor {
     public void testMetadataProcessor() throws Exception {
         MetadataFactory mf = protoMatadata("tables.proto");
         String ddl = DDLStringVisitor.getDDLString(mf.getSchema(), null, null);
-        //System.out.println(ddl);
+        System.out.println(ddl);
         //ObjectConverterUtil.write(new StringReader(ddl), UnitTestUtil.getTestDataFile("tables.ddl"));
         assertEquals(ObjectConverterUtil.convertFileToString(UnitTestUtil.getTestDataFile("tables.ddl")), ddl);
     }

--- a/connectors/infinispan/translator-infinispan-hotrod/src/test/java/org/teiid/translator/infinispan/hotrod/TestSchemaToProtobufProcessor.java
+++ b/connectors/infinispan/translator-infinispan-hotrod/src/test/java/org/teiid/translator/infinispan/hotrod/TestSchemaToProtobufProcessor.java
@@ -20,6 +20,7 @@ package org.teiid.translator.infinispan.hotrod;
 import java.io.FileReader;
 import java.util.Properties;
 
+import org.infinispan.commons.api.BasicCache;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.teiid.core.util.UnitTestUtil;
@@ -32,15 +33,20 @@ import static org.junit.Assert.*;
 
 public class TestSchemaToProtobufProcessor {
 
-    @Test
+    @SuppressWarnings("rawtypes")
+	@Test
     public void testConverstion() throws Exception {
         SchemaToProtobufProcessor tool = new SchemaToProtobufProcessor();
         MetadataFactory mf = TestProtobufMetadataProcessor.protoMatadata("tables.proto");
-        ProtobufResource resource = tool.process(mf, Mockito.mock(InfinispanConnection.class));
+        InfinispanConnection conn = Mockito.mock(InfinispanConnection.class);
+        BasicCache cache = Mockito.mock(BasicCache.class);
+        Mockito.stub(cache.getName()).toReturn("default");
+        Mockito.stub(conn.getCache()).toReturn(cache);
+        ProtobufResource resource = tool.process(mf, conn);
 
         String expected = "package model;\n" +
                 "\n" +
-                "/* @Indexed */\n" +
+                "/* @Indexed @Cache(name=foo) */\n" +
                 "message G1 {\n" +
                 "    /* @Id @IndexedField(index=true, store=false) */\n" +
                 "    required int32 e1 = 1;\n" +
@@ -125,7 +131,11 @@ public class TestSchemaToProtobufProcessor {
 
         SchemaToProtobufProcessor tool = new SchemaToProtobufProcessor();
         tool.setIndexMessages(true);
-        ProtobufResource resource = tool.process(mf, Mockito.mock(InfinispanConnection.class));
+        InfinispanConnection conn = Mockito.mock(InfinispanConnection.class);
+        BasicCache cache = Mockito.mock(BasicCache.class);
+        Mockito.stub(cache.getName()).toReturn("default");
+        Mockito.stub(conn.getCache()).toReturn(cache);
+        ProtobufResource resource = tool.process(mf, conn);
 
         String expected = "package model;\n" +
                 "\n" +

--- a/connectors/infinispan/translator-infinispan-hotrod/src/test/resources/tables.ddl
+++ b/connectors/infinispan/translator-infinispan-hotrod/src/test/resources/tables.ddl
@@ -7,14 +7,14 @@ CREATE FOREIGN TABLE G1 (
 	e4 string[] OPTIONS (ANNOTATION '@IndexedField(index=true, store=false)', SEARCHABLE 'Searchable', NATIVE_TYPE 'string', "teiid_ispn:TAG" '4'),
 	e5 string[] OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'string', "teiid_ispn:TAG" '5'),
 	CONSTRAINT PK_E1 PRIMARY KEY(e1)
-) OPTIONS (ANNOTATION '@Indexed', NAMEINSOURCE 'pm1.G1', UPDATABLE TRUE, "teiid_ispn:CACHE" 'default');
+) OPTIONS (ANNOTATION '@Indexed @Cache(name=foo)', NAMEINSOURCE 'pm1.G1', UPDATABLE TRUE, "teiid_ispn:CACHE" 'foo');
 
 CREATE FOREIGN TABLE G2 (
 	e1 integer NOT NULL OPTIONS (ANNOTATION '@Id', SEARCHABLE 'Searchable', NATIVE_TYPE 'int32', "teiid_ispn:TAG" '1'),
 	e2 string NOT NULL OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'string', "teiid_ispn:TAG" '2'),
 	g3_e1 integer NOT NULL OPTIONS (NAMEINSOURCE 'e1', SEARCHABLE 'Searchable', NATIVE_TYPE 'int32', "teiid_ispn:MESSAGE_NAME" 'pm1.G3', "teiid_ispn:PARENT_COLUMN_NAME" 'g3', "teiid_ispn:PARENT_TAG" '5', "teiid_ispn:TAG" '1'),
 	g3_e2 string NOT NULL OPTIONS (NAMEINSOURCE 'e2', SEARCHABLE 'Searchable', NATIVE_TYPE 'string', "teiid_ispn:MESSAGE_NAME" 'pm1.G3', "teiid_ispn:PARENT_COLUMN_NAME" 'g3', "teiid_ispn:PARENT_TAG" '5', "teiid_ispn:TAG" '2'),
-	e5 varbinary OPTIONS (ANNOTATION '@IndexedField(index=false)', NATIVE_TYPE 'bytes', "teiid_ispn:TAG" '7'),
+	e5 varbinary OPTIONS (ANNOTATION '@IndexedField(index=false)', SEARCHABLE 'Unsearchable', NATIVE_TYPE 'bytes', "teiid_ispn:TAG" '7'),
 	e6 long OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'fixed64', "teiid_ispn:TAG" '8'),
 	CONSTRAINT PK_E1 PRIMARY KEY(e1)
 ) OPTIONS (ANNOTATION '@Indexed', NAMEINSOURCE 'pm1.G2', UPDATABLE TRUE, "teiid_ispn:CACHE" 'default');
@@ -24,26 +24,26 @@ CREATE FOREIGN TABLE G4 (
 	e2 string NOT NULL OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'string', "teiid_ispn:TAG" '2'),
 	G2_e1 integer OPTIONS (NAMEINSOURCE 'e1', SEARCHABLE 'Searchable', "teiid_ispn:PSEUDO" 'g4'),
 	CONSTRAINT FK_G2 FOREIGN KEY(G2_e1) REFERENCES G2 (e1)
-) OPTIONS (ANNOTATION '@Indexed', NAMEINSOURCE 'pm1.G4', UPDATABLE TRUE, "teiid_ispn:CACHE" 'default', "teiid_ispn:MERGE" 'model.G2', "teiid_ispn:PARENT_COLUMN_NAME" 'g4', "teiid_ispn:PARENT_TAG" '6');
+) OPTIONS (ANNOTATION '@Indexed', NAMEINSOURCE 'pm1.G4', UPDATABLE TRUE, "teiid_ispn:MERGE" 'model.G2', "teiid_ispn:PARENT_COLUMN_NAME" 'g4', "teiid_ispn:PARENT_TAG" '6');
 
 CREATE FOREIGN TABLE G5 (
 	e1 integer NOT NULL OPTIONS (ANNOTATION '@Id', SEARCHABLE 'Searchable', NATIVE_TYPE 'int32', "teiid_ispn:TAG" '1'),
 	e2 string NOT NULL OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'string', "teiid_ispn:TAG" '2'),
 	e3 double OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'double', "teiid_ispn:TAG" '3'),
 	e4 float OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'float', "teiid_ispn:TAG" '4'),
-	e5 short OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'int32', "teiid_ispn:TAG" '5'),
-	e6 byte OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'int32', "teiid_ispn:TAG" '6'),
-	e7 char OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'string', "teiid_ispn:TAG" '7'),
+	e5 short OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'int32', "teiid_ispn:TAG" '5'),
+	e6 byte OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'int32', "teiid_ispn:TAG" '6'),
+	e7 char OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'string', "teiid_ispn:TAG" '7'),
 	e8 long OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'int64', "teiid_ispn:TAG" '8'),
-	e9 bigdecimal OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'string', "teiid_ispn:TAG" '9'),
-	e10 biginteger OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'string', "teiid_ispn:TAG" '10'),
-	e11 time OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'int64', "teiid_ispn:TAG" '11'),
-	e12 timestamp OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'int64', "teiid_ispn:TAG" '12'),
-	e13 date OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'int64', "teiid_ispn:TAG" '13'),
-	e14 object OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'bytes', "teiid_ispn:TAG" '14'),
-	e15 blob OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'bytes', "teiid_ispn:TAG" '15'),
-	e16 clob OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'bytes', "teiid_ispn:TAG" '16'),
-	e17 xml OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'bytes', "teiid_ispn:TAG" '17'),
-	e18 geometry OPTIONS (SEARCHABLE 'Searchable', NATIVE_TYPE 'bytes', "teiid_ispn:TAG" '18'),
+	e9 bigdecimal OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'string', "teiid_ispn:TAG" '9'),
+	e10 biginteger OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'string', "teiid_ispn:TAG" '10'),
+	e11 time OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'int64', "teiid_ispn:TAG" '11'),
+	e12 timestamp OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'int64', "teiid_ispn:TAG" '12'),
+	e13 date OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'int64', "teiid_ispn:TAG" '13'),
+	e14 object OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'bytes', "teiid_ispn:TAG" '14'),
+	e15 blob OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'bytes', "teiid_ispn:TAG" '15'),
+	e16 clob OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'bytes', "teiid_ispn:TAG" '16'),
+	e17 xml OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'bytes', "teiid_ispn:TAG" '17'),
+	e18 geometry OPTIONS (SEARCHABLE 'Unsearchable', NATIVE_TYPE 'bytes', "teiid_ispn:TAG" '18'),
 	CONSTRAINT PK_E1 PRIMARY KEY(e1)
 ) OPTIONS (ANNOTATION '@Indexed', NAMEINSOURCE 'pm1.G5', UPDATABLE TRUE, "teiid_ispn:CACHE" 'default');

--- a/connectors/infinispan/translator-infinispan-hotrod/src/test/resources/tables.proto
+++ b/connectors/infinispan/translator-infinispan-hotrod/src/test/resources/tables.proto
@@ -1,6 +1,6 @@
 package pm1;
 
-/* @Indexed */
+/* @Indexed @Cache(name=foo)*/
 message G1 {
    /*
      @Id


### PR DESCRIPTION
…ypes only, also preserving the cache name