### PR TITLE
TEIID-5521 updated van's changes for basepom alignment

### DIFF
--- a/cache-infinispan/pom.xml
+++ b/cache-infinispan/pom.xml
@@ -16,6 +16,11 @@
     <artifactId>cache-infinispan</artifactId>
     <description>Infinispan based cache</description>
     
+    <properties>
+        <!--  duplicate features.xml in infinispan jars  -->
+        <basepom.check.fail-duplicate-finder>false</basepom.check.fail-duplicate-finder>
+    </properties>  
+    
     <dependencies>
 
     <dependency>
@@ -24,15 +29,10 @@
     </dependency>
     
     <dependency>
-        <groupId>com.github.ben-manes.caffeine</groupId>
-        <artifactId>caffeine</artifactId>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-commons</artifactId>
     </dependency>
     
-    <dependency>
-        <groupId>io.reactivex.rxjava2</groupId>
-        <artifactId>rxjava</artifactId>
-    </dependency>
-
     <dependency>
         <groupId>org.teiid</groupId>
         <artifactId>teiid-engine</artifactId>
@@ -46,6 +46,11 @@
     <dependency>
         <groupId>org.teiid</groupId>
         <artifactId>teiid-common-core</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>javax.transaction</groupId>
+      <artifactId>javax.transaction-api</artifactId>
     </dependency>                    
 	</dependencies>
 

--- a/common-core/pom.xml
+++ b/common-core/pom.xml
@@ -66,7 +66,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>javax.activation</groupId>
-			<artifactId>activation</artifactId>
+			<artifactId>javax.activation-api</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/connectors/accumulo/translator-accumulo/pom.xml
+++ b/connectors/accumulo/translator-accumulo/pom.xml
@@ -5,10 +5,20 @@
 		<artifactId>accumulo</artifactId>
 		<version>12.1.0-SNAPSHOT</version>
 	</parent>
-	<groupId>org.teiid.connectors</groupId>
 	<artifactId>translator-accumulo</artifactId>
 	<name>Accumulo translator</name>
 	<description>Integrates the query engine with Accumulo</description>
+	
+	<properties>
+	   <!-- 1. We declare some transitive dependencies that are needed in the wildfly module.
+	        
+	        2. There are a lot of duplicates/conflicts between hadoop and accumulo, that we aren't going to resolve here.
+	   -->
+	   <basepom.check.fail-dependency>false</basepom.check.fail-dependency>
+
+	   <basepom.check.fail-dependency-versions-check>false</basepom.check.fail-dependency-versions-check>
+       <basepom.check.skip-duplicate-finder>true</basepom.check.skip-duplicate-finder>
+	</properties>
 
 	<dependencies>
 		<dependency>
@@ -42,13 +52,6 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
-			<exclusions>
-			     <exclusion>
-			         <!-- removed for Java 9 -->
-			         <artifactId>jdk.tools</artifactId>
-			         <groupId>jdk.tools</groupId>
-			     </exclusion>
-			</exclusions>
 		</dependency> 
 		<dependency>
 			<groupId>org.apache.thrift</groupId>

--- a/connectors/amazon/simpledb-api/pom.xml
+++ b/connectors/amazon/simpledb-api/pom.xml
@@ -5,10 +5,17 @@
 	<artifactId>amazon</artifactId>
         <version>12.1.0-SNAPSHOT</version>
 	</parent>
-	<groupId>org.teiid.connectors</groupId>
 	<artifactId>simpledb-api</artifactId>	
 	<name>SimpleDB API</name>
 	<description>This is API for communicating with SimpleDB</description>
+	<properties>
+	    <!-- 1. We declare some transitive dependencies that are needed in the wildfly module.
+	    -->
+        <basepom.check.fail-dependency>false</basepom.check.fail-dependency>
+    <!-- 
+    <basepom.check.fail-dependency-versions-check>false</basepom.check.fail-dependency-versions-check>
+    <basepom.check.fail-duplicate-finder>false</basepom.check.fail-duplicate-finder>-->
+    </properties>
 	<dependencies>
 		<dependency>
 			<groupId>com.amazonaws</groupId>

--- a/connectors/amazon/translator-amazon-s3/pom.xml
+++ b/connectors/amazon/translator-amazon-s3/pom.xml
@@ -9,6 +9,12 @@
     <artifactId>translator-amazon-s3</artifactId>
     <name>S3 Translator</name>
     <description>This translator provides access to the S3 file system.</description>
+    
+    <properties>
+        <!-- there is a duplicate resource in several of the javax jars -->
+        <basepom.check.fail-duplicate-finder>false</basepom.check.fail-duplicate-finder>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>org.teiid</groupId>

--- a/connectors/amazon/translator-simpledb/pom.xml
+++ b/connectors/amazon/translator-simpledb/pom.xml
@@ -6,7 +6,6 @@
 	<artifactId>amazon</artifactId>
         <version>12.1.0-SNAPSHOT</version>
 	</parent>
-	<groupId>org.teiid.connectors</groupId>
 	<artifactId>translator-simpledb</artifactId>
 	<name>Amazon SimpleDB Translator</name>
 	<description>This translator provides access to Amazon SimpleDB Database</description>
@@ -23,6 +22,10 @@
 		<dependency>
 			<groupId>org.teiid.connectors</groupId>
 			<artifactId>simpledb-api</artifactId>
+		</dependency>
+		<dependency>
+		    <groupId>com.amazonaws</groupId>
+		    <artifactId>aws-java-sdk-simpledb</artifactId>
 		</dependency>
 	</dependencies>
 	<build>

--- a/connectors/cassandra/translator-cassandra/pom.xml
+++ b/connectors/cassandra/translator-cassandra/pom.xml
@@ -5,10 +5,15 @@
       <version>12.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.teiid.connectors</groupId>
   <artifactId>translator-cassandra</artifactId>
   <name>Cassandra CQL translator</name>
   <description>Integrates the query engine with CQL.</description>
