### PR TITLE
fix spelling in Java code

### DIFF
--- a/admin/src/main/java/org/teiid/adminapi/impl/AdminObjectImpl.java
+++ b/admin/src/main/java/org/teiid/adminapi/impl/AdminObjectImpl.java
@@ -105,6 +105,10 @@ public abstract class AdminObjectImpl implements AdminObject, Serializable {
         return this.properties.remove(key);
     }
 
+    @Deprecated
+    public <T> T addAttchment(Class<T> type, T attachment) {
+        return addAttachment(type, attachment);
+    }
    /**
     * Add attachment
     *
@@ -115,7 +119,7 @@ public abstract class AdminObjectImpl implements AdminObject, Serializable {
     * @throws IllegalArgumentException for a null name, attachment or type
     * @throws UnsupportedOperationException when not supported by the implementation
     */
-    public <T> T addAttchment(Class<T> type, T attachment) {
+    public <T> T addAttachment(Class<T> type, T attachment) {
         if (type == null)
               throw new IllegalArgumentException("Null type"); //$NON-NLS-1$
           Object result = this.attachments.put(type, attachment);

--- a/admin/src/main/java/org/teiid/adminapi/impl/VDBMetadataParser.java
+++ b/admin/src/main/java/org/teiid/adminapi/impl/VDBMetadataParser.java
@@ -54,7 +54,11 @@ public class VDBMetadataParser {
 
     private boolean writePropertyElements;
 
+    @Deprecated
     public static VDBMetaData unmarshell(InputStream content) throws XMLStreamException {
+        return unmarshall(content);
+    }
+    public static VDBMetaData unmarshall(InputStream content) throws XMLStreamException {
          XMLInputFactory inputFactory=XMLType.getXmlInputFactory();
          XMLStreamReader reader = inputFactory.createXMLStreamReader(content);
          try {

--- a/admin/src/test/java/org/teiid/adminapi/impl/TestVDBMetadataParser.java
+++ b/admin/src/test/java/org/teiid/adminapi/impl/TestVDBMetadataParser.java
@@ -36,7 +36,7 @@ public class TestVDBMetadataParser {
         FileInputStream in = new FileInputStream(UnitTestUtil.getTestDataPath() + "/parser-test-vdb.xml");
         VDBMetadataParser.validate(in);
         in = new FileInputStream(UnitTestUtil.getTestDataPath() + "/parser-test-vdb.xml");
-        VDBMetaData vdb = VDBMetadataParser.unmarshell(in);
+        VDBMetaData vdb = VDBMetadataParser.unmarshall(in);
         TestVDBUtility.validateVDB(vdb);
     }
 
@@ -47,7 +47,7 @@ public class TestVDBMetadataParser {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         VDBMetadataParser.marshell(metadata, baos);
         baos.close();
-        VDBMetaData parsed = VDBMetadataParser.unmarshell(new ByteArrayInputStream(baos.toByteArray()));
+        VDBMetaData parsed = VDBMetadataParser.unmarshall(new ByteArrayInputStream(baos.toByteArray()));
         assertNull(parsed.getModel("model-one"));
     }
 

--- a/connectors/accumulo/translator-accumulo/src/main/java/org/teiid/translator/accumulo/EvaluatorIterator.java
+++ b/connectors/accumulo/translator-accumulo/src/main/java/org/teiid/translator/accumulo/EvaluatorIterator.java
@@ -144,8 +144,8 @@ public class EvaluatorIterator extends WrappingIterator {
             vdbMetaData.addModel(createModel(schema.getName(), schema.isPhysical()));
         }
         TransformationMetadata metadata = new TransformationMetadata(vdbMetaData, store, null, SFM.getSystemFunctions(), udfs);
-        vdbMetaData.addAttchment(TransformationMetadata.class, metadata);
-        vdbMetaData.addAttchment(QueryMetadataInterface.class, metadata);
+        vdbMetaData.addAttachment(TransformationMetadata.class, metadata);
+        vdbMetaData.addAttachment(QueryMetadataInterface.class, metadata);
         return metadata;
     }
 

--- a/engine/src/main/java/org/teiid/query/metadata/SystemMetadata.java
+++ b/engine/src/main/java/org/teiid/query/metadata/SystemMetadata.java
@@ -119,7 +119,7 @@ public class SystemMetadata {
         systemStore.addDataTypes(typeMap);
         loadSchema(vdb, p, "SYSADMIN", parser).mergeInto(systemStore); //$NON-NLS-1$
         TransformationMetadata tm = new TransformationMetadata(vdb, new CompositeMetadataStore(systemStore), null, systemFunctionManager.getSystemFunctions(), null);
-        vdb.addAttchment(QueryMetadataInterface.class, tm);
+        vdb.addAttachment(QueryMetadataInterface.class, tm);
         MetadataValidator validator = new MetadataValidator(this.typeMap, parser);
         ValidatorReport report = validator.validate(vdb, systemStore);
         if (report.hasItems()) {

--- a/engine/src/test/java/org/teiid/dqp/internal/process/TestAuthorizationValidationVisitor.java
+++ b/engine/src/test/java/org/teiid/dqp/internal/process/TestAuthorizationValidationVisitor.java
@@ -217,7 +217,7 @@ public class TestAuthorizationValidationVisitor {
     private DataRolePolicyDecider createPolicyDecider(
             QueryMetadataInterface metadata, VDBMetaData vdb,
             DataPolicyMetadata... roles) {
-        vdb.addAttchment(QueryMetadataInterface.class, metadata);
+        vdb.addAttachment(QueryMetadataInterface.class, metadata);
 
         HashMap<String, DataPolicy> policies = new HashMap<String, DataPolicy>();
         for (DataPolicyMetadata dataPolicyMetadata : roles) {

--- a/engine/src/test/java/org/teiid/dqp/internal/process/TestDQPCore.java
+++ b/engine/src/test/java/org/teiid/dqp/internal/process/TestDQPCore.java
@@ -116,7 +116,7 @@ public class TestDQPCore {
         context.setPolicies(policies);
 
         ConnectorManagerRepository repo = Mockito.mock(ConnectorManagerRepository.class);
-        context.getVDB().addAttchment(ConnectorManagerRepository.class, repo);
+        context.getVDB().addAttachment(ConnectorManagerRepository.class, repo);
         Mockito.stub(repo.getConnectorManager(Mockito.anyString())).toReturn(agds);
         BufferManagerImpl bm = BufferManagerFactory.createBufferManager();
         bm.setInlineLobs(false);

--- a/engine/src/test/java/org/teiid/dqp/internal/process/TestDataTierManager.java
+++ b/engine/src/test/java/org/teiid/dqp/internal/process/TestDataTierManager.java
@@ -129,7 +129,7 @@ public class TestDataTierManager {
 
         ConnectorManagerRepository repo = Mockito.mock(ConnectorManagerRepository.class);
         Mockito.stub(repo.getConnectorManager(Mockito.anyString())).toReturn(connectorManager);
-        vdb.addAttchment(ConnectorManagerRepository.class, repo);
+        vdb.addAttachment(ConnectorManagerRepository.class, repo);
 
         dtm = new DataTierManagerImpl(rm,bs.getBufferManager(), true);
     }

--- a/engine/src/test/java/org/teiid/dqp/internal/process/TestRequest.java
+++ b/engine/src/test/java/org/teiid/dqp/internal/process/TestRequest.java
@@ -124,7 +124,7 @@ public class TestRequest {
             request = new Request();
         }
         ConnectorManagerRepository repo = Mockito.mock(ConnectorManagerRepository.class);
-        workContext.getVDB().addAttchment(ConnectorManagerRepository.class, repo);
+        workContext.getVDB().addAttachment(ConnectorManagerRepository.class, repo);
         Mockito.stub(repo.getConnectorManager(Mockito.anyString())).toReturn(new AutoGenDataService());
 
         request.initialize(message, Mockito.mock(BufferManager.class),

--- a/engine/src/test/java/org/teiid/query/metadata/TestMetadataValidator.java
+++ b/engine/src/test/java/org/teiid/query/metadata/TestMetadataValidator.java
@@ -58,8 +58,8 @@ public class TestMetadataValidator {
 
     private TransformationMetadata buildTransformationMetadata() {
         TransformationMetadata metadata =  new TransformationMetadata(this.vdb, new CompositeMetadataStore(this.store), null, SFM.getSystemFunctions(), null);
-        this.vdb.addAttchment(QueryMetadataInterface.class, metadata);
-        this.vdb.addAttchment(TransformationMetadata.class, metadata);
+        this.vdb.addAttachment(QueryMetadataInterface.class, metadata);
+        this.vdb.addAttachment(TransformationMetadata.class, metadata);
         return metadata;
     }
 
@@ -75,7 +75,7 @@ public class TestMetadataValidator {
         mf.getSchema().setPhysical(physical);
         repo.loadMetadata(mf, null, null, ddl);
         mf.mergeInto(store);
-        model.addAttchment(MetadataFactory.class, mf);
+        model.addAttachment(MetadataFactory.class, mf);
         return model;
     }
 

--- a/engine/src/test/java/org/teiid/query/parser/TestDDLParser.java
+++ b/engine/src/test/java/org/teiid/query/parser/TestDDLParser.java
@@ -365,7 +365,7 @@ public class TestDDLParser {
         ModelMetaData modelOne = new ModelMetaData();
         modelOne.setName("model"); //$NON-NLS-1$
         vdb.addModel(modelOne);
-        vdb.addAttchment(QueryMetadataInterface.class, new BasicQueryMetadata());
+        vdb.addAttachment(QueryMetadataInterface.class, new BasicQueryMetadata());
 
         ValidatorReport report = new MetadataValidator().validate(vdb, s.asMetadataStore());
 
@@ -397,7 +397,7 @@ public class TestDDLParser {
         ModelMetaData modelOne = new ModelMetaData();
         modelOne.setName("model"); //$NON-NLS-1$
         vdb.addModel(modelOne);
-        vdb.addAttchment(QueryMetadataInterface.class, new BasicQueryMetadata());
+        vdb.addAttachment(QueryMetadataInterface.class, new BasicQueryMetadata());
 
         ValidatorReport report = new MetadataValidator().validate(vdb, s.asMetadataStore());
 
@@ -420,7 +420,7 @@ public class TestDDLParser {
         ModelMetaData modelOne = new ModelMetaData();
         modelOne.setName("model"); //$NON-NLS-1$
         vdb.addModel(modelOne);
-        vdb.addAttchment(QueryMetadataInterface.class, new BasicQueryMetadata());
+        vdb.addAttachment(QueryMetadataInterface.class, new BasicQueryMetadata());
 
         ModelMetaData modelTwo = new ModelMetaData();
         modelTwo.setName("model2"); //$NON-NLS-1$
@@ -1820,7 +1820,7 @@ public class TestDDLParser {
         assertNull(primaryKey.getColumns().get(0).getParent());
 
         TransformationMetadata tm = RealMetadataFactory.createTransformationMetadata(mds, "myVDB");
-        vdb.addAttchment(QueryMetadataInterface.class, tm);
+        vdb.addAttachment(QueryMetadataInterface.class, tm);
 
         ValidatorReport report = new MetadataValidator().validate(vdb, s.asMetadataStore());
 
@@ -1853,7 +1853,7 @@ public class TestDDLParser {
         assertNull(primaryKey.getColumns().get(0).getParent());
 
         TransformationMetadata tm = RealMetadataFactory.createTransformationMetadata(mds, "myVDB");
-        vdb.addAttchment(QueryMetadataInterface.class, tm);
+        vdb.addAttachment(QueryMetadataInterface.class, tm);
 
         ValidatorReport report = new MetadataValidator().validate(vdb, s.asMetadataStore());
 

--- a/engine/src/test/java/org/teiid/query/unittest/RealMetadataFactory.java
+++ b/engine/src/test/java/org/teiid/query/unittest/RealMetadataFactory.java
@@ -365,8 +365,8 @@ public class RealMetadataFactory {
             }
         }
         TransformationMetadata metadata = new TransformationMetadata(vdbMetaData, store, null, SFM.getSystemFunctions(), udfs);
-        vdbMetaData.addAttchment(TransformationMetadata.class, metadata);
-        vdbMetaData.addAttchment(QueryMetadataInterface.class, metadata);
+        vdbMetaData.addAttachment(TransformationMetadata.class, metadata);
+        vdbMetaData.addAttachment(QueryMetadataInterface.class, metadata);
         return metadata;
     }
 
@@ -1883,9 +1883,9 @@ public class RealMetadataFactory {
         session.setSessionId(String.valueOf(1));
         session.setUserName("foo"); //$NON-NLS-1$
         session.setVdb(vdb);
-        workContext.getVDB().addAttchment(QueryMetadataInterface.class, metadata);
+        workContext.getVDB().addAttachment(QueryMetadataInterface.class, metadata);
         if (metadata instanceof TransformationMetadata) {
-            workContext.getVDB().addAttchment(TransformationMetadata.class, (TransformationMetadata)metadata);
+            workContext.getVDB().addAttachment(TransformationMetadata.class, (TransformationMetadata)metadata);
         }
         DQPWorkContext.setWorkContext(workContext);
         return workContext;

--- a/metadata/src/test/java/org/teiid/metadata/index/VDBMetadataFactory.java
+++ b/metadata/src/test/java/org/teiid/metadata/index/VDBMetadataFactory.java
@@ -70,7 +70,7 @@ public class VDBMetadataFactory {
             Resource r = imf.resources.getEntriesPlusVisibilities().get("/META-INF/vdb.xml");
             VDBMetaData vdb = null;
             if (r != null) {
-                vdb = VDBMetadataParser.unmarshell(r.openStream());
+                vdb = VDBMetadataParser.unmarshall(r.openStream());
             }
             Collection<FunctionTree> trees = new ArrayList<>();
             for (Schema schema:imf.store.getSchemas().values()) {

--- a/runtime/src/main/java/org/teiid/deployers/CompositeVDB.java
+++ b/runtime/src/main/java/org/teiid/deployers/CompositeVDB.java
@@ -82,7 +82,7 @@ public class CompositeVDB {
         this.originalVDB = vdb;
         this.vdbKey = new VDBKey(originalVDB.getName(), originalVDB.getVersion());
         buildCompositeState(vdbRepository);
-        this.mergedVDB.addAttchment(VDBKey.class, this.vdbKey);
+        this.mergedVDB.addAttachment(VDBKey.class, this.vdbKey);
     }
 
     private static TransformationMetadata buildTransformationMetaData(VDBMetaData vdb,
@@ -141,7 +141,7 @@ public class CompositeVDB {
 
     private void buildCompositeState(VDBRepository vdbRepository) throws VirtualDatabaseException {
         if (vdb.getVDBImports().isEmpty()) {
-            this.vdb.addAttchment(ConnectorManagerRepository.class, this.cmr);
+            this.vdb.addAttachment(ConnectorManagerRepository.class, this.cmr);
             return;
         }
 
@@ -151,7 +151,7 @@ public class CompositeVDB {
             mergedRepo = new ConnectorManagerRepository();
             mergedRepo.getConnectorManagers().putAll(this.cmr.getConnectorManagers());
         }
-        newMergedVDB.addAttchment(ConnectorManagerRepository.class, mergedRepo);
+        newMergedVDB.addAttachment(ConnectorManagerRepository.class, mergedRepo);
         LinkedHashSet<ClassLoader> toSearch = new LinkedHashSet<>(vdb.getVDBImports().size()+1);
         toSearch.add(this.vdb.getAttachment(ClassLoader.class));
         this.children = new LinkedHashMap<VDBKey, CompositeVDB>();
@@ -229,7 +229,7 @@ public class CompositeVDB {
         }
         if (toSearch.iterator().next() != null) {
             CombinedClassLoader ccl = new CombinedClassLoader(toSearch.iterator().next().getParent(), toSearch.toArray(new ClassLoader[toSearch.size()]));
-            this.mergedVDB.addAttchment(ClassLoader.class, ccl);
+            this.mergedVDB.addAttachment(ClassLoader.class, ccl);
         }
         this.mergedVDB = newMergedVDB;
     }
@@ -328,9 +328,9 @@ public class CompositeVDB {
         if(multiSourceModels != null && !multiSourceModels.isEmpty()) {
             qmi = new MultiSourceMetadataWrapper(metadata, multiSourceModels);
         }
-        mergedVDB.addAttchment(QueryMetadataInterface.class, qmi);
-        mergedVDB.addAttchment(TransformationMetadata.class, metadata);
-        mergedVDB.addAttchment(MetadataStore.class, mergedStore);
+        mergedVDB.addAttachment(QueryMetadataInterface.class, qmi);
+        mergedVDB.addAttachment(TransformationMetadata.class, metadata);
+        mergedVDB.addAttachment(MetadataStore.class, mergedStore);
     }
 
     LinkedHashMap<VDBKey, CompositeVDB> getChildren() {

--- a/runtime/src/main/java/org/teiid/deployers/TranslatorUtil.java
+++ b/runtime/src/main/java/org/teiid/deployers/TranslatorUtil.java
@@ -293,7 +293,7 @@ public class TranslatorUtil {
             // ignore
         }
 
-        metadata.addAttchment(ExtendedPropertyMetadataList.class, propertyDefns);
+        metadata.addAttachment(ExtendedPropertyMetadataList.class, propertyDefns);
         return metadata;
     }
 

--- a/runtime/src/main/java/org/teiid/deployers/VDBRepository.java
+++ b/runtime/src/main/java/org/teiid/deployers/VDBRepository.java
@@ -354,10 +354,10 @@ public class VDBRepository implements Serializable{
 
                 // for  replication of events, temp tables and mat views
                 GlobalTableStore gts = CompositeGlobalTableStore.createInstance(v, this.bufferManager, this.objectReplictor);
-                metadataAwareVDB.addAttchment(GlobalTableStore.class, gts);
+                metadataAwareVDB.addAttachment(GlobalTableStore.class, gts);
 
                 if (this.databaseStore != null) {
-                    metadataAwareVDB.addAttchment(DatabaseStore.class, this.databaseStore);
+                    metadataAwareVDB.addAttachment(DatabaseStore.class, this.databaseStore);
                 }
 
                 notifyFinished(name, version, v);

--- a/runtime/src/main/java/org/teiid/deployers/VDBStatusChecker.java
+++ b/runtime/src/main/java/org/teiid/deployers/VDBStatusChecker.java
@@ -213,7 +213,7 @@ public abstract class VDBStatusChecker {
             } else {
                 //mark the model to indicate that it should be reloaded if it
                 //is currently failing a load
-                model.addAttchment(VDBStatusChecker.class, this);
+                model.addAttachment(VDBStatusChecker.class, this);
             }
         }
     }

--- a/runtime/src/main/java/org/teiid/odbc/ODBCServerRemoteImpl.java
+++ b/runtime/src/main/java/org/teiid/odbc/ODBCServerRemoteImpl.java
@@ -315,7 +315,7 @@ public class ODBCServerRemoteImpl implements ODBCServerRemote {
             this.connection =  driver.connect(url, info);
             //Propagate so that we can use in pg methods
             SessionMetadata sm = ((LocalServerConnection)this.connection.getServerConnection()).getWorkContext().getSession();
-            sm.addAttchment(ODBCServerRemoteImpl.class, this);
+            sm.addAttachment(ODBCServerRemoteImpl.class, this);
             setConnectionProperties(this.connection);
             Enumeration<?> keys = this.props.propertyNames();
             while (keys.hasMoreElements()) {

--- a/runtime/src/main/java/org/teiid/runtime/AbstractVDBDeployer.java
+++ b/runtime/src/main/java/org/teiid/runtime/AbstractVDBDeployer.java
@@ -127,7 +127,7 @@ public abstract class AbstractVDBDeployer {
                 repos.add(new MultiSourceMetadataRepository(columnName==null?MultiSourceElement.DEFAULT_MULTI_SOURCE_ELEMENT_NAME:columnName));
                 repo = new ChainingMetadataRepository(repos);
             }
-            model.addAttchment(MetadataRepository.class, repo);
+            model.addAttachment(MetadataRepository.class, repo);
         }
     }
 
@@ -313,7 +313,7 @@ public abstract class AbstractVDBDeployer {
                         if (te != null) {
                             errorMsg += ": " + te.getMessage(); //$NON-NLS-1$
                         }
-                        model.addAttchment(Exception.class, ex);
+                        model.addAttachment(Exception.class, ex);
                         model.addRuntimeError(errorMsg);
                         model.setMetadataStatus(Model.MetadataStatus.FAILED);
                         LogManager.logWarning(LogConstants.CTX_RUNTIME, ex, RuntimePlugin.Util.gs(RuntimePlugin.Event.TEIID50036,vdb.getName(), vdb.getVersion(), model.getName(), errorMsg));

--- a/runtime/src/main/java/org/teiid/runtime/EmbeddedServer.java
+++ b/runtime/src/main/java/org/teiid/runtime/EmbeddedServer.java
@@ -756,7 +756,7 @@ public class EmbeddedServer extends AbstractVDBDeployer implements EventDistribu
                 throw new VirtualDatabaseException(e);
             }
             try {
-                metadata = VDBMetadataParser.unmarshell(new ByteArrayInputStream(bytes));
+                metadata = VDBMetadataParser.unmarshall(new ByteArrayInputStream(bytes));
             } catch (XMLStreamException e) {
                 throw new VirtualDatabaseException(e);
             }
@@ -787,7 +787,7 @@ public class EmbeddedServer extends AbstractVDBDeployer implements EventDistribu
             }
             InputStream is = vdbMetadata.openStream();
             try {
-                metadata = VDBMetadataParser.unmarshell(is);
+                metadata = VDBMetadataParser.unmarshall(is);
             } catch (XMLStreamException e) {
                 throw new VirtualDatabaseException(e);
             }

--- a/runtime/src/main/java/org/teiid/runtime/EmbeddedServer.java
+++ b/runtime/src/main/java/org/teiid/runtime/EmbeddedServer.java
@@ -571,7 +571,7 @@ public class EmbeddedServer extends AbstractVDBDeployer implements EventDistribu
                 }
                 GlobalTableStore gts = CompositeGlobalTableStore.createInstance(vdb, dqp.getBufferManager(), replicator);
 
-                vdb.getVDB().addAttchment(GlobalTableStore.class, gts);
+                vdb.getVDB().addAttachment(GlobalTableStore.class, gts);
             }
 
             @Override
@@ -796,7 +796,7 @@ public class EmbeddedServer extends AbstractVDBDeployer implements EventDistribu
             DeploymentBasedDatabaseStore store = new DeploymentBasedDatabaseStore(getVDBRepository());
             metadata = store.getVDBMetadata(ObjectConverterUtil.convertToString(vdbMetadata.openStream()));
         }
-        metadata.addAttchment(VirtualFile.class, root); //for auto cleanup of zip fs
+        metadata.addAttachment(VirtualFile.class, root); //for auto cleanup of zip fs
         VDBResources resources = new VDBResources(root);
         deployVDB(metadata, resources);
     }
@@ -813,7 +813,7 @@ public class EmbeddedServer extends AbstractVDBDeployer implements EventDistribu
             throw new VirtualDatabaseException(RuntimePlugin.Event.TEIID40106, RuntimePlugin.Util.gs(RuntimePlugin.Event.TEIID40106, vdb.getName()));
         }
 
-        vdb.addAttchment(ClassLoader.class, Thread.currentThread().getContextClassLoader());
+        vdb.addAttachment(ClassLoader.class, Thread.currentThread().getContextClassLoader());
         try {
             createPreParser(vdb);
         } catch (TeiidException e1) {
@@ -1090,7 +1090,7 @@ public class EmbeddedServer extends AbstractVDBDeployer implements EventDistribu
         if (preparserClass != null) {
             ClassLoader vdbClassLoader = deployment.getAttachment(ClassLoader.class);
             PreParser preParser = (PreParser) ReflectionHelper.create(preparserClass, Collections.emptyList(), vdbClassLoader);
-            deployment.addAttchment(PreParser.class, preParser);
+            deployment.addAttachment(PreParser.class, preParser);
         }
     }
 

--- a/runtime/src/main/java/org/teiid/runtime/util/ConvertVDB.java
+++ b/runtime/src/main/java/org/teiid/runtime/util/ConvertVDB.java
@@ -131,7 +131,7 @@ public class ConvertVDB {
             byte[] bytes = ObjectConverterUtil.convertToByteArray(is);
             VDBMetaData metadata = null;
             try {
-                metadata = VDBMetadataParser.unmarshell(new ByteArrayInputStream(bytes));
+                metadata = VDBMetadataParser.unmarshall(new ByteArrayInputStream(bytes));
             } catch (XMLStreamException e) {
                 throw new VirtualDatabaseException(e);
             }

--- a/runtime/src/main/java/org/teiid/services/SessionServiceImpl.java
+++ b/runtime/src/main/java/org/teiid/services/SessionServiceImpl.java
@@ -268,7 +268,7 @@ public class SessionServiceImpl implements SessionService {
                     LogManager.logDetail(LogConstants.CTX_SECURITY, "Value for max sessions is invalid on", vdb); //$NON-NLS-1$
                 }
             }
-            vdb.addAttchment(MaxSessions.class, max);
+            vdb.addAttachment(MaxSessions.class, max);
         }
         if (max.val == null || max.val < 0) {
             return;

--- a/runtime/src/test/java/org/teiid/deployers/TestCompositeGlobalTableStore.java
+++ b/runtime/src/test/java/org/teiid/deployers/TestCompositeGlobalTableStore.java
@@ -47,7 +47,7 @@ public class TestCompositeGlobalTableStore {
         ms.addSchema(s);
         CompositeVDB imported = TestCompositeVDB.createCompositeVDB(ms, "foo");
         GlobalTableStore gts1 = Mockito.mock(GlobalTableStore.class);
-        imported.getVDB().addAttchment(GlobalTableStore.class, gts1);
+        imported.getVDB().addAttachment(GlobalTableStore.class, gts1);
         vdb.getChildren().put(new VDBKey("foo1", 1), imported);
 
         CompositeGlobalTableStore cgts = (CompositeGlobalTableStore)CompositeGlobalTableStore.createInstance(vdb, BufferManagerFactory.getStandaloneBufferManager(), null);

--- a/runtime/src/test/java/org/teiid/deployers/TestCompositeVDB.java
+++ b/runtime/src/test/java/org/teiid/deployers/TestCompositeVDB.java
@@ -58,7 +58,7 @@ public class TestCompositeVDB {
 
     public static CompositeVDB createCompositeVDB(MetadataStore metadataStore,    String vdbName) throws VirtualDatabaseException {
         VDBMetaData vdbMetaData = createVDBMetadata(metadataStore, vdbName);
-        vdbMetaData.addAttchment(Foo.class, new Foo());
+        vdbMetaData.addAttachment(Foo.class, new Foo());
         ConnectorManagerRepository cmr = new ConnectorManagerRepository();
         cmr.addConnectorManager("source", getConnectorManager("FakeTranslator", "FakeConnection", getFuncsOne()));
         cmr.addConnectorManager("source2", getConnectorManager("FakeTranslator2", "FakeConnection2", getFuncsTwo()));

--- a/runtime/src/test/java/org/teiid/services/TestSessionServiceImpl.java
+++ b/runtime/src/test/java/org/teiid/services/TestSessionServiceImpl.java
@@ -228,7 +228,7 @@ public class TestSessionServiceImpl {
         vdb.setVersion(1);
         vdb.setStatus(Status.ACTIVE);
         vdb.addProperty(SessionServiceImpl.MAX_SESSIONS_PER_USER, "1");
-        vdb.addAttchment(VDBKey.class, new VDBKey("x", 1));
+        vdb.addAttachment(VDBKey.class, new VDBKey("x", 1));
 
         Mockito.stub(repo.getLiveVDB("name", "1")).toReturn(vdb);
 

--- a/wildfly/rest-service/src/test/java/org/teiid/jboss/rest/TestRestWebArchiveBuilder.java
+++ b/wildfly/rest-service/src/test/java/org/teiid/jboss/rest/TestRestWebArchiveBuilder.java
@@ -74,7 +74,7 @@ public class TestRestWebArchiveBuilder {
     }
 
     private VDBMetaData getTestVDBMetaData() throws FileNotFoundException, XMLStreamException {
-        VDBMetaData vdb = VDBMetadataParser.unmarshell(new FileInputStream(UnitTestUtil.getTestDataFile("sample-vdb.xml")));
+        VDBMetaData vdb = VDBMetadataParser.unmarshall(new FileInputStream(UnitTestUtil.getTestDataFile("sample-vdb.xml")));
         MetadataStore ms = new MetadataStore();
         for (ModelMetaData model: vdb.getModelMetaDatas().values()) {
             MetadataFactory mf = TestDDLParser.helpParse(model.getSchemaText(), model.getName());

--- a/wildfly/rest-service/src/test/java/org/teiid/jboss/rest/TestRestWebArchiveBuilder.java
+++ b/wildfly/rest-service/src/test/java/org/teiid/jboss/rest/TestRestWebArchiveBuilder.java
@@ -82,9 +82,9 @@ public class TestRestWebArchiveBuilder {
         }
 
         TransformationMetadata metadata = RealMetadataFactory.createTransformationMetadata(ms, "Rest");
-        vdb.addAttchment(QueryMetadataInterface.class, metadata);
-        vdb.addAttchment(TransformationMetadata.class, metadata);
-        vdb.addAttchment(MetadataStore.class, ms);
+        vdb.addAttachment(QueryMetadataInterface.class, metadata);
+        vdb.addAttachment(TransformationMetadata.class, metadata);
+        vdb.addAttachment(MetadataStore.class, ms);
         return vdb;
     }
 

--- a/wildfly/test-integration/common/src/test/java/org/teiid/jdbc/FakeServer.java
+++ b/wildfly/test-integration/common/src/test/java/org/teiid/jdbc/FakeServer.java
@@ -179,7 +179,7 @@ public class FakeServer extends EmbeddedServer {
                 for (Schema schema : metadata.getSchemas().values()) {
                     ModelMetaData model = addModel(vdbMetaData, schema);
                     if (parameterObject.metadataRepo != null) {
-                        model.addAttchment(MetadataRepository.class, parameterObject.metadataRepo);
+                        model.addAttachment(MetadataRepository.class, parameterObject.metadataRepo);
                         //fakeserver does not load through the repository framework, so call load after the fact here.
                         MetadataFactory mf = createMetadataFactory(vdbMetaData, metadata, model, parameterObject.vdbResources);
                         mf.setSchema(schema);

--- a/wildfly/test-integration/common/src/test/java/org/teiid/jdbc/FakeServer.java
+++ b/wildfly/test-integration/common/src/test/java/org/teiid/jdbc/FakeServer.java
@@ -169,7 +169,7 @@ public class FakeServer extends EmbeddedServer {
             if (parameterObject.vdbResources != null && parameterObject.useVdbXml) {
                 VDBResource resource = parameterObject.vdbResources.get("/META-INF/vdb.xml");
                 if (resource !=null) {
-                    vdbMetaData = VDBMetadataParser.unmarshell(resource.openStream());
+                    vdbMetaData = VDBMetadataParser.unmarshall(resource.openStream());
                 }
             }
             if (vdbMetaData == null) {

--- a/wildfly/wildfly-admin/src/test/java/org/teiid/adminapi/jboss/TestVDBMetaData.java
+++ b/wildfly/wildfly-admin/src/test/java/org/teiid/adminapi/jboss/TestVDBMetaData.java
@@ -38,7 +38,7 @@ import org.teiid.core.util.UnitTestUtil;
 public class TestVDBMetaData {
 
     @Test
-    public void testMarshellUnmarshellDirectParsing() throws Exception {
+    public void testMarshellUnmarshallDirectParsing() throws Exception {
 
         VDBMetaData vdb = TestVDBUtility.buildVDB();
 
@@ -47,8 +47,8 @@ public class TestVDBMetaData {
 
         //System.out.println(new String(out.toByteArray()));
 
-        // UnMarshell
-        vdb = VDBMetadataParser.unmarshell(new ByteArrayInputStream(out.toByteArray()));
+        // Unmarshall
+        vdb = VDBMetadataParser.unmarshall(new ByteArrayInputStream(out.toByteArray()));
 
         TestVDBUtility.validateVDB(vdb);
     }

--- a/wildfly/wildfly-integration/src/main/java/org/teiid/jboss/TranslatorAdd.java
+++ b/wildfly/wildfly-integration/src/main/java/org/teiid/jboss/TranslatorAdd.java
@@ -97,7 +97,7 @@ class TranslatorAdd extends AbstractAddStepHandler {
                     throw new OperationFailedException(IntegrationPlugin.Util.gs(IntegrationPlugin.Event.TEIID50008, translatorName));
                 }
 
-                metadata.addAttchment(ClassLoader.class, translatorLoader);
+                metadata.addAttachment(ClassLoader.class, translatorLoader);
                 if (translatorName.equalsIgnoreCase(metadata.getName())) {
                     LogManager.logInfo(LogConstants.CTX_RUNTIME, IntegrationPlugin.Util.gs(IntegrationPlugin.Event.TEIID50006, metadata.getName()));
 

--- a/wildfly/wildfly-integration/src/main/java/org/teiid/jboss/TranslatorDeployer.java
+++ b/wildfly/wildfly-integration/src/main/java/org/teiid/jboss/TranslatorDeployer.java
@@ -67,7 +67,7 @@ public final class TranslatorDeployer implements DeploymentUnitProcessor {
                 }
                 deploymentUnit.putAttachment(TeiidAttachments.TRANSLATOR_METADATA, metadata);
                 metadata.addProperty(TranslatorUtil.DEPLOYMENT_NAME, moduleName);
-                metadata.addAttchment(ClassLoader.class, translatorLoader);
+                metadata.addAttachment(ClassLoader.class, translatorLoader);
 
                 LogManager.logInfo(LogConstants.CTX_RUNTIME, IntegrationPlugin.Util.gs(IntegrationPlugin.Event.TEIID50006, metadata.getName()));
 

--- a/wildfly/wildfly-integration/src/main/java/org/teiid/jboss/VDBDependencyDeployer.java
+++ b/wildfly/wildfly-integration/src/main/java/org/teiid/jboss/VDBDependencyDeployer.java
@@ -60,7 +60,7 @@ class VDBDependencyDeployer implements DeploymentUnitProcessor {
 
         final VDBMetaData deployment = deploymentUnit.getAttachment(TeiidAttachments.VDB_METADATA);
         ServiceModuleLoader sml = deploymentUnit.getAttachment(Attachments.SERVICE_MODULE_LOADER);
-        deployment.addAttchment(ServiceModuleLoader.class, sml);
+        deployment.addAttachment(ServiceModuleLoader.class, sml);
         ArrayList<ModuleDependency> localDependencies = new ArrayList<ModuleDependency>();
         ArrayList<ModuleDependency> userDependencies = new ArrayList<ModuleDependency>();
         String moduleNames = deployment.getPropertyValue("lib"); //$NON-NLS-1$

--- a/wildfly/wildfly-integration/src/main/java/org/teiid/jboss/VDBDeployer.java
+++ b/wildfly/wildfly-integration/src/main/java/org/teiid/jboss/VDBDeployer.java
@@ -134,8 +134,8 @@ class VDBDeployer implements DeploymentUnitProcessor {
 
         // add VDB module's classloader as an attachment
         ModuleClassLoader classLoader = deploymentUnit.getAttachment(Attachments.MODULE).getClassLoader();
-        deployment.addAttchment(ClassLoader.class, classLoader);
-        deployment.addAttchment(ScriptEngineManager.class, new ScriptEngineManager(classLoader));
+        deployment.addAttachment(ClassLoader.class, classLoader);
+        deployment.addAttachment(ScriptEngineManager.class, new ScriptEngineManager(classLoader));
 
         try {
             EmbeddedServer.createPreParser(deployment);
@@ -145,7 +145,7 @@ class VDBDeployer implements DeploymentUnitProcessor {
 
         UDFMetaData udf = new UDFMetaData();
         udf.setFunctionClassLoader(classLoader);
-        deployment.addAttchment(UDFMetaData.class, udf);
+        deployment.addAttachment(UDFMetaData.class, udf);
 
         VirtualFile file = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_ROOT).getRoot();
         VDBResources resources;

--- a/wildfly/wildfly-integration/src/main/java/org/teiid/jboss/VDBParserDeployer.java
+++ b/wildfly/wildfly-integration/src/main/java/org/teiid/jboss/VDBParserDeployer.java
@@ -112,11 +112,11 @@ class VDBParserDeployer implements DeploymentUnitProcessor {
             PropertyResolver propertyResolver = deploymentUnit.getAttachment(org.jboss.as.ee.metadata.property.Attachments.FINAL_PROPERTY_RESOLVER);
             PropertyReplacer replacer = PropertyReplacers.resolvingReplacer(propertyResolver);
             String vdbContents = replacer.replaceProperties(ObjectConverterUtil.convertToString(file.openStream()));
-            VDBMetaData vdb = VDBMetadataParser.unmarshell(new ByteArrayInputStream(vdbContents.getBytes("UTF-8"))); //$NON-NLS-1$
+            VDBMetaData vdb = VDBMetadataParser.unmarshall(new ByteArrayInputStream(vdbContents.getBytes("UTF-8"))); //$NON-NLS-1$
             ServiceController<?> sc = phaseContext.getServiceRegistry().getService(TeiidServiceNames.OBJECT_SERIALIZER);
             ObjectSerializer serializer = ObjectSerializer.class.cast(sc.getValue());
             if (serializer.buildVdbXml(vdb).exists()) {
-                vdb = VDBMetadataParser.unmarshell(new FileInputStream(serializer.buildVdbXml(vdb)));
+                vdb = VDBMetadataParser.unmarshall(new FileInputStream(serializer.buildVdbXml(vdb)));
             }
             vdb.setStatus(Status.LOADING);
             if (xmlDeployment) {
@@ -156,7 +156,7 @@ class VDBParserDeployer implements DeploymentUnitProcessor {
 
             // if there is persisted one, let that be XML version for now.
             if (serializer.buildVdbXml(vdb).exists()) {
-                vdb = VDBMetadataParser.unmarshell(new FileInputStream(serializer.buildVdbXml(vdb)));
+                vdb = VDBMetadataParser.unmarshall(new FileInputStream(serializer.buildVdbXml(vdb)));
             }
 
             vdb.setStatus(Status.LOADING);

--- a/wildfly/wildfly-integration/src/main/java/org/teiid/jboss/VDBService.java
+++ b/wildfly/wildfly-integration/src/main/java/org/teiid/jboss/VDBService.java
@@ -93,7 +93,7 @@ class VDBService extends AbstractVDBDeployer implements Service<RuntimeVDB> {
         ConnectorManagerRepository cmr = new ConnectorManagerRepository();
         TranslatorRepository repo = new TranslatorRepository();
 
-        this.vdb.addAttchment(TranslatorRepository.class, repo);
+        this.vdb.addAttachment(TranslatorRepository.class, repo);
 
         // check if this is a VDB with index files, if there are then build the TransformationMetadata
         UDFMetaData udf = this.vdb.getAttachment(UDFMetaData.class);
@@ -105,7 +105,7 @@ class VDBService extends AbstractVDBDeployer implements Service<RuntimeVDB> {
             String type = data.getType();
             VDBTranslatorMetaData parent = getTranslatorRepository().getTranslatorMetaData(type);
             data.setModuleName(parent.getModuleName());
-            data.addAttchment(ClassLoader.class, parent.getAttachment(ClassLoader.class));
+            data.addAttachment(ClassLoader.class, parent.getAttachment(ClassLoader.class));
             data.setParent(parent);
             repo.addTranslatorMetadata(data.getName(), data);
         }
@@ -396,7 +396,7 @@ class VDBService extends AbstractVDBDeployer implements Service<RuntimeVDB> {
             getExecutor().execute(wrap(job));
         } else {
             //defer the load to the status checker if/when a source is available/redeployed
-            model.addAttchment(Runnable.class, wrap(job));
+            model.addAttachment(Runnable.class, wrap(job));
         }
     }
 }


### PR DESCRIPTION
I changed a couple of methods to fix spelling. I left deprecated wrappers in order to keep the API stable.
