### PR TITLE
TEIID-5221: Correcting the metadata generation for OData V4 sources

### DIFF
--- a/connectors/odata/translator-odata4/src/main/java/org/teiid/translator/odata4/ODataPlugin.java
+++ b/connectors/odata/translator-odata4/src/main/java/org/teiid/translator/odata4/ODataPlugin.java
@@ -64,6 +64,7 @@ public class ODataPlugin {
         TEIID17031,
         TEIID17032,
         TEIID17033, 
-        TEIID17034
+        TEIID17034,
+        TEIID17035
     }
 }

--- a/connectors/odata/translator-odata4/src/main/java/org/teiid/translator/odata4/ODataQuery.java
+++ b/connectors/odata/translator-odata4/src/main/java/org/teiid/translator/odata4/ODataQuery.java
@@ -59,12 +59,12 @@ public class ODataQuery {
                 this.joinNode = node;
             } else {
                 // add the complex or expand tables                
-                String parentTable = table.getProperty(ODataMetadataProcessor.MERGE, false);
+                Table parentTable = ODataMetadataProcessor.getComplexTableParentTable(this.metadata, table);
                 if (parentTable == null) {
                     throw new TranslatorException(ODataPlugin.Event.TEIID17028, 
                             ODataPlugin.Util.gs(ODataPlugin.Event.TEIID17028, table.getName()));
                 }
-                addRootDocument(this.metadata.getTable(parentTable));
+                addRootDocument(parentTable);
                 // if this is not complex/navigation we already added 
                 // this as the parent document; no need to join
                 if (ODataMetadataProcessor.isComplexType(table)

--- a/connectors/odata/translator-odata4/src/main/java/org/teiid/translator/odata4/ODataSQLVisitor.java
+++ b/connectors/odata/translator-odata4/src/main/java/org/teiid/translator/odata4/ODataSQLVisitor.java
@@ -41,6 +41,7 @@ import org.teiid.language.SortSpecification;
 import org.teiid.language.SortSpecification.Ordering;
 import org.teiid.language.visitor.HierarchyVisitor;
 import org.teiid.metadata.Column;
+import org.teiid.metadata.ForeignKey;
 import org.teiid.metadata.RuntimeMetadata;
 import org.teiid.metadata.Table;
 import org.teiid.translator.TranslatorException;
@@ -180,7 +181,7 @@ public class ODataSQLVisitor extends HierarchyVisitor {
         }
         ColumnReference column = (ColumnReference)obj.getExpression();
         try {
-            Column c = normalizePseudoColumn(column.getMetadataObject());
+            Column c = ODataMetadataProcessor.normalizePseudoColumn(this.metadata, column.getMetadataObject());
             this.orderBy.append(c.getName());
         } catch (TranslatorException e) {
             this.exceptions.add(e);
@@ -209,7 +210,7 @@ public class ODataSQLVisitor extends HierarchyVisitor {
                         .gs(ODataPlugin.Event.TEIID17006, column.getName())));
             }
             try {
-                this.projectedColumns.add(normalizePseudoColumn(column));
+                this.projectedColumns.add(ODataMetadataProcessor.normalizePseudoColumn(this.metadata, column));
             } catch (TranslatorException e) {
                 this.exceptions.add(e);
             }
@@ -228,21 +229,6 @@ public class ODataSQLVisitor extends HierarchyVisitor {
         }
     }
     
-    private Column normalizePseudoColumn(Column column) throws TranslatorException {
-        String pseudo = ODataMetadataProcessor.getPseudo(column);
-        if (pseudo != null) {
-            try {
-                Table columnParent = (Table)column.getParent();
-                Table pseudoColumnParent = this.metadata.getTable(
-                        ODataMetadataProcessor.getMerge(columnParent));
-                return pseudoColumnParent.getColumnByName(pseudo);
-            } catch (TranslatorException e) {
-                this.exceptions.add(e);
-            }
-        }
-        return column;
-    }
-
     public void append(LanguageObject obj) {
         visitNode(obj);
     }

--- a/connectors/odata/translator-odata4/src/main/resources/org/teiid/translator/odata/i18n.properties
+++ b/connectors/odata/translator-odata4/src/main/resources/org/teiid/translator/odata/i18n.properties
@@ -51,3 +51,4 @@ TEIID17031=Empty response received from the source with status {0}
 TEIID17032=Update operation can not be completed as the service does not support JSON FULL not ATOM based payload to retrieve the Entity's editURL.
 TEIID17033=Actions with complex input parameters are currently not supported, {0} is not imported.
 TEIID17034=Error reading the metadata.  If this is an older non-OData v4 source, please use the odata translator instead.  If this is an OData4 source please raise an issue including the nested stacktrace.
+TEIID17035=No entity container associated with namespace {0}.  You may need to select a different namespace with the importer.schemaNamespace property. 

--- a/connectors/odata/translator-odata4/src/test/java/org/teiid/translator/odata4/TestODataMetadataProcessor.java
+++ b/connectors/odata/translator-odata4/src/test/java/org/teiid/translator/odata4/TestODataMetadataProcessor.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.*;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -274,11 +275,11 @@ public class TestODataMetadataProcessor {
         Table addressTable = mf.getSchema().getTable("Persons_address");
         assertEquals(4, addressTable.getColumns().size());
 		
-		assertNotNull(addressTable.getColumnByName("ssn"));
-		assertNotNull(addressTable.getColumnByName("ssn").getProperty(ODataMetadataProcessor.PSEUDO, false));
-		assertTrue(addressTable.getColumnByName("ssn").isSelectable());
+		assertNotNull(addressTable.getColumnByName("Persons_ssn"));
+        assertTrue(ODataMetadataProcessor.isPseudo(addressTable.getColumnByName("Persons_ssn")));
+		assertTrue(addressTable.getColumnByName("Persons_ssn").isSelectable());
         assertEquals(1, addressTable.getForeignKeys().size());
-        assertEquals("Persons", addressTable.getForeignKeys().get(0).getReferenceTableName());
+        assertEquals("northwind.Persons", addressTable.getForeignKeys().get(0).getReferenceTableName());
 	}
 
     static MetadataFactory getEntityWithComplexProperty()