+  
+  <properties>
+      <!-- 1. We declare some transitive dependencies that are needed in the wildfly module.
+      -->
+      <basepom.check.fail-dependency>false</basepom.check.fail-dependency>
+  </properties>
   
   <dependencies>
         <dependency>
@@ -22,110 +27,6 @@
         <dependency>
 			<groupId>com.datastax.cassandra</groupId>
 			<artifactId>cassandra-driver-core</artifactId>
-			<exclusions>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpcore</artifactId>
-                </exclusion>            
-                <exclusion>
-                    <groupId>org.apache.thrift</groupId>
-                    <artifactId>libthrift</artifactId>
-                </exclusion>            
-			     <exclusion>
-			     	<artifactId>cassandra-thrift</artifactId>
-			     	<groupId>org.apache.cassandra</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>commons-lang</artifactId>
-			     	<groupId>commons-lang</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>servlet-api</artifactId>
-			     	<groupId>javax.servlet</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>httpclient</artifactId>
-			     	<groupId>org.apache.httpcomponents</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>lz4</artifactId>
-			     	<groupId>net.jpountz.lz4</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>compress-lzf</artifactId>
-			     	<groupId>com.ning</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>commons-cli</artifactId>
-			     	<groupId>commons-cli</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>commons-codec</artifactId>
-			     	<groupId>commons-codec</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>antlr</artifactId>
-			     	<groupId>org.antlr</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>avro</artifactId>
-			     	<groupId>org.apache.cassandra.deps</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>jamm</artifactId>
-			     	<groupId>com.github.stephenc</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>jline</artifactId>
-			     	<groupId>jline</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>json-simple</artifactId>
-			     	<groupId>com.googlecode.json-simple</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>snakeyaml</artifactId>
-			     	<groupId>org.yaml</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>snaptree</artifactId>
-			     	<groupId>edu.stanford.ppl</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>jbcrypt</artifactId>
-			     	<groupId>org.mindrot</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>high-scale-lib</artifactId>
-			     	<groupId>
-			     		com.github.stephenc.high-scale-lib
-			     	</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>netty</artifactId>
-			     	<groupId>io.netty</groupId>
-			     </exclusion>
-			     <!-- <exclusion>
-			     	<artifactId>slf4j-api</artifactId>
-			     	<groupId>org.slf4j</groupId>
-			     </exclusion> -->
-			     <exclusion>
-			     	<artifactId>log4j</artifactId>
-			     	<groupId>log4j</groupId>
-			     </exclusion>
-			     <exclusion>
-			     	<artifactId>slf4j-log4j12</artifactId>
-			     	<groupId>org.slf4j</groupId>
-			     </exclusion>
-                 <exclusion>
-                    <artifactId>org.codehaus.jackson</artifactId>
-                    <groupId>jackson-core-asl</groupId>
-                 </exclusion>
-                 <exclusion>
-                    <artifactId>org.codehaus.jackson</artifactId>
-                    <groupId>jackson-mapper-asl</groupId>
-                 </exclusion>                 
-			</exclusions>
 		</dependency>     
 		<dependency>
           <groupId>com.google.guava</groupId>
@@ -135,10 +36,6 @@
           <groupId>io.dropwizard.metrics</groupId>
           <artifactId>metrics-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
-        </dependency>        
     </dependencies>
     
     <build>

--- a/connectors/couchbase/couchbase-api/pom.xml
+++ b/connectors/couchbase/couchbase-api/pom.xml
@@ -11,10 +11,6 @@
     <dependencies>
         <dependency>
             <groupId>org.teiid</groupId>
-            <artifactId>teiid-common-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.teiid</groupId>
             <artifactId>teiid-api</artifactId>
         </dependency>    
         <dependency>

--- a/connectors/couchbase/translator-couchbase/pom.xml
+++ b/connectors/couchbase/translator-couchbase/pom.xml
@@ -29,6 +29,15 @@
         <dependency>
             <groupId>org.teiid.connectors</groupId>
             <artifactId>translator-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.teiid</groupId>
+            <artifactId>teiid-admin</artifactId>
+            <scope>compile</scope>
+        </dependency> 
+        <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
         </dependency>                 
     </dependencies>
 

--- a/connectors/document-api/pom.xml
+++ b/connectors/document-api/pom.xml
@@ -13,10 +13,6 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.teiid</groupId>
-			<artifactId>teiid-common-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.teiid</groupId>
 			<artifactId>teiid-api</artifactId>
 		</dependency>
 	</dependencies>

--- a/connectors/file/translator-excel/pom.xml
+++ b/connectors/file/translator-excel/pom.xml
@@ -10,6 +10,10 @@
     <name>Excel Translator</name>
     <description>This translator provides access to the Excel data.</description>
     
+    <properties>
+        <basepom.check.fail-dependency>false</basepom.check.fail-dependency>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>org.teiid</groupId>

--- a/connectors/google/google-api/pom.xml
+++ b/connectors/google/google-api/pom.xml
@@ -12,15 +12,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.teiid</groupId>
-			<artifactId>teiid-common-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.teiid</groupId>
 			<artifactId>teiid-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/connectors/infinispan/infinispan-api/pom.xml
+++ b/connectors/infinispan/infinispan-api/pom.xml
@@ -10,6 +10,12 @@
 	<name>Infinispan API</name>
 	<description>This defines the common API for Infinispan</description>
 
+    <properties>
+        <basepom.check.fail-dependency>false</basepom.check.fail-dependency>
+        <!-- duplicates in infinispan jars -->
+        <basepom.check.fail-duplicate-finder>false</basepom.check.fail-duplicate-finder>
+    </properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.teiid</groupId>
@@ -43,6 +49,10 @@
 			<groupId>com.squareup</groupId>
 			<artifactId>protoparser</artifactId>
 		</dependency>
