### PR TITLE
TEIIDTOOLS-466 allowing for opentracing to be used in thorntail

### DIFF
--- a/teiid-feature-pack/client-feature-pack/src/main/resources/modules/system/layers/dv/io/opentracing/teiid/module.xml
+++ b/teiid-feature-pack/client-feature-pack/src/main/resources/modules/system/layers/dv/io/opentracing/teiid/module.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module xmlns="urn:jboss:module:1.3" name="io.opentracing">
+<module xmlns="urn:jboss:module:1.3" name="io.opentracing" slot="teiid">
 	<properties>
 		<property name="jboss.api" value="private" />
 	</properties>
 
 	<resources>
-		<artifact name="${io.opentracing.contrib:opentracing-concurrent}"/>
 		<artifact name="${io.opentracing:opentracing-api}"/>
 		<artifact name="${io.opentracing:opentracing-noop}"/>
 		<artifact name="${io.opentracing:opentracing-util}"/>

--- a/teiid-feature-pack/client-feature-pack/src/main/resources/modules/system/layers/dv/org/jboss/teiid/client/main/module.xml
+++ b/teiid-feature-pack/client-feature-pack/src/main/resources/modules/system/layers/dv/org/jboss/teiid/client/main/module.xml
@@ -16,6 +16,7 @@
         <module name="sun.jdk"/>
         <module name="org.jboss.modules"/>
         <module name="org.hibernate"/>
-        <module name="io.opentracing"/>
+        <module name="io.opentracing.tracer" optional="true"/>
+        <module name="io.opentracing" slot="teiid"/>
     </dependencies>
 </module>

--- a/teiid-feature-pack/wildfly-integration-feature-pack/src/main/resources/modules/system/layers/dv/org/jboss/teiid/main/module.xml
+++ b/teiid-feature-pack/wildfly-integration-feature-pack/src/main/resources/modules/system/layers/dv/org/jboss/teiid/main/module.xml
@@ -12,7 +12,8 @@
         <artifact name="${org.teiid:teiid-runtime}"/>
         <artifact name="${org.teiid:teiid-jboss-admin}"/>
         <artifact name="${org.teiid:teiid-data-quality}"/>
-        <resource-root path="deployments" />
+        <artifact name="${io.opentracing.contrib:opentracing-concurrent}"/>
+		<resource-root path="deployments" />
     </resources>
 
     <dependencies>
@@ -67,6 +68,7 @@
         <module name="org.jboss.as.controller-client"/> <!-- Admin -->
         <module name="org.jboss.as.controller"/> <!-- Admin -->
         
-        <module name="io.opentracing"/>
+        <module name="io.opentracing.tracer" optional="true"/>
+        <module name="io.opentracing" slot="teiid"/>
     </dependencies>
 </module>


### PR DESCRIPTION
need to move our io.opentracing module to a slot to not conflict with
the throntail module of the same name

moved opentracing-concurrent to a direct resource as it seemed to fail
as a separate module?

minor cleanup to the tracing util