@@ -324,14 +325,14 @@ public class TestODataMetadataProcessor {
 		Table personAddress= mf.getSchema().getTable("Persons_address");
 		assertEquals(4, personAddress.getColumns().size());
 		ForeignKey fk = personAddress.getForeignKeys().get(0);
-		assertNotNull(fk.getColumnByName("ssn"));
+		assertNotNull(fk.getColumnByName("Persons_ssn"));
 		
 		Table businessTable = mf.getSchema().getTable("Corporate");
 		assertEquals(1, businessTable.getColumns().size());
         Table corporateAddress= mf.getSchema().getTable("Corporate_address");
         assertEquals(4, corporateAddress.getColumns().size());
         fk = corporateAddress.getForeignKeys().get(0);
-        assertNotNull(fk.getColumnByName("name"));
+        assertNotNull(fk.getColumnByName("Corporate_name"));
 		
 	}
 		
@@ -343,7 +344,7 @@ public class TestODataMetadataProcessor {
 		Table g2 = mf.getSchema().getTable("G2");
 
 		ForeignKey fk = g2.getForeignKeys().get(0);
-		assertEquals("one_2_one", fk.getName());
+		assertEquals("G1_one_2_one", fk.getName());
 		assertNotNull(fk.getColumnByName("e1"));
 	}
 
@@ -549,7 +550,7 @@ public class TestODataMetadataProcessor {
                 
         Table g1 = mf.getSchema().getTable("G1_self");
         assertNotNull(g1);
-        assertEquals("self", g1.getForeignKeys().get(0).getName());
+        assertEquals("FK0", g1.getForeignKeys().get(0).getName());
         assertNotNull(g1.getForeignKeys().get(0).getColumnByName("G1_e1"));
         assertEquals("self", g1.getNameInSource());
     }	
@@ -562,9 +563,23 @@ public class TestODataMetadataProcessor {
         Table g2 = mf.getSchema().getTable("G2");
 
         ForeignKey fk = g2.getForeignKeys().get(0);
-        assertEquals("one_2_many", fk.getName());
+        assertEquals("G1_one_2_many", fk.getName());
         assertNotNull(fk.getColumnByName("e1"));
     }