+		<dependency>
+            <groupId>org.infinispan.protostream</groupId>
+            <artifactId>protostream</artifactId>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/connectors/infinispan/infinispan-tasks/pom.xml
+++ b/connectors/infinispan/infinispan-tasks/pom.xml
@@ -10,10 +10,15 @@
 	<name>Infinispan Server Tasks</name>
 	<description>This defines Server Side tasks for Infinispan</description>
 
+    <properties>
+        <!-- duplicates in infinispan jars -->
+        <basepom.check.fail-duplicate-finder>false</basepom.check.fail-duplicate-finder>
+    </properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.infinispan</groupId>
-			<artifactId>infinispan-commons</artifactId>
+			<artifactId>infinispan-core</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.infinispan</groupId>

--- a/connectors/infinispan/pom.xml
+++ b/connectors/infinispan/pom.xml
@@ -28,6 +28,12 @@
 	            <groupId>org.infinispan</groupId>
 	            <artifactId>infinispan-core</artifactId>
 	            <version>${version.org.infinispan}</version>
+	            <exclusions>
+	                <exclusion>
+	                    <groupId>org.jboss.spec.javax.transaction</groupId>
+	                    <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+	                </exclusion>
+	            </exclusions>
             </dependency>
             
             <dependency>
@@ -59,20 +65,6 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.6.1</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 
 	<modules>
 		<module>infinispan-api</module>

--- a/connectors/infinispan/translator-infinispan-hotrod/pom.xml
+++ b/connectors/infinispan/translator-infinispan-hotrod/pom.xml
@@ -10,6 +10,11 @@
 	<name>Infinispan Protobuf Translator</name>
 	<description>This translator is using protobuf based schema to access the Infinispan cache</description>
 
+    <properties>
+        <!-- protobuf and infinispan duplicates -->
+        <basepom.check.skip-duplicate-finder>true</basepom.check.skip-duplicate-finder>
+    </properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.teiid</groupId>
@@ -51,17 +56,10 @@
 			<groupId>com.squareup</groupId>
 			<artifactId>protoparser</artifactId>
 		</dependency>
-		<!-- test dependencies -->
-        <dependency>
-            <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+            <groupId>org.infinispan.protostream</groupId>
+            <artifactId>protostream</artifactId>
+        </dependency>     
 	</dependencies>
 
 	<build>

--- a/connectors/jdbc/translator-jdbc/pom.xml
+++ b/connectors/jdbc/translator-jdbc/pom.xml
@@ -23,10 +23,6 @@
 			<groupId>org.teiid</groupId>
 			<artifactId>teiid-admin</artifactId>
 		</dependency>
-        <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
-        </dependency>
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-core</artifactId>

--- a/connectors/jdbc/translator-phoenix/pom.xml
+++ b/connectors/jdbc/translator-phoenix/pom.xml
@@ -22,7 +22,10 @@
             <groupId>org.teiid.connectors</groupId>
             <artifactId>translator-jdbc</artifactId>
         </dependency>
-        
+        <dependency>
+            <groupId>org.teiid</groupId>
+            <artifactId>teiid-admin</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/connectors/jdbc/translator-prestodb/pom.xml
+++ b/connectors/jdbc/translator-prestodb/pom.xml
@@ -21,6 +21,10 @@
         <dependency>
             <groupId>org.teiid.connectors</groupId>
             <artifactId>translator-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.teiid</groupId>
+            <artifactId>teiid-admin</artifactId>
         </dependency>   
         <dependency>
             <groupId>org.teiid.connectors</groupId>

--- a/connectors/misc/translator-jpa/pom.xml
+++ b/connectors/misc/translator-jpa/pom.xml
@@ -10,6 +10,17 @@
     <name>JPA2 Translator</name>
     <description>This translator provides access to any JPA based entities</description>
     
+    <properties>
+       <!-- 1. We declare some transitive dependencies that are needed in the wildfly module.  It also complains both ways
+               about javax.persistence
+            
+            2. There are a lot of duplicates/conflicts with javax.persistence - there are three versions in play.
+       -->
+       <basepom.check.fail-dependency>false</basepom.check.fail-dependency>
+
+       <basepom.check.skip-duplicate-finder>true</basepom.check.skip-duplicate-finder>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>org.teiid</groupId>
@@ -40,7 +51,7 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-        </dependency>     
+        </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>eclipselink</artifactId>

--- a/connectors/misc/translator-olap/pom.xml
+++ b/connectors/misc/translator-olap/pom.xml
@@ -9,6 +9,13 @@
     <artifactId>translator-olap</artifactId>
     <name>OLAP Translator</name>
     <description>This translator provides access to Query Analysis Cubes</description>
+    <properties>
+        <!-- the xmla dependency -->
+        <basepom.check.fail-dependency>false</basepom.check.fail-dependency>
+        <!-- resource overlap in the olap jars -->
+        <basepom.check.fail-duplicate-finder>false</basepom.check.fail-duplicate-finder>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>org.teiid</groupId>

--- a/connectors/mongodb/translator-mongodb/pom.xml
+++ b/connectors/mongodb/translator-mongodb/pom.xml
@@ -38,7 +38,12 @@
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
             <scope>test</scope>
-        </dependency>        
+        </dependency>
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.process</artifactId>
+            <scope>test</scope>
+        </dependency>         
     </dependencies>
 
     <build>

--- a/connectors/odata/translator-odata/pom.xml
+++ b/connectors/odata/translator-odata/pom.xml
@@ -10,6 +10,11 @@
     <name>Odata Translator</name>
     <description>This translator provides access to Odata based data sources</description>
     
+    <properties>
+        <basepom.check.fail-dependency>false</basepom.check.fail-dependency>
+        <basepom.check.fail-duplicate-finder>false</basepom.check.fail-duplicate-finder>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>org.teiid</groupId>
@@ -42,6 +47,22 @@
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>javax.activation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.teiid</groupId>
+            <artifactId>teiid-admin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/connectors/odata/translator-odata4/pom.xml
+++ b/connectors/odata/translator-odata4/pom.xml
@@ -10,11 +10,16 @@
     <name>OData4 Translator</name>
     <description>This translator provides access to OData V4 based data sources</description>
     
