### PR TITLE
TEIID-5404: translator-jpa: Improve Embedded mappings handling.

### DIFF
--- a/connectors/misc/translator-jpa/src/main/java/org/teiid/translator/jpa/JPQLSelectVisitor.java
+++ b/connectors/misc/translator-jpa/src/main/java/org/teiid/translator/jpa/JPQLSelectVisitor.java
@@ -424,7 +424,12 @@ public class JPQLSelectVisitor extends HierarchyVisitor {
     		if (record != null) {
     			String name = record.getProperty(JPAMetadataProcessor.KEY_ASSOSIATED_WITH_FOREIGN_TABLE, false); 
     			if (name == null) {
-					buffer.append(column.getTable().getCorrelationName()).append(Tokens.DOT).append(column.getMetadataObject().getName());
+					/*
+					 * The fallback to getName() is really there just to save me
+					 * the trouble of updating the test data in sakila.ddl.
+					 */
+					buffer.append(column.getTable().getCorrelationName()).append(Tokens.DOT)
+							.append(record.getNameInSource() != null ? column.getMetadataObject().getNameInSource() : record.getName());
     			}
     			else {
 					String attrName = record.getProperty(JPAMetadataProcessor.RELATION_PROPERTY, false);

--- a/connectors/misc/translator-jpa/src/test/java/org/teiid/translator/jpa/TestJSelectJPQLVisitor.java
+++ b/connectors/misc/translator-jpa/src/test/java/org/teiid/translator/jpa/TestJSelectJPQLVisitor.java
@@ -104,5 +104,12 @@ public class TestJSelectJPQLVisitor {
 						"LEFT OUTER JOIN tp.thing_type AS J_1");
 	}
 
+	@Test
+	public void testEmbedded() throws Exception {
+    	helpExecute("select * from thing_with_embedded as t",
+				"SELECT t.id, t.embedded.prop1, t.embedded.prop2 " +
+						"FROM thing_with_embedded AS t");
+	}
+
 	// needs one with composite PK
 }

--- a/connectors/misc/translator-jpa/src/test/resources/sakila.ddl
+++ b/connectors/misc/translator-jpa/src/test/resources/sakila.ddl
@@ -115,3 +115,10 @@ CREATE FOREIGN TABLE thing (
   FOREIGN KEY (thing_type_id) REFERENCES thing_type (id) OPTIONS(NAMEINSOURCE 'thing_type'),
   FOREIGN KEY (thing_subtype_id) REFERENCES thing_type (id) OPTIONS(NAMEINSOURCE 'thing_subtype')
 );
+
+CREATE FOREIGN TABLE thing_with_embedded (
+  id integer NOT NULL AUTO_INCREMENT,
+  prop1 integer OPTIONS(NAMEINSOURCE 'embedded.prop1'),
+  prop2 integer OPTIONS(NAMEINSOURCE 'embedded.prop2'),
+  PRIMARY KEY (id)
+);


### PR DESCRIPTION
This prevents column collisions and query failures involving Embedded
mappings by keeping track of the ManagedType traversal. Fragments of the
path are joined by '_' to form the column name. They are joined by '.'
and stored in nameInSource to be used in JPQL queries.