+    
+    @Test
+    public void testMultipleNavigationProperties() throws Exception {
+        MetadataFactory mf = multipleNavigationProperties();
+        String metadataDDL = DDLStringVisitor.getDDLString(mf.getSchema(), null, null);
+        System.out.println(metadataDDL);
+        
+        Table g1 = mf.getSchema().getTable("G1");
+        Table g2 = mf.getSchema().getTable("G2");
+
+        ForeignKey fk = g2.getForeignKeys().get(0);
+        assertEquals("G1_one_2_many", fk.getName());
+        assertNotNull(fk.getColumnByName("e1"));
+    }    
 
     static MetadataFactory oneToManyRelationMetadata() throws TranslatorException {
         ODataMetadataProcessor processor = new ODataMetadataProcessor();
@@ -596,7 +611,50 @@ public class TestODataMetadataProcessor {
         processor.getMetadata(mf, metadata);
         
         return mf;
-    }	
+    }
+    
+    static MetadataFactory multipleNavigationProperties() throws TranslatorException {
+        ODataMetadataProcessor processor = new ODataMetadataProcessor();
+        MetadataFactory mf = new MetadataFactory("vdb", 1, "northwind",
+                SystemMetadata.getInstance().getRuntimeTypeMap(),
+                new Properties(), null);
+        
+        CsdlEntityType g1Entity = entityType("g1");
+        CsdlEntityType g2Entity = entityType("g2");
+        CsdlEntityType g3Entity = entityType("g3");
+        
+        CsdlNavigationProperty navProperty = new CsdlNavigationProperty();
+        navProperty.setName("one_2_many");
+        navProperty.setType("Collection(namespace.g2)");
+        navProperty.setNullable(false);
+        navProperty.setPartner("PartnerPath");
+        navProperty.setCollection(true);
+        
+        CsdlNavigationProperty navProperty2 = new CsdlNavigationProperty();
+        navProperty2.setName("one_2_g3");
+        navProperty2.setType("namespace.g3");
+        navProperty2.setNullable(true);
+        
+        g1Entity.setNavigationProperties(Arrays.asList(navProperty, navProperty2));
+        
+        CsdlEntitySet g1Set = createES("G1", "namespace.g1");
+        CsdlEntitySet g2Set = createES("G2", "namespace.g2");
+        CsdlEntitySet g3Set = createES("G3", "namespace.g3");
+        
+        CsdlNavigationPropertyBinding navBinding = new CsdlNavigationPropertyBinding();
+        navBinding.setPath("one_2_many");
+        navBinding.setTarget("G2");
+        CsdlNavigationPropertyBinding navBinding2 = new CsdlNavigationPropertyBinding();
+        navBinding2.setPath("one_2_g3");
+        navBinding2.setTarget("G3");
+        
+        g1Set.setNavigationPropertyBindings(Arrays.asList(navBinding, navBinding2));
+        
+        XMLMetadata metadata = buildXmlMetadata(g1Entity, g1Set, g2Entity, g2Set, g3Entity, g3Set);
+        processor.getMetadata(mf, metadata);
+        
+        return mf;
+    }    
     
     static MetadataFactory multiplePKMetadata() throws TranslatorException {
         ODataMetadataProcessor processor = new ODataMetadataProcessor();
@@ -676,7 +734,7 @@ public class TestODataMetadataProcessor {
 		assertNotNull(g2);
 		
 		ForeignKey fk = g2.getForeignKeys().get(0);
-		assertEquals("one_2_one", fk.getName());
+		assertEquals("G1_one_2_one", fk.getName());
 		assertNotNull(fk.getColumnByName("e2"));
 		assertEquals("g2e2", fk.getReferenceColumns().get(0));
 	}	

--- a/connectors/odata/translator-odata4/src/test/java/org/teiid/translator/odata4/TestODataMetadataProcessor.java
+++ b/connectors/odata/translator-odata4/src/test/java/org/teiid/translator/odata4/TestODataMetadataProcessor.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.*;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -96,6 +95,7 @@ public class TestODataMetadataProcessor {
         };
         Properties props = new Properties();
         props.setProperty("schemaNamespace", schemaNamespace);
+        processor.setSchemaNamespace(schemaNamespace);
         MetadataFactory mf = new MetadataFactory("vdb", 1, schema, SystemMetadata.getInstance().getRuntimeTypeMap(), props, null);
         processor.process(mf, null);
 //        String ddl = DDLStringVisitor.getDDLString(mf.getSchema(), null, null);
@@ -441,7 +441,16 @@ public class TestODataMetadataProcessor {
         
         type = ODataType.valueOf(table.getProperty(ODataMetadataProcessor.ODATA_TYPE, false));
         assertEquals(ODataType.COMPLEX_COLLECTION, type);
-    }    
+    }
+    
+    @Test public void testNorthwind() throws Exception {
+        String file = "northwind_v4.xml";
+        String schema = "northwind";
+        String schemaNamespace = "ODataWebExperimental.Northwind.Model";
+        MetadataFactory mf = createMetadata(file, schema, schemaNamespace);
+        String metadataDDL = DDLStringVisitor.getDDLString(mf.getSchema(), null, null);
+        System.out.println(metadataDDL);
+    }
 	
     private ProcedureParameter getReturnParameter(Procedure procedure) {
         for (ProcedureParameter pp:procedure.getParameters()) {
@@ -571,7 +580,6 @@ public class TestODataMetadataProcessor {
     public void testMultipleNavigationProperties() throws Exception {
         MetadataFactory mf = multipleNavigationProperties();
         String metadataDDL = DDLStringVisitor.getDDLString(mf.getSchema(), null, null);
-        System.out.println(metadataDDL);
         
         Table g1 = mf.getSchema().getTable("G1");
         Table g2 = mf.getSchema().getTable("G2");

--- a/connectors/odata/translator-odata4/src/test/java/org/teiid/translator/odata4/TestODataQueryExecution.java
+++ b/connectors/odata/translator-odata4/src/test/java/org/teiid/translator/odata4/TestODataQueryExecution.java
@@ -17,7 +17,9 @@
  */
 package org.teiid.translator.odata4;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -51,6 +53,7 @@ import org.teiid.language.Call;
 import org.teiid.language.Command;
 import org.teiid.language.QueryExpression;
 import org.teiid.metadata.MetadataFactory;
+import org.teiid.query.metadata.DDLStringVisitor;
 import org.teiid.translator.ExecutionContext;
 import org.teiid.translator.ProcedureExecution;
 import org.teiid.translator.ResultSetExecution;
@@ -647,23 +650,24 @@ public class TestODataQueryExecution {
         String expectedURL = "Airports?$select=IcaoCode,Location";
         
         FileReader reader = new FileReader(UnitTestUtil.getTestDataFile("airport-locations.json"));
+        MetadataFactory mf = TestODataMetadataProcessor.tripPinMetadata();
         ResultSetExecution execution = helpExecute(TestODataMetadataProcessor.tripPinMetadata(),
                 query, ObjectConverterUtil.convertToString(reader), expectedURL);
 
         List<?> row = execution.next();
         
-        assertEquals("187 Suffolk Ln.", row.get(1));
-        assertEquals("xyz", row.get(2));
+        assertEquals("187 Suffolk Ln.", row.get(2));
+        assertEquals("xyz", row.get(0));
         
-        GeometryInputSource gis = (GeometryInputSource)row.get(0);
+        GeometryInputSource gis = (GeometryInputSource)row.get(1);
         assertEquals("<gml:Point><gml:pos>-48.23456 20.12345</gml:pos></gml:Point>", ObjectConverterUtil.convertToString(gis.getGml()));
         assertEquals(4326, gis.getSrid().intValue());
         
         row = execution.next();
         
-        assertEquals("gso", row.get(2));
+        assertEquals("gso", row.get(0));
         
-        gis = (GeometryInputSource)row.get(0);
+        gis = (GeometryInputSource)row.get(1);
         assertEquals("<gml:Point><gml:pos>1.0 2.0</gml:pos></gml:Point>", ObjectConverterUtil.convertToString(gis.getGml()));
         
         assertNull(execution.next());

--- a/connectors/odata/translator-odata4/src/test/java/org/teiid/translator/odata4/TestODataSQLVistor.java
+++ b/connectors/odata/translator-odata4/src/test/java/org/teiid/translator/odata4/TestODataSQLVistor.java
@@ -155,7 +155,7 @@ public class TestODataSQLVistor {
     @Test
     public void testComplexTableJoin() throws Exception {
         helpExecute(TestODataMetadataProcessor.getEntityWithComplexProperty(),
-                "select p.name, pa.city from Persons p JOIN Persons_address pa ON p.ssn = pa.ssn",
+                "select p.name, pa.city from Persons p JOIN Persons_address pa ON p.ssn = pa.Persons_ssn",
                 "Persons?$select=name,address");
     }
     
@@ -163,7 +163,7 @@ public class TestODataSQLVistor {
     public void testComplexTableJoinWithPK() throws Exception {
         helpExecute(TestODataMetadataProcessor.getEntityWithComplexProperty(),
                 "select p.name, pa.city from Persons p "
-                + "JOIN Persons_address pa ON p.ssn = pa.ssn WHERE p.ssn=12",
+                + "JOIN Persons_address pa ON p.ssn = pa.Persons_ssn WHERE p.ssn=12",
                 "Persons?$select=name,address&$filter=ssn eq 12");
     }
     
@@ -171,8 +171,8 @@ public class TestODataSQLVistor {
     public void testTwoComplexTableJoinWithPK() throws Exception {
         helpExecute(TestODataMetadataProcessor.getEntityWithComplexProperty(),
                 "select p.name, pa.city, ps.city from Persons p "
-                + "JOIN Persons_address pa ON p.ssn = pa.ssn "
-                + "JOIN Persons_secondaddress ps ON p.ssn = ps.ssn "
+                + "JOIN Persons_address pa ON p.ssn = pa.Persons_ssn "
+                + "JOIN Persons_secondaddress ps ON p.ssn = ps.Persons_ssn "
                 + "WHERE p.ssn=12",
                 "Persons?$select=name,address,secondaddress&$filter=ssn eq 12");
     }    

--- a/connectors/odata/translator-odata4/src/test/java/org/teiid/translator/odata4/TestODataUpdateExecution.java
+++ b/connectors/odata/translator-odata4/src/test/java/org/teiid/translator/odata4/TestODataUpdateExecution.java
@@ -156,7 +156,7 @@ public class TestODataUpdateExecution {
 	
 	@Test
 	public void testInsertComplexType() throws Exception {
-		String query = "INSERT INTO Persons_address(street, city, state, ssn) "
+		String query = "INSERT INTO Persons_address(street, city, state, Persons_ssn) "
 		        + "VALUES('sesame street', 'Newyork', 'NY', 1234)";
 		String expectedURL = "Persons(1234)/address";
         

--- a/connectors/odata/translator-odata4/src/test/resources/northwind_v4.xml
+++ b/connectors/odata/translator-odata4/src/test/resources/northwind_v4.xml
@@ -1,0 +1,578 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+	<edmx:DataServices>
+		<Schema Namespace="NorthwindModel" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+			<EntityType Name="Category">
+				<Key>
+					<PropertyRef Name="CategoryID" />
+				</Key>
+				<Property Name="CategoryID" Type="Edm.Int32" Nullable="false"
+					p5:StoreGeneratedPattern="Identity"
+					xmlns:p5="http://schemas.microsoft.com/ado/2009/02/edm/annotation" />
+				<Property Name="CategoryName" Type="Edm.String" Nullable="false"
+					MaxLength="15" />
+				<Property Name="Description" Type="Edm.String" MaxLength="max" />
+				<Property Name="Picture" Type="Edm.Binary" MaxLength="max" />
+				<NavigationProperty Name="Products"
+					Type="Collection(NorthwindModel.Product)" Partner="Category" />
+			</EntityType>
+			<EntityType Name="CustomerDemographic">
+				<Key>
+					<PropertyRef Name="CustomerTypeID" />
+				</Key>
+				<Property Name="CustomerTypeID" Type="Edm.String" Nullable="false"
+					MaxLength="10" />
+				<Property Name="CustomerDesc" Type="Edm.String" MaxLength="max" />
+				<NavigationProperty Name="Customers"
+					Type="Collection(NorthwindModel.Customer)" Partner="CustomerDemographics" />
+			</EntityType>
+			<EntityType Name="Customer">
+				<Key>
+					<PropertyRef Name="CustomerID" />
+				</Key>
+				<Property Name="CustomerID" Type="Edm.String" Nullable="false"
+					MaxLength="5" />
+				<Property Name="CompanyName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+				<Property Name="ContactName" Type="Edm.String" MaxLength="30" />
+				<Property Name="ContactTitle" Type="Edm.String" MaxLength="30" />
+				<Property Name="Address" Type="Edm.String" MaxLength="60" />
+				<Property Name="City" Type="Edm.String" MaxLength="15" />
+				<Property Name="Region" Type="Edm.String" MaxLength="15" />
+				<Property Name="PostalCode" Type="Edm.String" MaxLength="10" />
+				<Property Name="Country" Type="Edm.String" MaxLength="15" />
+				<Property Name="Phone" Type="Edm.String" MaxLength="24" />
+				<Property Name="Fax" Type="Edm.String" MaxLength="24" />
+				<NavigationProperty Name="Orders"
+					Type="Collection(NorthwindModel.Order)" Partner="Customer" />
+				<NavigationProperty Name="CustomerDemographics"
+					Type="Collection(NorthwindModel.CustomerDemographic)" Partner="Customers" />
+			</EntityType>
+			<EntityType Name="Employee">
+				<Key>
+					<PropertyRef Name="EmployeeID" />
+				</Key>
+				<Property Name="EmployeeID" Type="Edm.Int32" Nullable="false"
+					p5:StoreGeneratedPattern="Identity"
+					xmlns:p5="http://schemas.microsoft.com/ado/2009/02/edm/annotation" />
+				<Property Name="LastName" Type="Edm.String" Nullable="false"
+					MaxLength="20" />
+				<Property Name="FirstName" Type="Edm.String" Nullable="false"
+					MaxLength="10" />
+				<Property Name="Title" Type="Edm.String" MaxLength="30" />
+				<Property Name="TitleOfCourtesy" Type="Edm.String"
+					MaxLength="25" />
+				<Property Name="BirthDate" Type="Edm.DateTimeOffset" />
+				<Property Name="HireDate" Type="Edm.DateTimeOffset" />
+				<Property Name="Address" Type="Edm.String" MaxLength="60" />
+				<Property Name="City" Type="Edm.String" MaxLength="15" />
+				<Property Name="Region" Type="Edm.String" MaxLength="15" />
+				<Property Name="PostalCode" Type="Edm.String" MaxLength="10" />
+				<Property Name="Country" Type="Edm.String" MaxLength="15" />
+				<Property Name="HomePhone" Type="Edm.String" MaxLength="24" />
+				<Property Name="Extension" Type="Edm.String" MaxLength="4" />
+				<Property Name="Photo" Type="Edm.Binary" MaxLength="max" />
+				<Property Name="Notes" Type="Edm.String" MaxLength="max" />
+				<Property Name="ReportsTo" Type="Edm.Int32" />
+				<Property Name="PhotoPath" Type="Edm.String" MaxLength="255" />
+				<NavigationProperty Name="Employees1"
+					Type="Collection(NorthwindModel.Employee)" Partner="Employee1" />
+				<NavigationProperty Name="Employee1"
+					Type="NorthwindModel.Employee" Partner="Employees1">
+					<ReferentialConstraint Property="ReportsTo"
+						ReferencedProperty="EmployeeID" />
+				</NavigationProperty>
+				<NavigationProperty Name="Orders"
+					Type="Collection(NorthwindModel.Order)" Partner="Employee" />
+				<NavigationProperty Name="Territories"
+					Type="Collection(NorthwindModel.Territory)" Partner="Employees" />
+			</EntityType>
+			<EntityType Name="Order_Detail">
+				<Key>
+					<PropertyRef Name="OrderID" />
+					<PropertyRef Name="ProductID" />
+				</Key>
+				<Property Name="OrderID" Type="Edm.Int32" Nullable="false" />
+				<Property Name="ProductID" Type="Edm.Int32" Nullable="false" />
+				<Property Name="UnitPrice" Type="Edm.Decimal" Nullable="false"
+					Precision="19" Scale="4" />
+				<Property Name="Quantity" Type="Edm.Int16" Nullable="false" />
+				<Property Name="Discount" Type="Edm.Single" Nullable="false" />
+				<NavigationProperty Name="Order" Type="NorthwindModel.Order"
+					Nullable="false" Partner="Order_Details">
+					<ReferentialConstraint Property="OrderID"
+						ReferencedProperty="OrderID" />
+				</NavigationProperty>
+				<NavigationProperty Name="Product" Type="NorthwindModel.Product"
+					Nullable="false" Partner="Order_Details">
+					<ReferentialConstraint Property="ProductID"
+						ReferencedProperty="ProductID" />
+				</NavigationProperty>
+			</EntityType>
+			<EntityType Name="Order">
+				<Key>
+					<PropertyRef Name="OrderID" />
+				</Key>
+				<Property Name="OrderID" Type="Edm.Int32" Nullable="false"
+					p5:StoreGeneratedPattern="Identity"
+					xmlns:p5="http://schemas.microsoft.com/ado/2009/02/edm/annotation" />
+				<Property Name="CustomerID" Type="Edm.String" MaxLength="5" />
+				<Property Name="EmployeeID" Type="Edm.Int32" />
+				<Property Name="OrderDate" Type="Edm.DateTimeOffset" />
+				<Property Name="RequiredDate" Type="Edm.DateTimeOffset" />
+				<Property Name="ShippedDate" Type="Edm.DateTimeOffset" />
+				<Property Name="ShipVia" Type="Edm.Int32" />
+				<Property Name="Freight" Type="Edm.Decimal" Precision="19"
+					Scale="4" />
+				<Property Name="ShipName" Type="Edm.String" MaxLength="40" />
+				<Property Name="ShipAddress" Type="Edm.String" MaxLength="60" />
+				<Property Name="ShipCity" Type="Edm.String" MaxLength="15" />
+				<Property Name="ShipRegion" Type="Edm.String" MaxLength="15" />
+				<Property Name="ShipPostalCode" Type="Edm.String"
+					MaxLength="10" />
+				<Property Name="ShipCountry" Type="Edm.String" MaxLength="15" />
+				<NavigationProperty Name="Customer"
+					Type="NorthwindModel.Customer" Partner="Orders">
+					<ReferentialConstraint Property="CustomerID"
+						ReferencedProperty="CustomerID" />
+				</NavigationProperty>
+				<NavigationProperty Name="Employee"
+					Type="NorthwindModel.Employee" Partner="Orders">
+					<ReferentialConstraint Property="EmployeeID"
+						ReferencedProperty="EmployeeID" />
+				</NavigationProperty>
+				<NavigationProperty Name="Order_Details"
+					Type="Collection(NorthwindModel.Order_Detail)" Partner="Order" />
+				<NavigationProperty Name="Shipper" Type="NorthwindModel.Shipper"
+					Partner="Orders">
+					<ReferentialConstraint Property="ShipVia"
+						ReferencedProperty="ShipperID" />
+				</NavigationProperty>
+			</EntityType>
+			<EntityType Name="Product">
+				<Key>
+					<PropertyRef Name="ProductID" />
+				</Key>
+				<Property Name="ProductID" Type="Edm.Int32" Nullable="false"
+					p5:StoreGeneratedPattern="Identity"
+					xmlns:p5="http://schemas.microsoft.com/ado/2009/02/edm/annotation" />
+				<Property Name="ProductName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+				<Property Name="SupplierID" Type="Edm.Int32" />
+				<Property Name="CategoryID" Type="Edm.Int32" />
+				<Property Name="QuantityPerUnit" Type="Edm.String"
+					MaxLength="20" />
+				<Property Name="UnitPrice" Type="Edm.Decimal" Precision="19"
+					Scale="4" />
+				<Property Name="UnitsInStock" Type="Edm.Int16" />
+				<Property Name="UnitsOnOrder" Type="Edm.Int16" />
+				<Property Name="ReorderLevel" Type="Edm.Int16" />
+				<Property Name="Discontinued" Type="Edm.Boolean" Nullable="false" />
+				<NavigationProperty Name="Category"
+					Type="NorthwindModel.Category" Partner="Products">
+					<ReferentialConstraint Property="CategoryID"
+						ReferencedProperty="CategoryID" />
+				</NavigationProperty>
+				<NavigationProperty Name="Order_Details"
+					Type="Collection(NorthwindModel.Order_Detail)" Partner="Product" />
+				<NavigationProperty Name="Supplier"
+					Type="NorthwindModel.Supplier" Partner="Products">
+					<ReferentialConstraint Property="SupplierID"
+						ReferencedProperty="SupplierID" />
+				</NavigationProperty>
+			</EntityType>
+			<EntityType Name="Region">
+				<Key>
+					<PropertyRef Name="RegionID" />
+				</Key>
+				<Property Name="RegionID" Type="Edm.Int32" Nullable="false" />
+				<Property Name="RegionDescription" Type="Edm.String"
+					Nullable="false" MaxLength="50" />
+				<NavigationProperty Name="Territories"
+					Type="Collection(NorthwindModel.Territory)" Partner="Region" />
+			</EntityType>
+			<EntityType Name="Shipper">
+				<Key>
+					<PropertyRef Name="ShipperID" />
+				</Key>
+				<Property Name="ShipperID" Type="Edm.Int32" Nullable="false"
+					p5:StoreGeneratedPattern="Identity"
+					xmlns:p5="http://schemas.microsoft.com/ado/2009/02/edm/annotation" />
+				<Property Name="CompanyName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+				<Property Name="Phone" Type="Edm.String" MaxLength="24" />
+				<NavigationProperty Name="Orders"
+					Type="Collection(NorthwindModel.Order)" Partner="Shipper" />
+			</EntityType>
+			<EntityType Name="Supplier">
+				<Key>
+					<PropertyRef Name="SupplierID" />
+				</Key>
+				<Property Name="SupplierID" Type="Edm.Int32" Nullable="false"
+					p5:StoreGeneratedPattern="Identity"
+					xmlns:p5="http://schemas.microsoft.com/ado/2009/02/edm/annotation" />
+				<Property Name="CompanyName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+				<Property Name="ContactName" Type="Edm.String" MaxLength="30" />
+				<Property Name="ContactTitle" Type="Edm.String" MaxLength="30" />
+				<Property Name="Address" Type="Edm.String" MaxLength="60" />
+				<Property Name="City" Type="Edm.String" MaxLength="15" />
+				<Property Name="Region" Type="Edm.String" MaxLength="15" />
+				<Property Name="PostalCode" Type="Edm.String" MaxLength="10" />
+				<Property Name="Country" Type="Edm.String" MaxLength="15" />
+				<Property Name="Phone" Type="Edm.String" MaxLength="24" />
+				<Property Name="Fax" Type="Edm.String" MaxLength="24" />
+				<Property Name="HomePage" Type="Edm.String" MaxLength="max" />
+				<NavigationProperty Name="Products"
+					Type="Collection(NorthwindModel.Product)" Partner="Supplier" />
+			</EntityType>
+			<EntityType Name="Territory">
+				<Key>
+					<PropertyRef Name="TerritoryID" />
+				</Key>
+				<Property Name="TerritoryID" Type="Edm.String" Nullable="false"
+					MaxLength="20" />
+				<Property Name="TerritoryDescription" Type="Edm.String"
+					Nullable="false" MaxLength="50" />
+				<Property Name="RegionID" Type="Edm.Int32" Nullable="false" />
+				<NavigationProperty Name="Region" Type="NorthwindModel.Region"
+					Nullable="false" Partner="Territories">
+					<ReferentialConstraint Property="RegionID"
+						ReferencedProperty="RegionID" />
+				</NavigationProperty>
+				<NavigationProperty Name="Employees"
+					Type="Collection(NorthwindModel.Employee)" Partner="Territories" />
+			</EntityType>
+			<EntityType Name="Alphabetical_list_of_product">
+				<Key>
+					<PropertyRef Name="CategoryName" />
+					<PropertyRef Name="Discontinued" />
+					<PropertyRef Name="ProductID" />
+					<PropertyRef Name="ProductName" />
+				</Key>
+				<Property Name="ProductID" Type="Edm.Int32" Nullable="false" />
+				<Property Name="ProductName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+				<Property Name="SupplierID" Type="Edm.Int32" />
+				<Property Name="CategoryID" Type="Edm.Int32" />
+				<Property Name="QuantityPerUnit" Type="Edm.String"
+					MaxLength="20" />
+				<Property Name="UnitPrice" Type="Edm.Decimal" Precision="19"
+					Scale="4" />
+				<Property Name="UnitsInStock" Type="Edm.Int16" />
+				<Property Name="UnitsOnOrder" Type="Edm.Int16" />
+				<Property Name="ReorderLevel" Type="Edm.Int16" />
+				<Property Name="Discontinued" Type="Edm.Boolean" Nullable="false" />
+				<Property Name="CategoryName" Type="Edm.String" Nullable="false"
+					MaxLength="15" />
+			</EntityType>
+			<EntityType Name="Category_Sales_for_1997">
+				<Key>
+					<PropertyRef Name="CategoryName" />
+				</Key>
+				<Property Name="CategoryName" Type="Edm.String" Nullable="false"
+					MaxLength="15" />
+				<Property Name="CategorySales" Type="Edm.Decimal"
+					Precision="19" Scale="4" />
+			</EntityType>
+			<EntityType Name="Current_Product_List">
+				<Key>
+					<PropertyRef Name="ProductID" />
+					<PropertyRef Name="ProductName" />
+				</Key>
+				<Property Name="ProductID" Type="Edm.Int32" Nullable="false"
+					p5:StoreGeneratedPattern="Identity"
+					xmlns:p5="http://schemas.microsoft.com/ado/2009/02/edm/annotation" />
+				<Property Name="ProductName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+			</EntityType>
+			<EntityType Name="Customer_and_Suppliers_by_City">
+				<Key>
+					<PropertyRef Name="CompanyName" />
+					<PropertyRef Name="Relationship" />
+				</Key>
+				<Property Name="City" Type="Edm.String" MaxLength="15" />
+				<Property Name="CompanyName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+				<Property Name="ContactName" Type="Edm.String" MaxLength="30" />
+				<Property Name="Relationship" Type="Edm.String" Nullable="false"
+					MaxLength="9" Unicode="false" />
+			</EntityType>
+			<EntityType Name="Invoice">
+				<Key>
+					<PropertyRef Name="CustomerName" />
+					<PropertyRef Name="Discount" />
+					<PropertyRef Name="OrderID" />
+					<PropertyRef Name="ProductID" />
+					<PropertyRef Name="ProductName" />
+					<PropertyRef Name="Quantity" />
+					<PropertyRef Name="Salesperson" />
+					<PropertyRef Name="ShipperName" />
+					<PropertyRef Name="UnitPrice" />
+				</Key>
+				<Property Name="ShipName" Type="Edm.String" MaxLength="40" />
+				<Property Name="ShipAddress" Type="Edm.String" MaxLength="60" />
+				<Property Name="ShipCity" Type="Edm.String" MaxLength="15" />
+				<Property Name="ShipRegion" Type="Edm.String" MaxLength="15" />
+				<Property Name="ShipPostalCode" Type="Edm.String"
+					MaxLength="10" />
+				<Property Name="ShipCountry" Type="Edm.String" MaxLength="15" />
+				<Property Name="CustomerID" Type="Edm.String" MaxLength="5" />
+				<Property Name="CustomerName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+				<Property Name="Address" Type="Edm.String" MaxLength="60" />
+				<Property Name="City" Type="Edm.String" MaxLength="15" />
+				<Property Name="Region" Type="Edm.String" MaxLength="15" />
+				<Property Name="PostalCode" Type="Edm.String" MaxLength="10" />
+				<Property Name="Country" Type="Edm.String" MaxLength="15" />
+				<Property Name="Salesperson" Type="Edm.String" Nullable="false"
+					MaxLength="31" />
+				<Property Name="OrderID" Type="Edm.Int32" Nullable="false" />
+				<Property Name="OrderDate" Type="Edm.DateTimeOffset" />
+				<Property Name="RequiredDate" Type="Edm.DateTimeOffset" />
+				<Property Name="ShippedDate" Type="Edm.DateTimeOffset" />
+				<Property Name="ShipperName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+				<Property Name="ProductID" Type="Edm.Int32" Nullable="false" />
+				<Property Name="ProductName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+				<Property Name="UnitPrice" Type="Edm.Decimal" Nullable="false"
+					Precision="19" Scale="4" />
+				<Property Name="Quantity" Type="Edm.Int16" Nullable="false" />
+				<Property Name="Discount" Type="Edm.Single" Nullable="false" />
+				<Property Name="ExtendedPrice" Type="Edm.Decimal"
+					Precision="19" Scale="4" />
+				<Property Name="Freight" Type="Edm.Decimal" Precision="19"
+					Scale="4" />
+			</EntityType>
+			<EntityType Name="Order_Details_Extended">
+				<Key>
+					<PropertyRef Name="Discount" />
+					<PropertyRef Name="OrderID" />
+					<PropertyRef Name="ProductID" />
+					<PropertyRef Name="ProductName" />
+					<PropertyRef Name="Quantity" />
+					<PropertyRef Name="UnitPrice" />
+				</Key>
+				<Property Name="OrderID" Type="Edm.Int32" Nullable="false" />
+				<Property Name="ProductID" Type="Edm.Int32" Nullable="false" />
+				<Property Name="ProductName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+				<Property Name="UnitPrice" Type="Edm.Decimal" Nullable="false"
+					Precision="19" Scale="4" />
+				<Property Name="Quantity" Type="Edm.Int16" Nullable="false" />
+				<Property Name="Discount" Type="Edm.Single" Nullable="false" />
+				<Property Name="ExtendedPrice" Type="Edm.Decimal"
+					Precision="19" Scale="4" />
+			</EntityType>
+			<EntityType Name="Order_Subtotal">
+				<Key>
+					<PropertyRef Name="OrderID" />
+				</Key>
+				<Property Name="OrderID" Type="Edm.Int32" Nullable="false" />
+				<Property Name="Subtotal" Type="Edm.Decimal" Precision="19"
+					Scale="4" />
+			</EntityType>
+			<EntityType Name="Orders_Qry">
+				<Key>
+					<PropertyRef Name="CompanyName" />
+					<PropertyRef Name="OrderID" />
+				</Key>
+				<Property Name="OrderID" Type="Edm.Int32" Nullable="false" />
+				<Property Name="CustomerID" Type="Edm.String" MaxLength="5" />
+				<Property Name="EmployeeID" Type="Edm.Int32" />
+				<Property Name="OrderDate" Type="Edm.DateTimeOffset" />
+				<Property Name="RequiredDate" Type="Edm.DateTimeOffset" />
+				<Property Name="ShippedDate" Type="Edm.DateTimeOffset" />
+				<Property Name="ShipVia" Type="Edm.Int32" />
+				<Property Name="Freight" Type="Edm.Decimal" Precision="19"
+					Scale="4" />
+				<Property Name="ShipName" Type="Edm.String" MaxLength="40" />
+				<Property Name="ShipAddress" Type="Edm.String" MaxLength="60" />
+				<Property Name="ShipCity" Type="Edm.String" MaxLength="15" />
+				<Property Name="ShipRegion" Type="Edm.String" MaxLength="15" />
+				<Property Name="ShipPostalCode" Type="Edm.String"
+					MaxLength="10" />
+				<Property Name="ShipCountry" Type="Edm.String" MaxLength="15" />
+				<Property Name="CompanyName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+				<Property Name="Address" Type="Edm.String" MaxLength="60" />
+				<Property Name="City" Type="Edm.String" MaxLength="15" />
+				<Property Name="Region" Type="Edm.String" MaxLength="15" />
+				<Property Name="PostalCode" Type="Edm.String" MaxLength="10" />
+				<Property Name="Country" Type="Edm.String" MaxLength="15" />
+			</EntityType>
+			<EntityType Name="Product_Sales_for_1997">
+				<Key>
+					<PropertyRef Name="CategoryName" />
+					<PropertyRef Name="ProductName" />
+				</Key>
+				<Property Name="CategoryName" Type="Edm.String" Nullable="false"
+					MaxLength="15" />
+				<Property Name="ProductName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+				<Property Name="ProductSales" Type="Edm.Decimal" Precision="19"
+					Scale="4" />
+			</EntityType>
+			<EntityType Name="Products_Above_Average_Price">
+				<Key>
+					<PropertyRef Name="ProductName" />
+				</Key>
+				<Property Name="ProductName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+				<Property Name="UnitPrice" Type="Edm.Decimal" Precision="19"
+					Scale="4" />
+			</EntityType>
+			<EntityType Name="Products_by_Category">
+				<Key>
+					<PropertyRef Name="CategoryName" />
+					<PropertyRef Name="Discontinued" />
+					<PropertyRef Name="ProductName" />
+				</Key>
+				<Property Name="CategoryName" Type="Edm.String" Nullable="false"
+					MaxLength="15" />
+				<Property Name="ProductName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+				<Property Name="QuantityPerUnit" Type="Edm.String"
+					MaxLength="20" />
+				<Property Name="UnitsInStock" Type="Edm.Int16" />
+				<Property Name="Discontinued" Type="Edm.Boolean" Nullable="false" />
+			</EntityType>
+			<EntityType Name="Sales_by_Category">
+				<Key>
+					<PropertyRef Name="CategoryID" />
+					<PropertyRef Name="CategoryName" />
+					<PropertyRef Name="ProductName" />
+				</Key>
+				<Property Name="CategoryID" Type="Edm.Int32" Nullable="false" />
+				<Property Name="CategoryName" Type="Edm.String" Nullable="false"
+					MaxLength="15" />
+				<Property Name="ProductName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+				<Property Name="ProductSales" Type="Edm.Decimal" Precision="19"
+					Scale="4" />
+			</EntityType>
+			<EntityType Name="Sales_Totals_by_Amount">
+				<Key>
+					<PropertyRef Name="CompanyName" />
+					<PropertyRef Name="OrderID" />
+				</Key>
+				<Property Name="SaleAmount" Type="Edm.Decimal" Precision="19"
+					Scale="4" />
+				<Property Name="OrderID" Type="Edm.Int32" Nullable="false" />
+				<Property Name="CompanyName" Type="Edm.String" Nullable="false"
+					MaxLength="40" />
+				<Property Name="ShippedDate" Type="Edm.DateTimeOffset" />
+			</EntityType>
+			<EntityType Name="Summary_of_Sales_by_Quarter">
+				<Key>
+					<PropertyRef Name="OrderID" />
+				</Key>
+				<Property Name="ShippedDate" Type="Edm.DateTimeOffset" />
+				<Property Name="OrderID" Type="Edm.Int32" Nullable="false" />
+				<Property Name="Subtotal" Type="Edm.Decimal" Precision="19"
+					Scale="4" />
+			</EntityType>
+			<EntityType Name="Summary_of_Sales_by_Year">
+				<Key>
+					<PropertyRef Name="OrderID" />
+				</Key>
+				<Property Name="ShippedDate" Type="Edm.DateTimeOffset" />
+				<Property Name="OrderID" Type="Edm.Int32" Nullable="false" />
+				<Property Name="Subtotal" Type="Edm.Decimal" Precision="19"
+					Scale="4" />
+			</EntityType>
+		</Schema>
+		<Schema Namespace="ODataWebExperimental.Northwind.Model" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+			<EntityContainer Name="NorthwindEntities"
+				p4:LazyLoadingEnabled="true"
+				xmlns:p4="http://schemas.microsoft.com/ado/2009/02/edm/annotation">
+				<EntitySet Name="Categories" EntityType="NorthwindModel.Category">
+					<NavigationPropertyBinding Path="Products"
+						Target="Products" />
+				</EntitySet>
+				<EntitySet Name="CustomerDemographics" EntityType="NorthwindModel.CustomerDemographic">
+					<NavigationPropertyBinding Path="Customers"
+						Target="Customers" />
+				</EntitySet>
+				<EntitySet Name="Customers" EntityType="NorthwindModel.Customer">
+					<NavigationPropertyBinding Path="CustomerDemographics"
+						Target="CustomerDemographics" />
+					<NavigationPropertyBinding Path="Orders"
+						Target="Orders" />
+				</EntitySet>
+				<EntitySet Name="Employees" EntityType="NorthwindModel.Employee">
+					<NavigationPropertyBinding Path="Employees1"
+						Target="Employees" />
+					<NavigationPropertyBinding Path="Employee1"
+						Target="Employees" />
+					<NavigationPropertyBinding Path="Orders"
+						Target="Orders" />
+					<NavigationPropertyBinding Path="Territories"
+						Target="Territories" />
+				</EntitySet>
+				<EntitySet Name="Order_Details" EntityType="NorthwindModel.Order_Detail">
+					<NavigationPropertyBinding Path="Order"
+						Target="Orders" />
+					<NavigationPropertyBinding Path="Product"
+						Target="Products" />
+				</EntitySet>
+				<EntitySet Name="Orders" EntityType="NorthwindModel.Order">
+					<NavigationPropertyBinding Path="Customer"
+						Target="Customers" />
+					<NavigationPropertyBinding Path="Employee"
+						Target="Employees" />
+					<NavigationPropertyBinding Path="Order_Details"
+						Target="Order_Details" />
+					<NavigationPropertyBinding Path="Shipper"
+						Target="Shippers" />
+				</EntitySet>
+				<EntitySet Name="Products" EntityType="NorthwindModel.Product">
+					<NavigationPropertyBinding Path="Category"
+						Target="Categories" />
+					<NavigationPropertyBinding Path="Order_Details"
+						Target="Order_Details" />
+					<NavigationPropertyBinding Path="Supplier"
+						Target="Suppliers" />
+				</EntitySet>
+				<EntitySet Name="Regions" EntityType="NorthwindModel.Region">
+					<NavigationPropertyBinding Path="Territories"
+						Target="Territories" />
+				</EntitySet>
+				<EntitySet Name="Shippers" EntityType="NorthwindModel.Shipper">
+					<NavigationPropertyBinding Path="Orders"
+						Target="Orders" />
+				</EntitySet>
+				<EntitySet Name="Suppliers" EntityType="NorthwindModel.Supplier">
+					<NavigationPropertyBinding Path="Products"
+						Target="Products" />
+				</EntitySet>
+				<EntitySet Name="Territories" EntityType="NorthwindModel.Territory">
+					<NavigationPropertyBinding Path="Employees"
+						Target="Employees" />
+					<NavigationPropertyBinding Path="Region"
+						Target="Regions" />
+				</EntitySet>
+				<EntitySet Name="Alphabetical_list_of_products"
+					EntityType="NorthwindModel.Alphabetical_list_of_product" />
+				<EntitySet Name="Category_Sales_for_1997" EntityType="NorthwindModel.Category_Sales_for_1997" />
+				<EntitySet Name="Current_Product_Lists" EntityType="NorthwindModel.Current_Product_List" />
+				<EntitySet Name="Customer_and_Suppliers_by_Cities"
+					EntityType="NorthwindModel.Customer_and_Suppliers_by_City" />
+				<EntitySet Name="Invoices" EntityType="NorthwindModel.Invoice" />
+				<EntitySet Name="Order_Details_Extendeds" EntityType="NorthwindModel.Order_Details_Extended" />
+				<EntitySet Name="Order_Subtotals" EntityType="NorthwindModel.Order_Subtotal" />
+				<EntitySet Name="Orders_Qries" EntityType="NorthwindModel.Orders_Qry" />
+				<EntitySet Name="Product_Sales_for_1997" EntityType="NorthwindModel.Product_Sales_for_1997" />
+				<EntitySet Name="Products_Above_Average_Prices"
+					EntityType="NorthwindModel.Products_Above_Average_Price" />
+				<EntitySet Name="Products_by_Categories" EntityType="NorthwindModel.Products_by_Category" />
+				<EntitySet Name="Sales_by_Categories" EntityType="NorthwindModel.Sales_by_Category" />
+				<EntitySet Name="Sales_Totals_by_Amounts" EntityType="NorthwindModel.Sales_Totals_by_Amount" />
+				<EntitySet Name="Summary_of_Sales_by_Quarters"
+					EntityType="NorthwindModel.Summary_of_Sales_by_Quarter" />
+				<EntitySet Name="Summary_of_Sales_by_Years" EntityType="NorthwindModel.Summary_of_Sales_by_Year" />
+			</EntityContainer>
+		</Schema>
+	</edmx:DataServices>
+</edmx:Edmx>

--- a/engine/src/main/resources/org/teiid/query/i18n.properties
+++ b/engine/src/main/resources/org/teiid/query/i18n.properties
@@ -1374,8 +1374,8 @@ TEIID31090=Materialization table {0} not found in Schema {1} for view {2}
 TEIID31091=Foreign Key definition on view {0} is incomplete. No reference key information not found.
 TEIID31092=Foreign Key definition on view {0} points to non-existent table {1} on schema {2}. Fully qualify the Reference Table name including the schema name.
 TEIID31093=Invalid Schema qualifier {0} is specified on Foreign Key definition for view {1}
-TEIID31094=Foreign Key definition on view {0} points to reference table {1} on schema {2} that has no primary keys
-TEIID31095=Foreign Key definition on view {0} points to reference table {1} on schema {2} that has no Primary Keys or Unique Keys that refer to column names {3}, create PK, or FK on the reference table first.
+TEIID31094=Foreign Key definition on {0} points to reference table {1} on schema {2} that has no primary keys or Unique Keys
+TEIID31095=Foreign Key definition on {0} points to reference table {1} on schema {2} that has no Primary Keys or Unique Keys that refer to column names {3}.
 
 
 TEIID30600=User defined aggregate function "{0}" method "{1}" must not be static.


### PR DESCRIPTION
Here's a combined pull request.  There is a failing unit test and just the sys.out from testNorthwind.  Have a look and see what you think of these changes.  It looks like there some fks that were not being created that should be, but creating both the implicit and the explicit can result in duplicate constraints:

CREATE FOREIGN TABLE Orders (
	OrderID integer NOT NULL OPTIONS (NATIVE_TYPE 'Edm.Int32'),
	CustomerID string(5),
	...
	CONSTRAINT Customers_Orders FOREIGN KEY(CustomerID) REFERENCES northwind.Customers (CustomerID),
	CONSTRAINT Employees_Orders FOREIGN KEY(EmployeeID) REFERENCES northwind.Employees (EmployeeID),
	CONSTRAINT Orders_Customer FOREIGN KEY(CustomerID) REFERENCES northwind.Customers (CustomerID),
	CONSTRAINT Orders_Employee FOREIGN KEY(EmployeeID) REFERENCES northwind.Employees (EmployeeID),
	CONSTRAINT Orders_Shipper FOREIGN KEY(ShipVia) REFERENCES northwind.Shippers (ShipperID)
) OPTIONS (UPDATABLE TRUE, "teiid_odata:NameInSchema" 'NorthwindModel.Order', "teiid_odata:Type" 'ENTITY_COLLECTION');

Note both Customers_Orders and Orders_Customer.  That can be avoided by looking for the reverse navigation, but I wanted to run this by you first before going further.