+    <properties>
+	   <!-- 1. We declare some transitive dependencies that are needed in the wildfly module.
+	        2. There are duplicate resources in the javax jars
+	   -->
+	   <basepom.check.fail-dependency>false</basepom.check.fail-dependency>
+	   
+	   <basepom.check.fail-duplicate-finder>false</basepom.check.fail-duplicate-finder>
+	</properties>
+    
     <dependencies>
-        <dependency>
-            <groupId>org.teiid</groupId>
-            <artifactId>teiid-common-core</artifactId>
-        </dependency>    
         <dependency>
             <groupId>org.teiid</groupId>
             <artifactId>teiid-olingo-common</artifactId>
@@ -43,8 +48,29 @@
             <groupId>org.apache.olingo</groupId>
             <artifactId>odata-client-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.olingo</groupId>
+            <artifactId>odata-commons-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.olingo</groupId>
+            <artifactId>odata-commons-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>javax.activation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+        </dependency>
+        <dependency>
+	      <groupId>org.teiid</groupId>
+	      <artifactId>teiid-engine</artifactId>
+	    </dependency>    
         
         <!-- Rutime dependencies -->
+        
 		<dependency>
 		    <groupId>commons-io</groupId>
 		    <artifactId>commons-io</artifactId>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -28,24 +28,9 @@
     <dependency>
       <groupId>org.teiid</groupId>
       <artifactId>teiid-common-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.teiid</groupId>
-      <artifactId>teiid-common-core</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.teiid</groupId>
-      <artifactId>teiid-client</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.teiid</groupId>
-      <artifactId>teiid-admin</artifactId>
-      <scope>test</scope>
-    </dependency>    
     <dependency>
       <groupId>org.teiid</groupId>
       <artifactId>teiid-engine</artifactId>
@@ -63,17 +48,6 @@
       <scope>test</scope>
     </dependency>        
 
-    <dependency>
-        <groupId>org.jboss</groupId>
-        <artifactId>jboss-vfs</artifactId>
-        <scope>test</scope>
-    </dependency> 
-    <dependency>
-        <groupId>org.jboss.logging</groupId>
-        <artifactId>jboss-logging</artifactId>
-        <scope>test</scope>        
-    </dependency>          
-    
   </dependencies>
   
   <modules>

--- a/connectors/salesforce/translator-salesforce-34/pom.xml
+++ b/connectors/salesforce/translator-salesforce-34/pom.xml
@@ -41,16 +41,8 @@
 			<artifactId>teiid-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.teiid</groupId>
-			<artifactId>teiid-common-core</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>com.force.api</groupId>
 			<artifactId>force-partner-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.force.api</groupId>
-			<artifactId>force-wsc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.teiid.connectors</groupId>

--- a/connectors/salesforce/translator-salesforce-41/pom.xml
+++ b/connectors/salesforce/translator-salesforce-41/pom.xml
@@ -41,16 +41,8 @@
 			<artifactId>teiid-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.teiid</groupId>
-			<artifactId>teiid-common-core</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>com.force.api</groupId>
 			<artifactId>force-partner-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.force.api</groupId>
-			<artifactId>force-wsc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.teiid.connectors</groupId>

--- a/connectors/salesforce/translator-salesforce/pom.xml
+++ b/connectors/salesforce/translator-salesforce/pom.xml
@@ -53,6 +53,14 @@
 			<groupId>com.force.api</groupId>
 			<artifactId>force-wsc</artifactId>
 		</dependency>
+		<dependency>
+            <groupId>org.teiid</groupId>
+            <artifactId>teiid-admin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+        </dependency>        
 	</dependencies>
 
 	<build>

--- a/connectors/sandbox/translator-logger/pom.xml
+++ b/connectors/sandbox/translator-logger/pom.xml
@@ -16,10 +16,6 @@
             <groupId>org.teiid</groupId>
             <artifactId>teiid-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.teiid</groupId>
-            <artifactId>teiid-common-core</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/connectors/solr/translator-solr/pom.xml
+++ b/connectors/solr/translator-solr/pom.xml
@@ -9,6 +9,13 @@
     <artifactId>translator-solr</artifactId>
     <name>Apache SOLR Translator</name>
     <description>This translator provides access to Apache SOLR</description>
+    
+    <properties>
+	    <!-- 1. We declare some transitive dependencies that are needed in the wildfly module.
+	    -->
+	    <basepom.check.fail-dependency>false</basepom.check.fail-dependency>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>org.teiid</groupId>
@@ -29,10 +36,6 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-        </dependency>        
-        <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
         </dependency>        
         <dependency>
             <groupId>org.teiid.connectors</groupId>

--- a/connectors/swagger/translator-swagger/pom.xml
+++ b/connectors/swagger/translator-swagger/pom.xml
@@ -10,6 +10,12 @@
 	<groupId>org.teiid.connectors</groupId>
 	<name>Swagger Translator</name>
 	<description>This translator provides access Swagger based data sources.</description>
+	
+	<properties>
+        <basepom.check.fail-dependency>false</basepom.check.fail-dependency>
+        <basepom.check.fail-duplicate-finder>false</basepom.check.fail-duplicate-finder>
+    </properties>
+    
 	<dependencies>
 		<dependency>
 			<groupId>org.teiid</groupId>
@@ -82,7 +88,19 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-        </dependency>                                        
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-models</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>javax.activation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+        </dependency>
     </dependencies>
 
 	<build>

--- a/connectors/webservice/translator-ws/pom.xml
+++ b/connectors/webservice/translator-ws/pom.xml
@@ -9,6 +9,12 @@
     <artifactId>translator-ws</artifactId>
     <name>Web service Translator</name>
     <description>This translator provides access to Web Services.</description>
+    
+    <properties>
+        <!-- there is a duplicate resource in several of the javax jars -->
+        <basepom.check.fail-duplicate-finder>false</basepom.check.fail-duplicate-finder>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>org.teiid</groupId>
@@ -27,12 +33,16 @@
 		    <artifactId>json-simple</artifactId>
 		</dependency>
         <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-        </dependency>
-        <dependency>
           <groupId>wsdl4j</groupId>
           <artifactId>wsdl4j</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>javax.activation</groupId>
+          <artifactId>javax.activation-api</artifactId>
         </dependency>        
     </dependencies>
 

--- a/eclipselink-platform/pom.xml
+++ b/eclipselink-platform/pom.xml
@@ -9,18 +9,34 @@
 	<name>Eclipselink DatabasePlatform</name>
 	<description>Teiid Eclipselink DatabasePlatform</description>
 
+	<properties>
+	    <!-- turned off dup finder with dups across the eclipse jars -->
+	    <basepom.check.skip-duplicate-finder>true</basepom.check.skip-duplicate-finder>
+    </properties>
+
 	<dependencies>
 	
 		<dependency>
 			<groupId>org.eclipse.persistence</groupId>
 			<artifactId>eclipselink</artifactId>
 		</dependency>
+		
+		<dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>javax.persistence</artifactId>
+        </dependency>
         
 		<dependency>
 			<groupId>org.teiid</groupId>
 			<artifactId>teiid-client</artifactId>
 			<scope>test</scope>
 		</dependency>
+		
+		<dependency>
+            <groupId>org.teiid</groupId>
+            <artifactId>teiid-api</artifactId>
+            <scope>test</scope>
+        </dependency>
 		
 		<dependency>
 			<groupId>org.teiid</groupId>
@@ -39,6 +55,12 @@
 			<artifactId>translator-file</artifactId>
 			<scope>test</scope>
 		</dependency>
+		
+		<dependency>
+            <groupId>org.teiid.connectors</groupId>
+            <artifactId>file-api</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.teiid</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -97,12 +97,6 @@
         </dependency>
 
 		<dependency>
-		    <!-- dependecy for jboss-vfs -->
-		    <groupId>org.jboss.logging</groupId>
-		    <artifactId>jboss-logging</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>net.sf.saxon</groupId>
 			<artifactId>Saxon-HE</artifactId>
 		</dependency>
@@ -133,8 +127,13 @@
         </dependency>
         
         <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+        </dependency>
+        
+        <dependency>
             <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
+            <artifactId>javax.activation-api</artifactId>
         </dependency>
         
         <dependency>

--- a/metadata/pom.xml
+++ b/metadata/pom.xml
@@ -58,6 +58,11 @@
         <artifactId>jboss-vfs</artifactId>
     </dependency>    
 
+    <dependency>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis</artifactId>
+    </dependency>
+
   </dependencies>
   
 </project>

--- a/olingo-common/pom.xml
+++ b/olingo-common/pom.xml
@@ -13,10 +13,15 @@
     </licenses>
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.teiid</groupId>
     <artifactId>teiid-olingo-common</artifactId>
     <name>teiid-olingo-common</name>
     <description>Teiid OData4 Common module</description>
+    
+    <properties>
+	    <!-- 1. We declare some transitive dependencies that are needed in the wildfly module.
+	    -->
+        <basepom.check.fail-dependency>false</basepom.check.fail-dependency>
+    </properties>
     
     <dependencies>
 
@@ -48,6 +53,11 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.vividsolutions</groupId>
+            <artifactId>jts</artifactId>
         </dependency> 
                 
     </dependencies>

--- a/olingo/pom.xml
+++ b/olingo/pom.xml
@@ -10,6 +10,12 @@
     <name>teiid-olingo</name>
     <description>Teiid OData4 Server module</description>
     
+    <properties>
+	    <!-- 1. We declare some transitive dependencies that are needed in the wildfly module.
+	    -->
+        <basepom.check.fail-dependency>false</basepom.check.fail-dependency>
+    </properties>
+    
     <build>
         <plugins>
             <plugin>
@@ -74,6 +80,16 @@
             <groupId>org.apache.olingo</groupId>
             <artifactId>odata-server-api</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>org.apache.olingo</groupId>
+            <artifactId>odata-commons-api</artifactId>
+        </dependency>        
+
+        <dependency>
+            <groupId>org.apache.olingo</groupId>
+            <artifactId>odata-commons-core</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.olingo</groupId>
@@ -99,6 +115,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
                 
         <!--  runtime dependencies -->
 
@@ -122,12 +143,17 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
-                                
+        
         <!-- aalto-xml runtime dependency -->
 		<dependency>
 		    <groupId>org.codehaus.woodstox</groupId>
 		    <artifactId>stax2-api</artifactId>
 		</dependency>
+		
+		<dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>
@@ -179,10 +205,6 @@
             <artifactId>teiid-metadata</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.teiid</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <!-- TODO: replace with basepom --> 
-    <!-- <parent>
-      <groupId>org.jboss</groupId>
-      <artifactId>jboss-parent</artifactId>
-      <version>28</version>
-      <relativePath />
-    </parent> -->
+    <parent>
+        <groupId>org.basepom</groupId>
+        <artifactId>basepom-oss</artifactId>
+        <version>25</version>
+    </parent>
     
     <modelVersion>4.0.0</modelVersion>
 	<groupId>org.teiid</groupId>
@@ -23,7 +21,33 @@
 	    <victims.updates>weekly</victims.updates>
             
         <jdk.min.version>1.8</jdk.min.version>
-      
+        
+        <basepom.git-id.skip>false</basepom.git-id.skip>
+        <basepom.check.skip-checkstyle>true</basepom.check.skip-checkstyle>
+        <basepom.check.skip-license>true</basepom.check.skip-license>
+        <basepom.check.skip-findbugs>true</basepom.check.skip-findbugs>
+        <!-- some modules, especially on a build server will exceed the 30 second default -->
+        <basepom.test.timeout>600</basepom.test.timeout>
+        
+        <!-- without separating some of the odata / web tests as integration tests 
+             that launch jetty with an embedded server, we need more memory for everything
+        -->
+        <basepom.test.memory>1024m</basepom.test.memory>
+
+        <!-- the tests under java 11 fail with the default version -->
+        <dep.plugin.jacoco.version>0.8.3</dep.plugin.jacoco.version>
+        
+        <!-- from syndesis.io -->
+        <!-- Don't fork based on cores, doesn't work nicely in the cloud -->
+	    <basepom.test.fork-count>1</basepom.test.fork-count>
+	    <basepom.failsafe.fork-count>1</basepom.failsafe.fork-count>
+	    <basepom.failsafe.reuse-vm>true</basepom.failsafe.reuse-vm>
+	    <!-- takes a really long time -->
+        <basepom.check.skip-dependency-versions-check>true</basepom.check.skip-dependency-versions-check>
+        <dep.plugin.surefire.version>2.21.0</dep.plugin.surefire.version> <!-- SUREFIRE-1422 -->
+        <dep.plugin.failsafe.version>2.21.0</dep.plugin.failsafe.version> <!-- SUREFIRE-1422 -->
+        <!-- end from syndesis.io -->
+        
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
@@ -48,10 +72,11 @@
         <version.com.googlecode.json-simple>1.1.1</version.com.googlecode.json-simple>      
         
         <version.commons-configuration>1.6</version.commons-configuration>
-        <version.commons-logging>1.1</version.commons-logging>
+        <version.commons-logging>1.2</version.commons-logging>
         <version.commons-net>3.5</version.commons-net>
 
         <version.de.flapdoodle.embed.mongo>2.2.0</version.de.flapdoodle.embed.mongo>
+        <version.de.flapdoodle.embed.process>2.1.2</version.de.flapdoodle.embed.process>
 
         <version.gdata-core>1.47.1</version.gdata-core>
         <version.hadoop-common>2.6.4</version.hadoop-common>
@@ -83,11 +108,12 @@
         <version.org.dbunit>2.2</version.org.dbunit>
         <version.org.eclipse.jetty>9.2.7.v20150116</version.org.eclipse.jetty>
         <version.org.eclipse.persistence>2.5.0</version.org.eclipse.persistence>
+        <version.org.eclipse.persistence.javax>2.1.0</version.org.eclipse.persistence.javax>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.2.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api><version.org.mockito>1.10.19</version.org.mockito>
         <version.org.jboss.oreva>1.0.0</version.org.jboss.oreva>
         <version.org.mockito>1.10.19</version.org.mockito>
         <version.org.mongodb.mongo-java-driver>3.9.1</version.org.mongodb.mongo-java-driver>
-        <version.org.reflections>0.9.9</version.org.reflections>
+        <version.org.reflections>0.9.11</version.org.reflections>
         <version.org.springframework>3.2.12.RELEASE</version.org.springframework>
         <version.org.springframework.asm>3.1.4.RELEASE</version.org.springframework.asm>
         
@@ -103,7 +129,6 @@
         <version.sun.jaxb>2.3.0</version.sun.jaxb>      
         <version.swagger-parser>1.0.33</version.swagger-parser>
 
-        <version.xerces>2.11.0</version.xerces>
         <version.xml-apis>1.4.01</version.xml-apis>
 
         <version.zookeeper>3.4.10</version.zookeeper>
@@ -177,6 +202,9 @@
         <activation>
             <activeByDefault>true</activeByDefault>
         </activation>
+        <properties>
+            <basepom.check.skip-dependency-versions-check>false</basepom.check.skip-dependency-versions-check>
+        </properties>
         <modules>
             <module>wildfly</module>
         </modules>
@@ -196,6 +224,9 @@
 			<module>build</module>
 			<module>wildfly</module>
 		</modules>
+		<properties>
+            <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
+        </properties>
 		<build>
 			<plugins>
 				<plugin>
@@ -237,6 +268,9 @@
 		<modules>
 			<module>build</module>
 		</modules>
+		<properties>
+            <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
+        </properties>
 		<build>
 			<plugins>
 				<plugin>
@@ -261,10 +295,13 @@
 	</profile>
 	<profile>
 		<!-- This is to enable faster build for development time. -->
+		<!-- TODO: copy the flash profile from syndesis - there's a lot of other plugins to
+		     turned off directly -->
 		<id>dev</id>
 		<properties>
 			<maven.javadoc.skip>true</maven.javadoc.skip>
 			<skipTests>true</skipTests>
+			<basepom.check.skip-all>true</basepom.check.skip-all>
 		</properties>
 		<modules>
 			<module>build</module>
@@ -518,7 +555,7 @@
             <scope>test</scope>
         </dependency>
    </dependencies>
-	    <dependencyManagement>
+   <dependencyManagement>
         <dependencies>
 
             <dependency>
@@ -566,6 +603,110 @@
                 <groupId>com.datastax.cassandra</groupId>
                 <artifactId>cassandra-driver-core</artifactId>
                 <version>${version.cassandra-driver-core}</version>
+                <exclusions>
+	                <exclusion>
+	                    <groupId>org.apache.httpcomponents</groupId>
+	                    <artifactId>httpcore</artifactId>
+	                </exclusion>            
+	                <exclusion>
+	                    <groupId>org.apache.thrift</groupId>
+	                    <artifactId>libthrift</artifactId>
+	                </exclusion>            
+	                 <exclusion>
+	                    <artifactId>cassandra-thrift</artifactId>
+	                    <groupId>org.apache.cassandra</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>commons-lang</artifactId>
+	                    <groupId>commons-lang</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>servlet-api</artifactId>
+	                    <groupId>javax.servlet</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>httpclient</artifactId>
+	                    <groupId>org.apache.httpcomponents</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>lz4</artifactId>
+	                    <groupId>net.jpountz.lz4</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>compress-lzf</artifactId>
+	                    <groupId>com.ning</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>commons-cli</artifactId>
+	                    <groupId>commons-cli</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>commons-codec</artifactId>
+	                    <groupId>commons-codec</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>antlr</artifactId>
+	                    <groupId>org.antlr</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>avro</artifactId>
+	                    <groupId>org.apache.cassandra.deps</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>jamm</artifactId>
+	                    <groupId>com.github.stephenc</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>jline</artifactId>
+	                    <groupId>jline</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>json-simple</artifactId>
+	                    <groupId>com.googlecode.json-simple</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>snakeyaml</artifactId>
+	                    <groupId>org.yaml</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>snaptree</artifactId>
+	                    <groupId>edu.stanford.ppl</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>jbcrypt</artifactId>
+	                    <groupId>org.mindrot</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>high-scale-lib</artifactId>
+	                    <groupId>
+	                        com.github.stephenc.high-scale-lib
+	                    </groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>netty</artifactId>
+	                    <groupId>io.netty</groupId>
+	                 </exclusion>
+	                 <!-- <exclusion>
+	                    <artifactId>slf4j-api</artifactId>
+	                    <groupId>org.slf4j</groupId>
+	                 </exclusion> -->
+	                 <exclusion>
+	                    <artifactId>log4j</artifactId>
+	                    <groupId>log4j</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>slf4j-log4j12</artifactId>
+	                    <groupId>org.slf4j</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>org.codehaus.jackson</artifactId>
+	                    <groupId>jackson-core-asl</groupId>
+	                 </exclusion>
+	                 <exclusion>
+	                    <artifactId>org.codehaus.jackson</artifactId>
+	                    <groupId>jackson-mapper-asl</groupId>
+	                 </exclusion>                 
+	            </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml</groupId>
@@ -707,10 +848,17 @@
                 <artifactId>commons-net</artifactId>
                 <version>${version.commons-net}</version>
             </dependency>
+            
             <dependency>
                 <groupId>de.flapdoodle.embed</groupId>
                 <artifactId>de.flapdoodle.embed.mongo</artifactId>
                 <version>${version.de.flapdoodle.embed.mongo}</version>
+            </dependency>
+            
+            <dependency>
+                <groupId>de.flapdoodle.embed</groupId>
+                <artifactId>de.flapdoodle.embed.process</artifactId>
+                <version>${version.de.flapdoodle.embed.process}</version>
             </dependency>
 
             <dependency>
@@ -835,6 +983,13 @@
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
                 <version>${version.hadoop-common}</version>
+                <exclusions>
+	                 <exclusion>
+	                     <!-- removed for Java 9 -->
+	                     <artifactId>jdk.tools</artifactId>
+	                     <groupId>jdk.tools</groupId>
+	                 </exclusion>
+                 </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.olingo</groupId>
@@ -908,6 +1063,13 @@
                 <groupId>org.apache.xmlbeans</groupId>
                 <artifactId>xmlbeans</artifactId>
                 <version>${version.org.apache.xmlbeans}</version>
+                <exclusions>
+                    <!-- rely on xml-apis instead -->
+                    <exclusion>
+                        <groupId>stax</groupId>
+                        <artifactId>stax-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.arrahtec</groupId>
@@ -973,6 +1135,11 @@
                 <version>${version.org.eclipse.persistence}</version>
             </dependency>
             <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>javax.persistence</artifactId>
+                <version>${version.org.eclipse.persistence.javax}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-core</artifactId>
                 <version>${version.hamcrest}</version>
@@ -1021,6 +1188,10 @@
                         <groupId>org.eclipse.persistence</groupId>
                         <artifactId>eclipselink</artifactId>
                     </exclusion>
+                    <exclusion>
+			            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+			            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+			        </exclusion>
                     <!-- <exclusion> <groupId>joda-time</groupId> <artifactId>joda-time</artifactId> 
                         </exclusion> -->
                 </exclusions>
@@ -1330,11 +1501,6 @@
             </dependency>
 
             <dependency>
-                <groupId>xerces</groupId>
-                <artifactId>xercesImpl</artifactId>
-                <version>${version.xerces}</version>
-            </dependency>
-            <dependency>
                 <groupId>xml-apis</groupId>
                 <artifactId>xml-apis</artifactId>
                 <version>${version.xml-apis}</version>
@@ -1346,6 +1512,12 @@
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-core</artifactId>
                 <version>9.4.3.Final</version>
+                <exclusions>
+		            <exclusion>
+		                <groupId>org.jboss.spec.javax.transaction</groupId>
+		                <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+		            </exclusion>
+		        </exclusions>
             </dependency> 
             <dependency>
                 <groupId>org.infinispan</groupId>
@@ -1362,21 +1534,6 @@
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging</artifactId>
                 <version>3.3.2.Final</version>       
-            </dependency>  
-            <dependency>
-                <groupId>org.jboss.marshalling</groupId>
-                <artifactId>jboss-marshalling-river</artifactId>
-                <version>2.0.6.Final</version>      
-            </dependency>  
-            <dependency>
-                <groupId>org.jboss.marshalling</groupId>
-                <artifactId>jboss-marshalling</artifactId>
-                <version>2.0.6.Final</version>      
-            </dependency>  
-            <dependency>
-                <groupId>org.jboss.marshalling</groupId>
-                <artifactId>jboss-marshalling-osgi</artifactId>
-                <version>2.0.5.Final</version>      
             </dependency>  
             
             <dependency>
@@ -1416,21 +1573,12 @@
            </dependency>
            
            <dependency>
+               <!-- TODO: get this from the infinispan bom
+                    not explicitly used in Teiid, but referenced by Teiid Spring Boot    
+                 -->
                <groupId>com.github.ben-manes.caffeine</groupId>
                <artifactId>caffeine</artifactId>
                <version>2.6.2</version>
-           </dependency>
-           
-           <dependency>
-               <groupId>io.reactivex.rxjava2</groupId>
-               <artifactId>rxjava</artifactId>
-               <version>2.2.0</version>
-           </dependency>
-           
-           <dependency>
-               <groupId>org.jboss</groupId>
-               <artifactId>staxmapper</artifactId>
-               <version>1.3.0.Final</version>
            </dependency>
            
            <dependency>
@@ -1443,6 +1591,12 @@
                <groupId>org.hibernate</groupId>
                <artifactId>hibernate-core</artifactId>
                <version>5.3.7.Final</version>
+               <exclusions>
+                   <exclusion>
+                       <groupId>org.jboss.spec.javax.transaction</groupId>
+                       <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                   </exclusion>
+               </exclusions>
            </dependency>
            
            <dependency>
@@ -1478,7 +1632,7 @@
            <dependency>
                <groupId>org.apache.httpcomponents</groupId>
                <artifactId>httpclient</artifactId>
-               <version>4.5.2</version>
+               <version>4.5.4</version>
            </dependency>
            
            <dependency>
@@ -1491,6 +1645,24 @@
                <groupId>org.jboss.resteasy</groupId>
                <artifactId>resteasy-jaxrs</artifactId>
                <version>3.6.2.Final</version>
+               <exclusions>
+                   <exclusion>
+                       <groupId>org.jboss.spec.javax.ws.rs</groupId>
+                       <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+                   </exclusion>
+                   <exclusion>
+                       <groupId>javax.activation</groupId>
+                       <artifactId>activation</artifactId>
+                   </exclusion>
+                   <exclusion>
+                       <groupId>org.jboss.spec.javax.xml.bind</groupId>
+                       <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+                   </exclusion>
+                   <exclusion>
+                       <groupId>org.jboss.spec.javax.annotation</groupId>
+                       <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+                   </exclusion>
+               </exclusions>
            </dependency>
 
            <dependency>
@@ -1524,10 +1696,9 @@
             </dependency>       
             <dependency>
                 <groupId>javax.activation</groupId>
-                <artifactId>activation</artifactId>
-                <version>1.1.1</version>
+                <artifactId>javax.activation-api</artifactId>
+                <version>1.2.0</version>
             </dependency>
-                      
             <dependency>
                 <groupId>javax.ws.rs</groupId>
                 <artifactId>javax.ws.rs-api</artifactId>
@@ -1556,7 +1727,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.22</version>
+                <version>1.7.25</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -21,6 +21,11 @@
   <name>Runtime Engine</name>
   <description>Teiid Runtime Engine</description>
       
+  <properties>
+      <!--  duplicate features.xml in infinispan jars  -->
+      <basepom.check.fail-duplicate-finder>false</basepom.check.fail-duplicate-finder>
+  </properties>    
+      
   <dependencies>
     <dependency>
       <groupId>org.teiid</groupId>
@@ -72,14 +77,6 @@
       <artifactId>javax.transaction-api</artifactId>
     </dependency>
     <dependency>
-        <groupId>org.jboss.marshalling</groupId>
-        <artifactId>jboss-marshalling-river</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>org.jboss.marshalling</groupId>
-        <artifactId>jboss-marshalling</artifactId>
-    </dependency>
-    <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging</artifactId>
     </dependency>
@@ -87,9 +84,17 @@
         <groupId>org.jboss</groupId>
         <artifactId>jboss-vfs</artifactId>
     </dependency>    
-    <dependency>   
-        <groupId>org.jboss</groupId>
-        <artifactId>staxmapper</artifactId>
+    <dependency>
+        <groupId>io.opentracing</groupId>
+        <artifactId>opentracing-api</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>io.opentracing</groupId>
+        <artifactId>opentracing-util</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis</artifactId>
     </dependency>    
     <dependency>
         <groupId>org.postgresql</groupId>
@@ -109,6 +114,11 @@
     <dependency>
       <groupId>org.teiid</groupId>
       <artifactId>cache-infinispan</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-core</artifactId>
       <scope>test</scope>
     </dependency>    
   </dependencies>

--- a/saxon-xom/pom.xml
+++ b/saxon-xom/pom.xml
@@ -28,12 +28,7 @@
             <groupId>com.io7m.xom</groupId>
             <artifactId>xom</artifactId>
         </dependency>
-        
-        <dependency>
-            <groupId>xerces</groupId>
-            <artifactId>xercesImpl</artifactId>
-        </dependency>
-                                  
+                                          
 	</dependencies>
 
 </project>

--- a/wildfly/rest-service/pom.xml
+++ b/wildfly/rest-service/pom.xml
@@ -45,6 +45,11 @@
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
 
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>

--- a/wildfly/test-integration/common/src/test/java/org/teiid/systemmodel/TestExternalMatViews.java
+++ b/wildfly/test-integration/common/src/test/java/org/teiid/systemmodel/TestExternalMatViews.java
@@ -37,7 +37,6 @@ import java.util.logging.Logger;
 
 import javax.sql.DataSource;
 
-import org.apache.log4j.Level;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -99,11 +98,6 @@ public class TestExternalMatViews {
 
     private static boolean DEBUG = false;
 
-    static org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger("org.teiid.MATVIEWS");
-    {
-        logger.setLevel(Level.DEBUG);
-    }
-    
 	private Connection conn;
 	private FakeServer server;
 	private static DataSource h2DataSource;


### PR DESCRIPTION
- used targeted skip/ignore rather than explicit configuring the plugins with allowable exceptions
- sparingly removed unused / transitive dependencies - so that the poms mirror the modules. we can revisit that, which will remove a lot of the ignores
- turned off everything for dev profile
- need to re-enable checkstyle