### PR TITLE
TEIID-5798 adding the concept of a row policy

### DIFF
--- a/api/src/main/java/org/teiid/connector/DataPlugin.java
+++ b/api/src/main/java/org/teiid/connector/DataPlugin.java
@@ -65,6 +65,8 @@ public class DataPlugin {
         TEIID60037,
         TEIID60038,
         TEIID60039,
-        TEIID60040
+        TEIID60040,
+        TEIID60041,
+        TEIID60042
     }
 }

--- a/api/src/main/java/org/teiid/language/SQLConstants.java
+++ b/api/src/main/java/org/teiid/language/SQLConstants.java
@@ -196,6 +196,9 @@ public class SQLConstants {
 
         static final String EPOCH = "EPOCH"; //$NON-NLS-1$
         static final String QUARTER = "QUARTER"; //$NON-NLS-1$
+
+        //policy
+        static final String POLICY = "POLICY"; //$NON-NLS-1$
     }
 
     public interface Reserved {

--- a/api/src/main/java/org/teiid/metadata/Grant.java
+++ b/api/src/main/java/org/teiid/metadata/Grant.java
@@ -17,232 +17,31 @@
  */
 package org.teiid.metadata;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.List;
-
-import org.teiid.metadata.Database.ResourceType;
-
+/**
+ * Represents a grant / revoke.  We do not yet store grants, just permissions,
+ * as there is no identity to the grantor.
+ */
 public class Grant extends AbstractMetadataRecord {
     private static final long serialVersionUID = 3728259393244582775L;
 
-    public static class Permission {
-        public enum Privilege {
-            SELECT, INSERT, UPDATE, DELETE, EXECUTE,
-            ALTER, DROP,
-            USAGE,
-            ALL_PRIVILEGES("ALL PRIVILEGES"), //$NON-NLS-1$
-            TEMPORARY_TABLE("TEMPORARY TABLE"), //$NON-NLS-1$
-            CREATE;
-
-            private final String toString;
-
-            Privilege(String toString) {
-                this.toString = toString;
-            }
-
-            Privilege() {
-                this.toString = name();
-            }
-
-            public String toString() {
-                return toString;
-            }
-        }
-        private Database.ResourceType resourceType= null;
-        private String resource = null;
-        private String mask = null;
-        private Integer maskOrder;
-        private String condition = null;
-        private Boolean isConstraint;
-        private EnumSet<Privilege> privileges = EnumSet.noneOf(Privilege.class);
-        private EnumSet<Privilege> revokePrivileges = EnumSet.noneOf(Privilege.class);
-
-        /**
-         * The {@link org.teiid.adminapi.DataPolicy.ResourceType}, never null.  Will default
-         * to DATABASE
-         * @return
-         */
-        public Database.ResourceType getResourceType() {
-            if (resourceType == null) {
-                return ResourceType.DATABASE;
-            }
-            return resourceType;
-        }
-
-        public void setResourceType(Database.ResourceType on) {
-            this.resourceType = on;
-        }
-
-        public String getResourceName() {
-            return resource;
-        }
-
-        public void setResourceName(String resource) {
-            this.resource = resource;
-        }
-
-        public String getMask() {
-            return mask;
-        }
-
-        public void setMask(String mask) {
-            this.mask = mask;
-        }
-
-        public Integer getMaskOrder() {
-            return maskOrder;
-        }
-
-        public void setMaskOrder(Integer maskOrder) {
-            this.maskOrder = maskOrder;
-        }
-
-        public String getCondition() {
-            return condition;
-        }
-
-        public void setCondition(String condition, Boolean isConstraint) {
-            this.condition = condition;
-            this.isConstraint = isConstraint;
-        }
-
-        public Boolean isConditionAConstraint() {
-            return isConstraint;
-        }
-
-        public EnumSet<Privilege> getPrivileges() {
-            return privileges;
-        }
-
-        public EnumSet<Privilege> getRevokePrivileges() {
-            return revokePrivileges;
-        }
-
-        public Boolean hasPrivilege(Privilege allow) {
-            if (this.privileges.contains(allow)) {
-                return true;
-            }
-            if (this.revokePrivileges.contains(allow)) {
-                return false;
-            }
-            return null;
-        }
-
-        public void setPrivileges(List<Privilege> types) {
-            if (types == null ||types.isEmpty()) {
-                return;
-            }
-            this.privileges = EnumSet.copyOf(types);
-        }
-
-        public void setRevokePrivileges(List<Privilege> types) {
-            if (types == null ||types.isEmpty()) {
-                return;
-            }
-            this.revokePrivileges = EnumSet.copyOf(types);
-        }
-
-        public void appendPrivileges(EnumSet<Privilege> types) {
-            if (types == null ||types.isEmpty()) {
-                return;
-            }
-            for (Privilege a:types) {
-                this.privileges.add(a);
-                this.revokePrivileges.remove(a);
-            }
-        }
-
-        public void removePrivileges(EnumSet<Privilege> types) {
-            if (types == null ||types.isEmpty()) {
-                return;
-            }
-            for (Privilege a:types) {
-                if (!this.privileges.remove(a)) {
-                    this.revokePrivileges.add(a);
-                }
-            }
-        }
-
-        private void setAllows(Boolean allow, Privilege privilege) {
-            if(allow!= null) {
-                if (allow) {
-                    this.revokePrivileges.remove(privilege);
-                    this.privileges.add(privilege);
-                } else {
-                    if (!this.privileges.remove(privilege)) {
-                        this.revokePrivileges.add(privilege);
-                    }
-                }
-            }
-        }
-
-        public void setAllowSelect(Boolean allow) {
-            setAllows(allow, Privilege.SELECT);
-        }
-
-        public void setAllowAlter(Boolean allow) {
-            setAllows(allow, Privilege.ALTER);
-        }
-
-        public void setAllowInsert(Boolean allow) {
-            setAllows(allow, Privilege.INSERT);
-        }
-
-        public void setAllowDelete(Boolean allow) {
-            setAllows(allow, Privilege.DELETE);
-        }
-
-        public void setAllowExecute(Boolean allow) {
-            setAllows(allow, Privilege.EXECUTE);
-        }
-
-        public void setAllowUpdate(Boolean allow) {
-            setAllows(allow, Privilege.UPDATE);
-        }
-
-        public void setAllowDrop(Boolean allow) {
-            setAllows(allow, Privilege.DROP);
-        }
-
-        public void setAllowUsage(Boolean allow) {
-            setAllows(allow, Privilege.USAGE);
-        }
-        public void setAllowAllPrivileges(Boolean allow) {
-            setAllows(allow, Privilege.ALL_PRIVILEGES);
-        }
-        public void setAllowTemporyTables(Boolean allow) {
-            setAllows(allow, Privilege.TEMPORARY_TABLE);
-        }
-
-        public boolean resourceMatches(Permission other) {
-            if (getResourceType() != other.getResourceType()) {
-                return false;
-            }
-            if (resource == null && other.resource == null) {
-                return true;
-            }
-            if (resource != null && other.resource != null && resource.equalsIgnoreCase(other.resource)) {
-                return true;
-            }
-            return false;
-        }
-    }
-
-    protected List<Permission> permissions = new ArrayList<Permission>();
+    //private String grantor;
     private String role;
+    private Permission permission;
 
-    public Collection<Grant.Permission> getPermissions() {
-        return this.permissions;
+    public Grant() {
     }
 
-    public void addPermission(Grant.Permission permission) {
-        this.permissions.add(permission);
+    public Grant(String role, Permission permission) {
+        this.role = role;
+        this.permission = permission;
     }
 
-    void removePermission(Grant.Permission permission) {
-        this.permissions.remove(permission);
+    public Permission getPermission() {
+        return permission;
+    }
+
+    public void setPermission(Permission permission) {
+        this.permission = permission;
     }
 
     public String getRole() {

--- a/api/src/main/java/org/teiid/metadata/Permission.java
+++ b/api/src/main/java/org/teiid/metadata/Permission.java
@@ -1,0 +1,199 @@
+package org.teiid.metadata;
+
+import java.util.EnumSet;
+import java.util.List;
+
+import org.teiid.metadata.Database.ResourceType;
+
+public class Permission extends AbstractMetadataRecord {
+    private static final long serialVersionUID = -1445856249500105877L;
+
+    public enum Privilege {
+        SELECT, INSERT, UPDATE, DELETE, EXECUTE,
+        ALTER, DROP,
+        USAGE,
+        ALL_PRIVILEGES("ALL PRIVILEGES"), //$NON-NLS-1$
+        TEMPORARY_TABLE("TEMPORARY TABLE"), //$NON-NLS-1$
+        CREATE;
+
+        private final String toString;
+
+        Privilege(String toString) {
+            this.toString = toString;
+        }
+
+        Privilege() {
+            this.toString = name();
+        }
+
+        public String toString() {
+            return toString;
+        }
+    }
+    private Database.ResourceType resourceType= null;
+    private String resource = null;
+    private String mask = null;
+    private Integer maskOrder;
+    private String condition = null;
+    private Boolean isConstraint;
+    private EnumSet<Permission.Privilege> privileges = EnumSet.noneOf(Permission.Privilege.class);
+    private EnumSet<Permission.Privilege> revokePrivileges = EnumSet.noneOf(Permission.Privilege.class);
+
+    /**
+     * The {@link org.teiid.adminapi.DataPolicy.ResourceType}, never null.  Will default
+     * to DATABASE
+     * @return
+     */
+    public Database.ResourceType getResourceType() {
+        if (resourceType == null) {
+            return ResourceType.DATABASE;
+        }
+        return resourceType;
+    }
+
+    public void setResourceType(Database.ResourceType on) {
+        this.resourceType = on;
+    }
+
+    public String getResourceName() {
+        return resource;
+    }
+
+    public void setResourceName(String resource) {
+        this.resource = resource;
+    }
+
+    public String getMask() {
+        return mask;
+    }
+
+    public void setMask(String mask) {
+        this.mask = mask;
+    }
+
+    public Integer getMaskOrder() {
+        return maskOrder;
+    }
+
+    public void setMaskOrder(Integer maskOrder) {
+        this.maskOrder = maskOrder;
+    }
+
+    public String getCondition() {
+        return condition;
+    }
+
+    public void setCondition(String condition, Boolean isConstraint) {
+        this.condition = condition;
+        this.isConstraint = isConstraint;
+    }
+
+    public Boolean isConditionAConstraint() {
+        return isConstraint;
+    }
+
+    public EnumSet<Permission.Privilege> getPrivileges() {
+        return privileges;
+    }
+
+    public EnumSet<Permission.Privilege> getRevokePrivileges() {
+        return revokePrivileges;
+    }
+
+    public Boolean hasPrivilege(Permission.Privilege allow) {
+        if (this.privileges.contains(allow)) {
+            return true;
+        }
+        if (this.revokePrivileges.contains(allow)) {
+            return false;
+        }
+        return null;
+    }
+
+    public void setPrivileges(List<Permission.Privilege> types) {
+        if (types == null ||types.isEmpty()) {
+            return;
+        }
+        this.privileges = EnumSet.copyOf(types);
+    }
+
+    public void setRevokePrivileges(List<Permission.Privilege> types) {
+        if (types == null ||types.isEmpty()) {
+            return;
+        }
+        this.revokePrivileges = EnumSet.copyOf(types);
+    }
+
+    public void appendPrivileges(EnumSet<Permission.Privilege> types) {
+        if (types == null ||types.isEmpty()) {
+            return;
+        }
+        for (Permission.Privilege a:types) {
+            this.privileges.add(a);
+            this.revokePrivileges.remove(a);
+        }
+    }
+
+    public void removePrivileges(EnumSet<Permission.Privilege> types) {
+        if (types == null ||types.isEmpty()) {
+            return;
+        }
+        for (Permission.Privilege a:types) {
+            if (!this.privileges.remove(a)) {
+                this.revokePrivileges.add(a);
+            }
+        }
+    }
+
+    private void setAllows(Boolean allow, Permission.Privilege privilege) {
+        if(allow!= null) {
+            if (allow) {
+                this.revokePrivileges.remove(privilege);
+                this.privileges.add(privilege);
+            } else {
+                if (!this.privileges.remove(privilege)) {
+                    this.revokePrivileges.add(privilege);
+                }
+            }
+        }
+    }
+
+    public void setAllowSelect(Boolean allow) {
+        setAllows(allow, Privilege.SELECT);
+    }
+
+    public void setAllowAlter(Boolean allow) {
+        setAllows(allow, Privilege.ALTER);
+    }
+
+    public void setAllowInsert(Boolean allow) {
+        setAllows(allow, Privilege.INSERT);
+    }
+
+    public void setAllowDelete(Boolean allow) {
+        setAllows(allow, Privilege.DELETE);
+    }
+
+    public void setAllowExecute(Boolean allow) {
+        setAllows(allow, Privilege.EXECUTE);
+    }
+
+    public void setAllowUpdate(Boolean allow) {
+        setAllows(allow, Privilege.UPDATE);
+    }
+
+    public void setAllowDrop(Boolean allow) {
+        setAllows(allow, Privilege.DROP);
+    }
+
+    public void setAllowUsage(Boolean allow) {
+        setAllows(allow, Privilege.USAGE);
+    }
+    public void setAllowAllPrivileges(Boolean allow) {
+        setAllows(allow, Privilege.ALL_PRIVILEGES);
+    }
+    public void setAllowTemporyTables(Boolean allow) {
+        setAllows(allow, Privilege.TEMPORARY_TABLE);
+    }
+
+}

--- a/api/src/main/java/org/teiid/metadata/Policy.java
+++ b/api/src/main/java/org/teiid/metadata/Policy.java
@@ -1,0 +1,57 @@
+package org.teiid.metadata;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class Policy extends AbstractMetadataRecord {
+
+    public static enum Operation {
+        ALL,
+        SELECT,
+        INSERT,
+        UPDATE,
+        DELETE
+    }
+
+    private static final long serialVersionUID = 6571225750196709855L;
+
+    private Database.ResourceType resourceType;
+    private String resourceName;
+    private String condition;
+    private Set<Operation> operations = new LinkedHashSet<>(1);
+
+    public Database.ResourceType getResourceType() {
+        return resourceType;
+    }
+
+    public void setResourceType(Database.ResourceType resourceType) {
+        this.resourceType = resourceType;
+    }
+
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    public void setResourceName(String resource) {
+        this.resourceName = resource;
+    }
+
+    public String getCondition() {
+        return condition;
+    }
+
+    public void setCondition(String condition) {
+        this.condition = condition;
+    }
+
+    public Set<Operation> getOperations() {
+        return operations;
+    }
+
+    public boolean appliesTo(Operation operation) {
+        return operations.isEmpty() || operations.contains(operation) || operations.contains(Operation.ALL);
+    }
+
+    //TODO: should this set the role (or resource) as parent
+
+}

--- a/api/src/main/java/org/teiid/metadata/Role.java
+++ b/api/src/main/java/org/teiid/metadata/Role.java
@@ -18,12 +18,74 @@
 package org.teiid.metadata;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.teiid.connector.DataPlugin;
+import org.teiid.metadata.Database.ResourceType;
 
 public class Role extends AbstractMetadataRecord {
+
+    public static class ResourceKey implements Comparable<ResourceKey> {
+        private String name;
+        private ResourceType type;
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name==null?13:name.toLowerCase(), type);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof ResourceKey)) {
+                return false;
+            }
+            ResourceKey other = (ResourceKey)obj;
+            return name.equalsIgnoreCase(other.name)
+                    && Objects.equals(type, other.type);
+        }
+
+        public static ResourceKey of(String name, ResourceType type) {
+            ResourceKey key = new ResourceKey();
+            key.name = name;
+            key.type = type==null?ResourceType.DATABASE:type;
+            return key;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public ResourceType getType() {
+            return type;
+        }
+
+        @Override
+        public int compareTo(ResourceKey other) {
+            int result = String.CASE_INSENSITIVE_ORDER.compare(name, other.name);
+            if (result == 0) {
+                return type.compareTo(other.type);
+            }
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return type + " " + name; //$NON-NLS-1$
+        }
+    }
+
     private static final long serialVersionUID = 1379125260214964302L;
     private List<String> mappedRoles;
     private boolean anyAuthenticated;
+
+    private Map<ResourceKey, Permission> grants = new LinkedHashMap<>();
+    private Map<ResourceKey, Map<String, Policy>> policies = new LinkedHashMap<>();
 
     public Role(String name) {
         super.setName(name);
@@ -51,4 +113,104 @@ public class Role extends AbstractMetadataRecord {
     public void setAnyAuthenticated(boolean b) {
         this.anyAuthenticated = b;
     }
+
+
+    public Map<ResourceKey, Permission> getGrants() {
+        return grants;
+    }
+
+    public Map<ResourceKey, Map<String, Policy>> getPolicies() {
+        return policies;
+    }
+
+    public void addGrant(Permission grant) {
+        if (grant == null) {
+            return;
+        }
+        ResourceKey key = ResourceKey.of(grant.getResourceName(), grant.getResourceType());
+        Permission previous = this.grants.get(key);
+        if (previous == null) {
+            this.grants.put(key, grant);
+        } else {
+            if (grant.getMask() != null) {
+                if (previous.getMask() != null) {
+                    throw new MetadataException(DataPlugin.Event.TEIID60035, DataPlugin.Util.gs(DataPlugin.Event.TEIID60035, grant.getMask(), previous.getMask()));
+                }
+                previous.setMask(grant.getMask());
+                previous.setMaskOrder(grant.getMaskOrder());
+            }
+            if (grant.getCondition() != null) {
+                if (previous.getCondition() != null) {
+                    throw new MetadataException(DataPlugin.Event.TEIID60036, DataPlugin.Util.gs(DataPlugin.Event.TEIID60036, grant.getCondition(), previous.getCondition()));
+                }
+                previous.setCondition(previous.getCondition(), grant.isConditionAConstraint());
+            }
+            previous.appendPrivileges(grant.getPrivileges());
+        }
+    }
+
+    public void removeGrant(Permission toRemoveGrant) {
+        if (toRemoveGrant == null) {
+            return;
+        }
+        ResourceKey key = ResourceKey.of(toRemoveGrant.getResourceName(), toRemoveGrant.getResourceType());
+        Permission previous = this.grants.get(key);
+        if (previous == null) {
+            this.grants.put(key, toRemoveGrant);
+        } else {
+            if (toRemoveGrant.getMask() != null) {
+                if (previous.getMask() != null) {
+                    previous.setMask(null);
+                    previous.setMaskOrder(null);
+                } else {
+                    //TODO: could be exception
+                }
+            }
+            if (toRemoveGrant.getCondition() != null) {
+                if (previous.getCondition() != null) {
+                    previous.setCondition(null, null);
+                } else {
+                    //TODO: could be exception
+                }
+            }
+            previous.removePrivileges(toRemoveGrant.getRevokePrivileges());
+            if (previous.getPrivileges().isEmpty()
+                    && previous.getRevokePrivileges().isEmpty()
+                    && previous.getCondition() == null
+                    && previous.getMask() == null) {
+                this.grants.remove(key);
+            }
+        }
+    }
+
+    public void addPolicy(Policy policy) {
+        ResourceKey key = ResourceKey.of(policy.getResourceName(), policy.getResourceType());
+        Map<String, Policy> resourcePolicies = policies.computeIfAbsent(key, (k)->{return new LinkedHashMap<>();});
+        if (resourcePolicies.put(policy.getName(), policy) != null) {
+            throw new MetadataException(DataPlugin.Event.TEIID60041, DataPlugin.Util.gs(DataPlugin.Event.TEIID60041, policy.getName(), getName(), policy.getResourceName()));
+        }
+    }
+
+    public void removePolicy(Policy policy) {
+        ResourceKey key = ResourceKey.of(policy.getResourceName(), policy.getResourceType());
+        Map<String, Policy> resourcePolicies = policies.get(key);
+        if (resourcePolicies == null) {
+            throw new MetadataException(DataPlugin.Event.TEIID60042, DataPlugin.Util.gs(DataPlugin.Event.TEIID60042, policy.getName(), getName(), policy.getResourceName()));
+        }
+        if (resourcePolicies.remove(policy.getName()) == null) {
+            throw new MetadataException(DataPlugin.Event.TEIID60042, DataPlugin.Util.gs(DataPlugin.Event.TEIID60042, policy.getName(), getName(), policy.getResourceName()));
+        }
+    }
+
+    public void mergeInto(Role existing) {
+        for (Permission g : grants.values()) {
+            existing.addGrant(g);
+        }
+        for (Map<String, Policy> all : policies.values()) {
+            for (Policy policy : all.values()) {
+                existing.addPolicy(policy);
+            }
+        }
+    }
+
 }

--- a/api/src/main/resources/org/teiid/connector/i18n.properties
+++ b/api/src/main/resources/org/teiid/connector/i18n.properties
@@ -53,7 +53,7 @@ TEIID60019=Streaming result has already been read once.  Ensure that only one re
 file_not_found=File not found {0}
 TEIID60028=Duplicate Role {0}
 TEIID60029=Role not found {0}
-TEIID60030=Role {0} is currently in use with grant on resource {1} of type {2}; revoke the grant first to delete the role.
+TEIID60030=Role {0} is currently in use with a grant or policy.  Revoke all its privileges and drop all of its policies.
 
 TEIID60032={0} is not a known base type
 TEIID60033={0} type name already exists
@@ -67,3 +67,6 @@ TEIID60037=The custom {0} for uri {1} is no longer allowed.  Please remove the S
 
 TEIID60038=Column name {0} contained . character, renaming as {1}
 TEIID60039={2} name {0} not unique, renaming as {1}
+
+TEIID60041=Policy {0} already exists on role {1} for resource {2}
+TEIID60042=Policy {0} does not exist on role {1} for resource {2}

--- a/engine/src/main/java/org/teiid/dqp/internal/process/DQPWorkContext.java
+++ b/engine/src/main/java/org/teiid/dqp/internal/process/DQPWorkContext.java
@@ -301,9 +301,11 @@ public class DQPWorkContext implements Serializable {
             } else {
                 allPolicies = metadata.getPolicies().values();
             }
-            for (DataPolicy policy : allPolicies) {
-                if (matchesPrincipal(userRoles, policy)) {
-                    this.policies.put(policy.getName(), policy);
+            if (allPolicies != null) {
+                for (DataPolicy policy : allPolicies) {
+                    if (matchesPrincipal(userRoles, policy)) {
+                        this.policies.put(policy.getName(), policy);
+                    }
                 }
             }
         }

--- a/engine/src/main/java/org/teiid/query/metadata/DatabaseStore.java
+++ b/engine/src/main/java/org/teiid/query/metadata/DatabaseStore.java
@@ -29,7 +29,7 @@ import org.teiid.connector.DataPlugin;
 import org.teiid.core.TeiidComponentException;
 import org.teiid.metadata.*;
 import org.teiid.metadata.Database.ResourceType;
-import org.teiid.metadata.Grant.Permission.Privilege;
+import org.teiid.metadata.Permission.Privilege;
 import org.teiid.metadata.Table.Type;
 import org.teiid.query.QueryPlugin;
 import org.teiid.query.parser.OptionsUtil;
@@ -93,7 +93,7 @@ public abstract class DatabaseStore {
         if (!assertInEditMode(Mode.DATABASE_STRUCTURE)) {
             return;
         }
-        assertGrant(Grant.Permission.Privilege.CREATE, Database.ResourceType.DATABASE, db);
+        assertGrant(Permission.Privilege.CREATE, Database.ResourceType.DATABASE, db);
 
         Database database = this.databases.get(vdbKey(db));
         if ( database != null) {
@@ -201,7 +201,7 @@ public abstract class DatabaseStore {
         if (!assertInEditMode(Mode.DATABASE_STRUCTURE)) {
             return;
         }
-        assertGrant(Grant.Permission.Privilege.CREATE, Database.ResourceType.SCHEMA, schema);
+        assertGrant(Permission.Privilege.CREATE, Database.ResourceType.SCHEMA, schema);
 
         verifyDatabaseExists();
         setUUID(this.currentDatabase.getName(), this.currentDatabase.getVersion(), schema);
@@ -228,7 +228,7 @@ public abstract class DatabaseStore {
             throw new org.teiid.metadata.MetadataException(QueryPlugin.Event.TEIID31273,
                     QueryPlugin.Util.gs(QueryPlugin.Event.TEIID31273, s.getName()));
         }
-        assertGrant(Grant.Permission.Privilege.DROP, Database.ResourceType.SCHEMA, s);
+        assertGrant(Permission.Privilege.DROP, Database.ResourceType.SCHEMA, s);
 
         this.currentDatabase.removeSchema(schemaName);
 
@@ -301,7 +301,7 @@ public abstract class DatabaseStore {
         if (!assertInEditMode(Mode.DATABASE_STRUCTURE)) {
             return;
         }
-        assertGrant(Grant.Permission.Privilege.CREATE, Database.ResourceType.DATAWRAPPER, wrapper);
+        assertGrant(Permission.Privilege.CREATE, Database.ResourceType.DATAWRAPPER, wrapper);
 
         verifyDatabaseExists();
         this.currentDatabase.addDataWrapper(wrapper);
@@ -314,7 +314,7 @@ public abstract class DatabaseStore {
         verifyDatabaseExists();
         verifyDataWrapperExists(wrapperName);
 
-        assertGrant(Grant.Permission.Privilege.DROP, Database.ResourceType.DATAWRAPPER, this.currentDatabase.getDataWrapper(wrapperName));
+        assertGrant(Permission.Privilege.DROP, Database.ResourceType.DATAWRAPPER, this.currentDatabase.getDataWrapper(wrapperName));
 
         for (Server s:this.currentDatabase.getServers()) {
             if (s.getDataWrapper().equalsIgnoreCase(wrapperName)) {
@@ -333,7 +333,7 @@ public abstract class DatabaseStore {
         verifyDatabaseExists();
         verifyDataWrapperExists(server.getDataWrapper());
 
-        assertGrant(Grant.Permission.Privilege.CREATE, Database.ResourceType.SERVER, server);
+        assertGrant(Permission.Privilege.CREATE, Database.ResourceType.SERVER, server);
 
         this.currentDatabase.addServer(server);
     }
@@ -354,7 +354,7 @@ public abstract class DatabaseStore {
         }
         verifyDatabaseExists();
         verifyServerExists(serverName);
-        assertGrant(Grant.Permission.Privilege.DROP, Database.ResourceType.SERVER, this.currentDatabase.getServer(serverName));
+        assertGrant(Permission.Privilege.DROP, Database.ResourceType.SERVER, this.currentDatabase.getServer(serverName));
 
         for (Schema s : this.currentDatabase.getSchemas()) {
             for (Server server : s.getServers()) {
@@ -396,7 +396,7 @@ public abstract class DatabaseStore {
         if (!assertInEditMode(Mode.SCHEMA)) {
             return;
         }
-        assertGrant(Grant.Permission.Privilege.CREATE, Database.ResourceType.TABLE, table);
+        assertGrant(Permission.Privilege.CREATE, Database.ResourceType.TABLE, table);
 
         Schema s = getCurrentSchema();
         setUUID(s.getUUID(), table);
@@ -418,7 +418,7 @@ public abstract class DatabaseStore {
             throw new org.teiid.metadata.MetadataException(QueryPlugin.Event.TEIID31238,
                     QueryPlugin.Util.gs(QueryPlugin.Event.TEIID31238, table.getFullName()));
         }
-        assertGrant(Grant.Permission.Privilege.ALTER, Database.ResourceType.TABLE, table);
+        assertGrant(Permission.Privilege.ALTER, Database.ResourceType.TABLE, table);
         table.setSelectTransformation(definition);
     }
 
@@ -427,7 +427,7 @@ public abstract class DatabaseStore {
             return;
         }
         Table table = (Table)getSchemaRecord(name, type);
-        assertGrant(Grant.Permission.Privilege.ALTER, Database.ResourceType.TABLE, table);
+        assertGrant(Permission.Privilege.ALTER, Database.ResourceType.TABLE, table);
         Schema s = table.getParent();
         if (s.getTable(newName) != null) {
             throw new DuplicateRecordException(DataPlugin.Event.TEIID60013, DataPlugin.Util.gs(DataPlugin.Event.TEIID60013, newName));
@@ -442,7 +442,7 @@ public abstract class DatabaseStore {
             return;
         }
         Table table = (Table)getSchemaRecord(objectName, type);
-        assertGrant(Grant.Permission.Privilege.ALTER, Database.ResourceType.TABLE, table);
+        assertGrant(Permission.Privilege.ALTER, Database.ResourceType.TABLE, table);
 
         Column column = table.getColumnByName(childName);
         if (column == null) {
@@ -457,7 +457,7 @@ public abstract class DatabaseStore {
             return;
         }
         Table table = (Table)getSchemaRecord(tableName, ResourceType.TABLE);
-        assertGrant(Grant.Permission.Privilege.DROP, Database.ResourceType.TABLE, table);
+        assertGrant(Permission.Privilege.DROP, Database.ResourceType.TABLE, table);
 
         if (!(globalTemp ^ (table.getTableType() != Type.TemporaryTable))) {
             throw new org.teiid.metadata.MetadataException(QueryPlugin.Event.TEIID31273,
@@ -476,7 +476,7 @@ public abstract class DatabaseStore {
         if (!assertInEditMode(Mode.SCHEMA)) {
             return;
         }
-        assertGrant(Grant.Permission.Privilege.CREATE, Database.ResourceType.PROCEDURE, procedure);
+        assertGrant(Permission.Privilege.CREATE, Database.ResourceType.PROCEDURE, procedure);
 
         Schema s = getCurrentSchema();
         setUUID(s.getUUID(), procedure);
@@ -496,7 +496,7 @@ public abstract class DatabaseStore {
         }
         Procedure procedure = (Procedure)getSchemaRecord(procedureName, ResourceType.PROCEDURE);
 
-        assertGrant(Grant.Permission.Privilege.ALTER, Database.ResourceType.PROCEDURE, procedure);
+        assertGrant(Permission.Privilege.ALTER, Database.ResourceType.PROCEDURE, procedure);
 
         if (!procedure.isVirtual()) {
             throw new org.teiid.metadata.MetadataException(QueryPlugin.Event.TEIID31238,
@@ -517,7 +517,7 @@ public abstract class DatabaseStore {
                     QueryPlugin.Util.gs(QueryPlugin.Event.TEIID31273, procedure.getFullName()));
         }
 
-        assertGrant(Grant.Permission.Privilege.DROP, Database.ResourceType.PROCEDURE,
+        assertGrant(Permission.Privilege.DROP, Database.ResourceType.PROCEDURE,
                 procedure);
 
         Schema s = procedure.getParent();
@@ -528,7 +528,7 @@ public abstract class DatabaseStore {
         if (!assertInEditMode(Mode.SCHEMA)) {
             return;
         }
-        assertGrant(Grant.Permission.Privilege.CREATE, Database.ResourceType.FUNCTION, function);
+        assertGrant(Permission.Privilege.CREATE, Database.ResourceType.FUNCTION, function);
 
         Schema s = getCurrentSchema();
 
@@ -546,7 +546,7 @@ public abstract class DatabaseStore {
             return;
         }
         FunctionMethod fm = verifyFunctionExists(functionName);
-        assertGrant(Grant.Permission.Privilege.DROP, Database.ResourceType.FUNCTION, fm);
+        assertGrant(Permission.Privilege.DROP, Database.ResourceType.FUNCTION, fm);
 
         Schema s = getCurrentSchema();
         s.removeFunctions(functionName);
@@ -561,7 +561,7 @@ public abstract class DatabaseStore {
         if (table == null) {
             throw new MetadataException(QueryPlugin.Util.getString("SQLParser.group_doesnot_exist", tableName)); //$NON-NLS-1$
         }
-        assertGrant(Grant.Permission.Privilege.ALTER, Database.ResourceType.TABLE, table);
+        assertGrant(Permission.Privilege.ALTER, Database.ResourceType.TABLE, table);
         if (!table.isVirtual()) {
             if (!isAfter) {
                 throw new MetadataException(QueryPlugin.Util.getString("SQLParser.not_view", tableName)); //$NON-NLS-1$
@@ -603,7 +603,7 @@ public abstract class DatabaseStore {
             throw new org.teiid.metadata.MetadataException(QueryPlugin.Event.TEIID31244,
                     QueryPlugin.Util.gs(QueryPlugin.Event.TEIID31244, tableName));
         }
-        assertGrant(Grant.Permission.Privilege.ALTER, Database.ResourceType.TABLE, table);
+        assertGrant(Permission.Privilege.ALTER, Database.ResourceType.TABLE, table);
 
         switch(event) {
         case DELETE:
@@ -769,12 +769,7 @@ public abstract class DatabaseStore {
 
     protected Role verifyRoleExists(String roleName) {
         verifyDatabaseExists();
-        Role role = this.currentDatabase.getRole(roleName);
-        if (role == null) {
-            throw new org.teiid.metadata.MetadataException(QueryPlugin.Event.TEIID31222,
-                    QueryPlugin.Util.gs(QueryPlugin.Event.TEIID31222, roleName, this.currentDatabase.getName()));
-        }
-        return role;
+        return this.currentDatabase.findRole(roleName);
     }
 
     public void roleCreated(Role role) {
@@ -782,7 +777,7 @@ public abstract class DatabaseStore {
             return;
         }
         verifyDatabaseExists();
-        assertGrant(Grant.Permission.Privilege.CREATE, Database.ResourceType.ROLE, role);
+        assertGrant(Permission.Privilege.CREATE, Database.ResourceType.ROLE, role);
 
         this.currentDatabase.addRole(role);
     }
@@ -792,7 +787,7 @@ public abstract class DatabaseStore {
             return;
         }
         Role role = verifyRoleExists(roleName);
-        assertGrant(Grant.Permission.Privilege.DROP, Database.ResourceType.ROLE, role);
+        assertGrant(Permission.Privilege.DROP, Database.ResourceType.ROLE, role);
 
         this.currentDatabase.removeRole(roleName);
     }
@@ -803,13 +798,7 @@ public abstract class DatabaseStore {
         }
         verifyDatabaseExists();
         verifyRoleExists(grant.getRole());
-        assertGrant(Grant.Permission.Privilege.CREATE, Database.ResourceType.GRANT, grant);
-
-        for (Grant.Permission p:grant.getPermissions()) {
-            if (p.getResourceType() == ResourceType.LANGUAGE) {
-                continue;
-            }
-        }
+        assertGrant(Permission.Privilege.CREATE, Database.ResourceType.GRANT, grant);
 
         this.currentDatabase.addGrant(grant);
     }
@@ -820,15 +809,31 @@ public abstract class DatabaseStore {
         }
         verifyDatabaseExists();
         verifyRoleExists(grant.getRole());
-        assertGrant(Grant.Permission.Privilege.DROP, Database.ResourceType.GRANT, grant);
-
-        for (Grant.Permission p:grant.getPermissions()) {
-            if (p.getResourceType() == ResourceType.LANGUAGE) {
-                continue;
-            }
-        }
+        assertGrant(Permission.Privilege.DROP, Database.ResourceType.GRANT, grant);
 
         this.currentDatabase.revokeGrant(grant);
+    }
+
+    public void policyCreated(String roleName, Policy policy) {
+        if (!assertInEditMode(Mode.SCHEMA)) {
+            return;
+        }
+        verifyDatabaseExists();
+        verifyRoleExists(roleName);
+        assertGrant(Permission.Privilege.DROP, Database.ResourceType.POLICY, policy);
+
+        this.currentDatabase.addPolicy(roleName, policy);
+    }
+
+    public void policyDropped(String roleName, Policy policy) {
+        if (!assertInEditMode(Mode.SCHEMA)) {
+            return;
+        }
+        verifyDatabaseExists();
+        verifyRoleExists(roleName);
+        assertGrant(Permission.Privilege.DROP, Database.ResourceType.POLICY, policy);
+
+        this.currentDatabase.removePolicy(roleName, policy);
     }
 
     public void renameBaseColumn(String objectName, Database.ResourceType type, String oldName, String newName) {
@@ -840,12 +845,12 @@ public abstract class DatabaseStore {
         switch (type) {
         case TABLE:
             Table table = (Table)getSchemaRecord(objectName, type);
-            assertGrant(Grant.Permission.Privilege.ALTER, Database.ResourceType.TABLE, table);
+            assertGrant(Permission.Privilege.ALTER, Database.ResourceType.TABLE, table);
             factory.renameColumn(oldName, newName, table);
             break;
         case PROCEDURE:
             Procedure proc = (Procedure)getSchemaRecord(objectName, type);
-            assertGrant(Grant.Permission.Privilege.ALTER, Database.ResourceType.PROCEDURE, proc);
+            assertGrant(Permission.Privilege.ALTER, Database.ResourceType.PROCEDURE, proc);
             factory.renameParameter(oldName, newName, proc);
             break;
         default:
@@ -858,14 +863,14 @@ public abstract class DatabaseStore {
         BaseColumn column = null;
         if (type == Database.ResourceType.TABLE){
             Table table = (Table)getSchemaRecord(objectName, type);
-            assertGrant(Grant.Permission.Privilege.ALTER, Database.ResourceType.TABLE, table);
+            assertGrant(Permission.Privilege.ALTER, Database.ResourceType.TABLE, table);
             column = table.getColumnByName(childName);
             if (column == null){
                 throw new ParseException(QueryPlugin.Util.getString("SQLParser.no_table_column_found", childName, table.getName())); //$NON-NLS-1$
             }
         } else {
             Procedure proc = (Procedure)getSchemaRecord(objectName, type);
-            assertGrant(Grant.Permission.Privilege.ALTER, Database.ResourceType.PROCEDURE, proc);
+            assertGrant(Permission.Privilege.ALTER, Database.ResourceType.PROCEDURE, proc);
             column = proc.getParameterByName(childName);
             if (column == null){
                 throw new ParseException(QueryPlugin.Util.getString("SQLParser.no_proc_column_found", childName, proc.getName())); //$NON-NLS-1$
@@ -961,7 +966,7 @@ public abstract class DatabaseStore {
         }
 
         Table table = (Table)getSchemaRecord(objectName, type);
-        assertGrant(Grant.Permission.Privilege.ALTER, Database.ResourceType.TABLE, table);
+        assertGrant(Permission.Privilege.ALTER, Database.ResourceType.TABLE, table);
         return table;
     }
 

--- a/engine/src/main/java/org/teiid/query/optimizer/relational/rules/RuleApplySecurity.java
+++ b/engine/src/main/java/org/teiid/query/optimizer/relational/rules/RuleApplySecurity.java
@@ -29,6 +29,7 @@ import org.teiid.api.exception.query.QueryMetadataException;
 import org.teiid.api.exception.query.QueryPlannerException;
 import org.teiid.core.TeiidComponentException;
 import org.teiid.core.TeiidProcessingException;
+import org.teiid.metadata.Policy;
 import org.teiid.query.analysis.AnalysisRecord;
 import org.teiid.query.metadata.QueryMetadataInterface;
 import org.teiid.query.optimizer.capabilities.CapabilitiesFinder;
@@ -139,7 +140,7 @@ public class RuleApplySecurity implements OptimizerRule {
                 }
 
                 //logically filters are applied below masking
-                Criteria filter = RowBasedSecurityHelper.getRowBasedFilters(metadata, group, context, false);
+                Criteria filter = RowBasedSecurityHelper.getRowBasedFilters(metadata, group, context, false, Policy.Operation.SELECT);
                 if (filter == null) {
                     continue;
                 }

--- a/engine/src/main/javacc/org/teiid/query/parser/SQLParser.jj
+++ b/engine/src/main/javacc/org/teiid/query/parser/SQLParser.jj
@@ -538,6 +538,7 @@ TOKEN : /* NonReserved words */
 |   <FORMAT: "format">
 |   <YAML: "yaml">
 |   <HANDLER: "handler">
+|   <POLICY: "policy">
 |   <EPOCH: "epoch">
 |   <QUARTER: "quarter">
 }
@@ -660,7 +661,7 @@ Token basicNonReserved() :
      |<VERSION>|<INCLUDING>|<EXCLUDING>|<XMLDECLARATION>|<VARIADIC>|<RAISE>|<CHAIN>|<JSONARRAY_AGG>|<JSONOBJECT>|<PRESERVE>|<UPSERT>|<AFTER>
      |<TYPE>|<TRANSLATOR>|<JAAS>|<CONDITION>|<MASK>|<ACCESS>|<CONTROL>|<NONE>|<DATA>|<DATABASE>|<PRIVILEGES>|<ROLE>|<SCHEMA>|<USE>|<REPOSITORY>|<RENAME>
      |<DOMAIN>|<USAGE>|<POSITION>|<CURRENT>|<UNBOUNDED>|<PRECEDING>|<FOLLOWING>|<LISTAGG>
-     |<EXPLAIN>|<ANALYZE>|<TEXT>|<FORMAT>|<YAML>|<EPOCH>|<QUARTER>)
+     |<EXPLAIN>|<ANALYZE>|<TEXT>|<FORMAT>|<YAML>|<EPOCH>|<QUARTER>|<POLICY>)
     {
         return getToken(0);
     }   
@@ -5332,8 +5333,10 @@ void ddlStmt(DatabaseStore dbStore) :
 	 LOOKAHEAD(3)  createServer(dbStore) |
 	 LOOKAHEAD(3)  createRole(dbStore) |
 	 LOOKAHEAD(3)  dropRole(dbStore) |
-	 LOOKAHEAD(2)  grantOption(dbStore) |
-	 LOOKAHEAD(2)  revokeGrantOption(dbStore) | 
+	 LOOKAHEAD(2)  grant(dbStore) |
+	 LOOKAHEAD(2)  revokeGrant(dbStore) | 
+	 LOOKAHEAD(2)  createPolicy(dbStore, ParseInfo.DEFAULT_INSTANCE) |
+	 LOOKAHEAD(2)  dropPolicy(dbStore) |
 	 LOOKAHEAD(3)  dropServer(dbStore) |
 	 LOOKAHEAD(3)  dropTableView(dbStore) |
 	 LOOKAHEAD(2)  importSchema(dbStore) |
@@ -5651,11 +5654,86 @@ void dropRole(DatabaseStore dbStore) :
 }
 
 /*
-name=Create GRANT
+name=CREATE POLICY
+description=CREATE row level policy
+example=[source,sql]\n----\nCREATE POLICY pname ON tbl FOR SELECT,INSERT TO role USING col = user();\n----\n
+*/
+void createPolicy(DatabaseStore dbStore, ParseInfo info) :
+{
+    Database.ResourceType on= Database.ResourceType.TABLE;
+    Policy policy = new Policy();
+    String resource = null;
+    String policyName = null;
+    Expression condition = null;
+    String to = null;
+    Token operation = null;
+}
+{
+    <CREATE> <POLICY>
+    policyName = id(Boolean.TRUE)
+    <ON> ( 
+      (resource = id(null)
+       [ <FOR> (<ALL> 
+                | ((operation = <SELECT> | operation = <INSERT> | operation = <UPDATE> | operation = <DELETE>) 
+                   {policy.getOperations().add(Policy.Operation.valueOf(operation.image.toUpperCase()));} 
+                   (<COMMA> 
+                    (operation = <SELECT> | operation = <INSERT> | operation = <UPDATE> | operation = <DELETE>)
+                    {policy.getOperations().add(Policy.Operation.valueOf(operation.image.toUpperCase()));} )*)
+               ) 
+       ]
+      )
+      |
+      (<PROCEDURE> resource = id(null) {on = Database.ResourceType.PROCEDURE;}
+       [ <FOR> ( token = <ALL> ) {policy.getOperations().add(Policy.Operation.ALL);}] 
+      )
+    ) 
+    <TO>( to = id(null) )
+    <USING> <LPAREN> condition = booleanPrimary(info) <RPAREN>
+    {
+        policy.setName(policyName);
+        policy.setResourceName(resource);
+        policy.setResourceType(on);
+        policy.setCondition(condition.toString());
+        dbStore.policyCreated(to, policy);
+    } 
+}
+
+/*
+name=DROP POLICY
+description=DROP row level policy
+example=[source,sql]\n----\DROP POLICY pname ON tbl TO role\n----\n
+*/
+void dropPolicy(DatabaseStore dbStore) :
+{
+    Policy policy = new Policy();
+    Database.ResourceType on= Database.ResourceType.TABLE;
+    String resource = null;
+    String policyName = null;
+    String to = null;
+}
+{
+    <DROP> <POLICY>
+    policyName = id(Boolean.TRUE)
+    <ON> ( 
+      resource = id(null)
+      |
+      (<PROCEDURE> resource = id(null) {on = Database.ResourceType.PROCEDURE;})
+    ) 
+    <TO>( to = id(null) )
+    {
+      policy.setName(policyName);
+      policy.setResourceName(resource);
+      policy.setResourceType(on);
+      dbStore.policyDropped(to, policy);
+    }
+}
+
+/*
+name=GRANT
 description=Defines GRANT for a role
 example=[source,sql]\n----\nGRANT SELECT ON TABLE x.y TO role\n----\n
 */
-void grantOption(DatabaseStore dbStore) :
+void grant(DatabaseStore dbStore) :
 {
     Database.ResourceType on= null;
     Grant grant = new Grant();
@@ -5668,8 +5746,8 @@ void grantOption(DatabaseStore dbStore) :
         isConstraint = false;
     }
     String to = null;
-    ArrayList<Grant.Permission.Privilege> privileges = new ArrayList<Grant.Permission.Privilege>();
-    Grant.Permission permission = new Grant.Permission();
+    ArrayList<Permission.Privilege> privileges = new ArrayList<Permission.Privilege>();
+    Permission permission = new Permission();
 }
 {
     <GRANT> 
@@ -5687,11 +5765,11 @@ void grantOption(DatabaseStore dbStore) :
        )
       ) 
       |
-      (<ALL> <PRIVILEGES> {privileges.add(Grant.Permission.Privilege.ALL_PRIVILEGES);})
+      (<ALL> <PRIVILEGES> {privileges.add(Permission.Privilege.ALL_PRIVILEGES);})
       |
-      (<TEMPORARY> <TABLE> {privileges.add(Grant.Permission.Privilege.TEMPORARY_TABLE);}) 
+      (<TEMPORARY> <TABLE> {privileges.add(Permission.Privilege.TEMPORARY_TABLE);}) 
       |
-      (<USAGE> {privileges.add(Grant.Permission.Privilege.USAGE); on = Database.ResourceType.LANGUAGE;} <ON> <LANGUAGE> resource=id(null))
+      (<USAGE> {privileges.add(Permission.Privilege.USAGE); on = Database.ResourceType.LANGUAGE;} <ON> <LANGUAGE> resource=id(null))
     )
     <TO>( to = id(null)
         {
@@ -5711,7 +5789,7 @@ void grantOption(DatabaseStore dbStore) :
                 permission.setCondition(condition, isConstraint);               
             }
             grant.setRole(to);
-            grant.addPermission(permission);
+            grant.setPermission(permission);
             dbStore.grantCreated(grant);
         } 
     )
@@ -5722,7 +5800,7 @@ name=Revoke GRANT
 description=Revokes GRANT for a role
 example=[source,sql]\n----\nREVOKE SELECT ON TABLE x.y TO role\n----\n
 */
-void revokeGrantOption(DatabaseStore dbStore) :
+void revokeGrant(DatabaseStore dbStore) :
 {
     Database.ResourceType on= null;
     Grant grant = new Grant();
@@ -5730,8 +5808,8 @@ void revokeGrantOption(DatabaseStore dbStore) :
     String mask = null;
     String condition = null;
     String to = null;
-    ArrayList<Grant.Permission.Privilege> privileges = new ArrayList<Grant.Permission.Privilege>();
-    Grant.Permission permission = new Grant.Permission();
+    ArrayList<Permission.Privilege> privileges = new ArrayList<Permission.Privilege>();
+    Permission permission = new Permission();
 }
 {
     <REVOKE> 
@@ -5749,11 +5827,11 @@ void revokeGrantOption(DatabaseStore dbStore) :
        )
       ) 
       |
-      (<ALL> <PRIVILEGES> {privileges.add(Grant.Permission.Privilege.ALL_PRIVILEGES);})
+      (<ALL> <PRIVILEGES> {privileges.add(Permission.Privilege.ALL_PRIVILEGES);})
       |
-      (<TEMPORARY> <TABLE> {privileges.add(Grant.Permission.Privilege.TEMPORARY_TABLE);}) 
+      (<TEMPORARY> <TABLE> {privileges.add(Permission.Privilege.TEMPORARY_TABLE);}) 
       |
-      (<USAGE> {privileges.add(Grant.Permission.Privilege.USAGE); on = Database.ResourceType.LANGUAGE;} <ON> <LANGUAGE> resource=id(null))
+      (<USAGE> {privileges.add(Permission.Privilege.USAGE); on = Database.ResourceType.LANGUAGE;} <ON> <LANGUAGE> resource=id(null))
     )
     <FROM>( to = id(null)
         {
@@ -5770,7 +5848,7 @@ void revokeGrantOption(DatabaseStore dbStore) :
                 permission.setCondition(condition, null);               
             }
             grant.setRole(to);
-            grant.addPermission(permission);
+            grant.setPermission(permission);
             dbStore.grantRevoked(grant);
         } 
     )
@@ -7026,15 +7104,15 @@ void identifierList(List<String> strings) :
 /*
 name=grant type
 */
-void readGrantTypes(ArrayList<Grant.Permission.Privilege> privileges) :
+void readGrantTypes(ArrayList<Permission.Privilege> privileges) :
 {
 }
 {        
-    <SELECT> {privileges.add(Grant.Permission.Privilege.SELECT);} |
-    <INSERT> {privileges.add(Grant.Permission.Privilege.INSERT);} |
-    <UPDATE> {privileges.add(Grant.Permission.Privilege.UPDATE);} |
-    <DELETE> {privileges.add(Grant.Permission.Privilege.DELETE);} |
-    <EXECUTE> {privileges.add(Grant.Permission.Privilege.EXECUTE);} |
-    <ALTER> {privileges.add(Grant.Permission.Privilege.ALTER);} |
-    <DROP> {privileges.add(Grant.Permission.Privilege.DROP);}
+    <SELECT> {privileges.add(Permission.Privilege.SELECT);} |
+    <INSERT> {privileges.add(Permission.Privilege.INSERT);} |
+    <UPDATE> {privileges.add(Permission.Privilege.UPDATE);} |
+    <DELETE> {privileges.add(Permission.Privilege.DELETE);} |
+    <EXECUTE> {privileges.add(Permission.Privilege.EXECUTE);} |
+    <ALTER> {privileges.add(Permission.Privilege.ALTER);} |
+    <DROP> {privileges.add(Permission.Privilege.DROP);}
 }

--- a/engine/src/test/java/org/teiid/query/metadata/TestDDLStringVisitor.java
+++ b/engine/src/test/java/org/teiid/query/metadata/TestDDLStringVisitor.java
@@ -521,55 +521,45 @@ public class TestDDLStringVisitor {
 
         Role role1 = new Role("uber");
 
-        Grant.Permission permission = new Grant.Permission();
+        Permission permission = new Permission();
         permission.setAllowAlter(true);
         permission.setAllowSelect(true);
         permission.setResourceName("schema.tableName");
         permission.setResourceType(ResourceType.TABLE);
 
-        Grant.Permission permission2 = new Grant.Permission();
+        Permission permission2 = new Permission();
         permission2.setAllowDelete(true);
         permission2.setResourceName("schema.tableName");
         permission2.setResourceType(ResourceType.TABLE);
 
-        Grant.Permission permission3 = new Grant.Permission();
+        Permission permission3 = new Permission();
         permission3.setAllowAllPrivileges(true);
         permission3.setAllowTemporyTables(true);
 
-        Grant.Permission permission4 = new Grant.Permission();
+        Permission permission4 = new Permission();
         permission4.setAllowTemporyTables(true);
 
-        Grant.Permission permission5 = new Grant.Permission();
+        Permission permission5 = new Permission();
         permission5.setAllowDelete(true);
         permission5.setResourceName("schema.tableName.col");
         permission5.setResourceType(ResourceType.COLUMN);
 
-        Grant.Permission permission6 = new Grant.Permission();
+        Permission permission6 = new Permission();
         permission6.setAllowSelect(true);
         permission6.setResourceName("schema.tableName.col");
         permission6.setResourceType(ResourceType.TABLE);
 
-        Grant g = new Grant();
-        g.setRole(role.getName());
-        g.addPermission(permission);
-        g.addPermission(permission4);
-
-        Grant g2 = new Grant();
-        g2.setRole(role.getName());
-        g2.addPermission(permission2);
-        g2.addPermission(permission5);
-        g2.addPermission(permission6);
-
-        Grant g3 = new Grant();
-        g3.setRole("uber");
-        g3.addPermission(permission3);
-
         db.addRole(role);
         db.addRole(role1);
-        db.addGrant(g);
-        db.addGrant(g2);
-        db.addGrant(g3);
 
+        db.addGrant(new Grant(role.getName(), permission));
+        db.addGrant(new Grant(role.getName(), permission4));
+
+        db.addGrant(new Grant(role.getName(), permission2));
+        db.addGrant(new Grant(role.getName(), permission5));
+        db.addGrant(new Grant(role.getName(), permission6));
+
+        db.addGrant(new Grant("uber", permission3));
 
         String expected = "\n" +
                 "/*\n" +

--- a/engine/src/test/java/org/teiid/query/processor/TestRowPolicies.java
+++ b/engine/src/test/java/org/teiid/query/processor/TestRowPolicies.java
@@ -1,0 +1,423 @@
+/*
+ * Copyright Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags and
+ * the COPYRIGHT.txt file distributed with this work.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.teiid.query.processor;
+
+import static org.teiid.query.processor.TestProcessor.*;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.teiid.adminapi.DataPolicy;
+import org.teiid.adminapi.impl.DataPolicyMetadata;
+import org.teiid.adminapi.impl.DataPolicyMetadata.PermissionMetaData;
+import org.teiid.api.exception.query.QueryMetadataException;
+import org.teiid.api.exception.query.QueryPlannerException;
+import org.teiid.api.exception.query.QueryProcessingException;
+import org.teiid.core.TeiidProcessingException;
+import org.teiid.dqp.internal.process.DQPWorkContext;
+import org.teiid.metadata.Policy;
+import org.teiid.metadata.Policy.Operation;
+import org.teiid.metadata.Role;
+import org.teiid.query.metadata.TransformationMetadata;
+import org.teiid.query.optimizer.TestOptimizer;
+import org.teiid.query.optimizer.capabilities.BasicSourceCapabilities;
+import org.teiid.query.optimizer.capabilities.DefaultCapabilitiesFinder;
+import org.teiid.query.optimizer.capabilities.SourceCapabilities.Capability;
+import org.teiid.query.unittest.RealMetadataFactory;
+import org.teiid.query.util.CommandContext;
+
+@SuppressWarnings({"nls"})
+public class TestRowPolicies {
+
+    CommandContext context;
+
+    @Before public void setup() {
+        context = createContext();
+    }
+
+    private static CommandContext createContext() {
+        CommandContext context = createCommandContext();
+        DQPWorkContext workContext = new DQPWorkContext();
+        HashMap<String, DataPolicy> policies = new HashMap<String, DataPolicy>();
+        DataPolicyMetadata policy = new DataPolicyMetadata();
+        policies.put("some-role", policy);
+
+        Role r = new Role("some-role");
+
+        Policy pmd = new Policy();
+        pmd.setResourceType(org.teiid.metadata.Database.ResourceType.TABLE);
+        pmd.setResourceName("pm1.g1");
+        pmd.setCondition("e1 = user()");
+
+        r.addPolicy(pmd);
+
+        Policy pmd1 = new Policy();
+        pmd1.setResourceType(org.teiid.metadata.Database.ResourceType.TABLE);
+        pmd1.setResourceName("pm1.g2");
+        pmd1.setCondition("foo = bar");
+
+        r.addPolicy(pmd1);
+
+        Policy pmd2 = new Policy();
+        pmd2.setResourceType(org.teiid.metadata.Database.ResourceType.TABLE);
+        pmd2.setResourceName("pm1.g4");
+        pmd2.setCondition("e1 = max(e2)");
+
+        r.addPolicy(pmd2);
+
+        Policy pmd4 = new Policy();
+        pmd4.setResourceType(org.teiid.metadata.Database.ResourceType.PROCEDURE);
+        pmd4.setResourceName("pm1.sp1");
+        pmd4.setCondition("e1 = 'a'");
+
+        r.addPolicy(pmd4);
+
+        //update only a subset
+
+        Policy pmd6 = new Policy();
+        pmd6.setName("update");
+        pmd6.setResourceType(org.teiid.metadata.Database.ResourceType.TABLE);
+        pmd6.setResourceName("pm1.g3");
+        pmd6.setCondition("e1 = user()");
+        pmd6.getOperations().add(Operation.DELETE);
+        pmd6.getOperations().add(Operation.INSERT);
+        pmd6.getOperations().add(Operation.UPDATE);
+
+        r.addPolicy(pmd6);
+
+        policy.addPolicies(r.getPolicies());
+
+        workContext.setPolicies(policies);
+        context.setDQPWorkContext(workContext);
+        return context;
+    }
+
+    @Test public void testSelectFilter() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        dataManager.addData("SELECT pm1.g1.e1, pm1.g1.e2 FROM pm1.g1", new List<?>[] {Arrays.asList("a", 1), Arrays.asList("b", 2)});
+        ProcessorPlan plan = helpGetPlan(helpParse("select e2 from pm1.g1"), RealMetadataFactory.example1Cached(), new DefaultCapabilitiesFinder(), context);
+        List<?>[] expectedResults = new List<?>[0];
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    /**
+     * Note that we create an inline view to keep the proper position of the filter
+     */
+    @Test public void testSelectFilterOuterJoin() throws Exception {
+        BasicSourceCapabilities caps = TestOptimizer.getTypicalCapabilities();
+        caps.setCapabilitySupport(Capability.QUERY_FROM_JOIN_OUTER, true);
+        caps.setCapabilitySupport(Capability.QUERY_FROM_JOIN_OUTER_FULL, true);
+        caps.setCapabilitySupport(Capability.QUERY_FROM_INLINE_VIEWS, true);
+        ProcessorPlan plan = helpGetPlan(helpParse("SELECT pm1.g1.e1, pm1.g1.e2 FROM pm1.g1 full outer join pm1.g3 on (pm1.g1.e1=pm1.g3.e1)"), RealMetadataFactory.example1Cached(), new DefaultCapabilitiesFinder(caps), context);
+        TestOptimizer.checkAtomicQueries(new String[] {"SELECT v_0.c_0, v_0.c_1 FROM (SELECT g_0.e1 AS c_0, g_0.e2 AS c_1 FROM pm1.g1 AS g_0 WHERE g_0.e1 = 'user') AS v_0 FULL OUTER JOIN pm1.g3 AS g_1 ON v_0.c_0 = g_1.e1"}, plan);
+    }
+
+    /**
+     * Same as above, but ensures it's still in effect under a proceudre
+     */
+    @Test public void testTransitiveFilter() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        dataManager.addData("SELECT pm1.g1.e1, pm1.g1.e2 FROM pm1.g1", new List<?>[] {Arrays.asList("a", 1), Arrays.asList("b", 2)});
+        dataManager.addData("exec pm1.sq1()", new List<?>[] {Arrays.asList("a", 1), Arrays.asList("b", 2)});
+        ProcessorPlan plan = helpGetPlan(helpParse("exec pm1.sq1()"), RealMetadataFactory.example1Cached(), new DefaultCapabilitiesFinder(), context);
+        List<?>[] expectedResults = new List<?>[0];
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    /**
+     * restricted to e1 = a
+     */
+    @Test public void testProcedureFilter() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        dataManager.addData("EXEC pm1.sp1()", new List<?>[] {Arrays.asList("a", 1), Arrays.asList("b", 2)});
+        ProcessorPlan plan = helpGetPlan(helpParse("exec pm1.sp1()"), RealMetadataFactory.example1Cached(), new DefaultCapabilitiesFinder(), context);
+        List<?>[] expectedResults = new List<?>[] {Arrays.asList("a", 1)};
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    @Test public void testProcedureRelationalFilter() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        dataManager.addData("EXEC pm1.sp1()", new List<?>[] {Arrays.asList("a", 1), Arrays.asList("b", 2)});
+        ProcessorPlan plan = helpGetPlan(helpParse("select * from pm1.sp1"), RealMetadataFactory.example1Cached(), new DefaultCapabilitiesFinder(), context);
+        List<?>[] expectedResults = new List<?>[] {Arrays.asList("a", 1)};
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    /**
+     * Shouldn't even execute as 'user' <> 'a'
+     */
+    @Test public void testDeleteFilter() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        ProcessorPlan plan = helpGetPlan(helpParse("delete from pm1.g1 where e1 = 'a'"), RealMetadataFactory.example1Cached(), TestOptimizer.getGenericFinder(), context);
+        List<?>[] expectedResults = new List<?>[] {Arrays.asList(0)};
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    /**
+     * invalid insert value
+     */
+    @Test(expected=QueryPlannerException.class) public void testInsertConstraint() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        ProcessorPlan plan = helpGetPlan(helpParse("insert into pm1.g1 (e1) values ('a')"), RealMetadataFactory.example1Cached(), TestOptimizer.getGenericFinder(), context);
+        helpProcess(plan, context, dataManager, null);
+    }
+
+    /**
+     * Assumes the null value for e1, which results in a violation
+     */
+    @Test(expected=QueryPlannerException.class) public void testInsertConstraint1() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        ProcessorPlan plan = helpGetPlan(helpParse("insert into pm1.g1 (e2) values (1)"), RealMetadataFactory.example1Cached(), TestOptimizer.getGenericFinder(), context);
+        helpProcess(plan, context, dataManager, null);
+    }
+
+    @Test(expected=TeiidProcessingException.class) public void testInsertConstraintCorrelatedSubquery() throws Exception {
+        DataPolicyMetadata policy1 = new DataPolicyMetadata();
+        PermissionMetaData pmd3 = new PermissionMetaData();
+        pmd3.setResourceName("pm1.g1");
+        pmd3.setCondition("e1 = (select min(e1) from pm1.g3 where pm1.g1.e2 = e2)");
+        policy1.addPermission(pmd3);
+        policy1.setName("some-other-role");
+        context.getAllowedDataPolicies().put("some-other-role", policy1);
+
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        ProcessorPlan plan = helpGetPlan(helpParse("insert into pm1.g1 (e1, e2) values ('a', 1)"), RealMetadataFactory.example1Cached(), TestOptimizer.getGenericFinder(), context);
+        List<?>[] expectedResults = new List<?>[] {Arrays.asList(0)};
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    @Test public void testInsertConstraintSubquery() throws Exception {
+        DataPolicyMetadata policy1 = new DataPolicyMetadata();
+        PermissionMetaData pmd3 = new PermissionMetaData();
+        pmd3.setResourceName("pm1.g1");
+        pmd3.setCondition("e1 = (select min(e1) from pm1.g3)");
+        policy1.addPermission(pmd3);
+        policy1.setName("some-other-role");
+        context.getAllowedDataPolicies().put("some-other-role", policy1);
+
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        dataManager.addData("SELECT g_0.e1 FROM pm1.g3 AS g_0", new List<?>[] {Arrays.asList("a"), Arrays.asList("b")});
+        dataManager.addData("INSERT INTO pm1.g1 (e1, e2) VALUES ('a', 1)", new List<?>[] {Arrays.asList(1)});
+        ProcessorPlan plan = helpGetPlan(helpParse("insert into pm1.g1 (e1, e2) values ('a', 1)"), RealMetadataFactory.example1Cached(), TestOptimizer.getGenericFinder(), context);
+        List<?>[] expectedResults = new List<?>[] {Arrays.asList(1)};
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    /**
+     * should fail since it doesn't match the condition
+     */
+    @Test(expected=QueryProcessingException.class) public void testInsertConstraintWithQueryExpression() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        dataManager.addData("SELECT pm1.g3.e1 FROM pm1.g3", new List<?>[] {Arrays.asList("a"), Arrays.asList("b")});
+        BasicSourceCapabilities bsc = new BasicSourceCapabilities();
+        bsc.setCapabilitySupport(Capability.INSERT_WITH_QUERYEXPRESSION, true);
+        DefaultCapabilitiesFinder capFinder = new DefaultCapabilitiesFinder(bsc);
+        ProcessorPlan plan = helpGetPlan(helpParse("insert into pm1.g1 (e1) select e1 from pm1.g3"), RealMetadataFactory.example1Cached(), capFinder, context);
+        List<?>[] expectedResults = new List<?>[] {Arrays.asList(0)};
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    @Test public void testInsertConstraintAutoIncrement() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        TransformationMetadata tm = RealMetadataFactory.fromDDL("create foreign table g1 (e1 string, e2 integer not null auto_increment) options (updatable true)", "x", "pm1");
+        ProcessorPlan plan = helpGetPlan(helpParse("insert into pm1.g1 (e1) values ('user')"), tm, TestOptimizer.getGenericFinder(), context);
+        dataManager.addData("INSERT INTO pm1.g1 (e1) VALUES ('user')", new List<?>[] {Arrays.asList(1)});
+        helpProcess(plan, context, dataManager, null);
+    }
+
+    @Test(expected=QueryPlannerException.class) public void testInsertConstraintAutoIncrement1() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        TransformationMetadata tm = RealMetadataFactory.fromDDL("create foreign table g1 (e1 string not null auto_increment, e2 integer) options (updatable true)", "x", "pm1");
+        ProcessorPlan plan = helpGetPlan(helpParse("insert into pm1.g1 (e2) values (1)"), tm, TestOptimizer.getGenericFinder(), context);
+        helpProcess(plan, context, dataManager, null);
+    }
+
+    /**
+     * should succeed since it matches the condition
+     */
+    @Test public void testInsertConstraintWithQueryExpression1() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        dataManager.addData("SELECT pm1.g3.e1 FROM pm1.g3", new List<?>[] {Arrays.asList("a")});
+        dataManager.addData("INSERT INTO pm1.g1 (e1) VALUES ('user')", new List<?>[] {Arrays.asList(1)});
+        BasicSourceCapabilities bsc = new BasicSourceCapabilities();
+        bsc.setCapabilitySupport(Capability.INSERT_WITH_QUERYEXPRESSION, true);
+        DefaultCapabilitiesFinder capFinder = new DefaultCapabilitiesFinder(bsc);
+        ProcessorPlan plan = helpGetPlan(helpParse("insert into pm1.g1 (e1) select user() from pm1.g3"), RealMetadataFactory.example1Cached(), capFinder, context);
+        List<?>[] expectedResults = new List<?>[] {Arrays.asList(1)};
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    @Test public void testInsertFilter1() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        dataManager.addData("INSERT INTO pm1.g1 (e1) VALUES ('user')", new List<?>[] {Arrays.asList(1)});
+        ProcessorPlan plan = helpGetPlan(helpParse("insert into pm1.g1 (e1) values ('user')"), RealMetadataFactory.example1Cached(), TestOptimizer.getGenericFinder(), context);
+        List<?>[] expectedResults = new List<?>[] {Arrays.asList(1)};
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    /**
+     * not a valid value for e1
+     */
+    @Test(expected=QueryPlannerException.class) public void testUpdateFilter() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        ProcessorPlan plan = helpGetPlan(helpParse("update pm1.g1 set e1 = 'a' where e2 = 5"), RealMetadataFactory.example1Cached(), TestOptimizer.getGenericFinder(), context);
+        List<?>[] expectedResults = new List<?>[] {Arrays.asList(0)};
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    /**
+     * no primary key for compensation
+     */
+    @Test(expected=QueryPlannerException.class) public void testUpdateFilter1() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        ProcessorPlan plan = helpGetPlan(helpParse("update pm1.g1 set e1 = e3 where e2 = 5"), RealMetadataFactory.example1Cached(), TestOptimizer.getGenericFinder(), context);
+        List<?>[] expectedResults = new List<?>[] {Arrays.asList(0)};
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    @Test(expected=QueryProcessingException.class) public void testUpdateFilter2() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        dataManager.addData("SELECT g_0.e3, g_0.e1 FROM pm1.g1 AS g_0 WHERE (g_0.e1 = 'user') AND (g_0.e2 = 5)", new List<?>[] {Arrays.asList(Boolean.TRUE, "user")});
+        ProcessorPlan plan = helpGetPlan(helpParse("update pm1.g1 set e1 = e3 || 'r' where e2 = 5"), RealMetadataFactory.example4(), TestOptimizer.getGenericFinder(), context);
+        List<?>[] expectedResults = new List<?>[] {Arrays.asList(0)};
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    /**
+     * Ensures that the filter still gets applied to the insert
+     */
+    @Test public void testUpdateFilter3() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        dataManager.addData("UPDATE pm1.g1 SET e2 = 1 WHERE (e2 = 5) AND (e1 = 'user')", new List<?>[] {Arrays.asList(1)});
+        ProcessorPlan plan = helpGetPlan(helpParse("update pm1.g1 set e2 = 1 where e2 = 5"), RealMetadataFactory.example4(), TestOptimizer.getGenericFinder(), context);
+        List<?>[] expectedResults = new List<?>[] {Arrays.asList(1)};
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    /**
+     * Tests an outside column in the constraint
+     */
+    @Test public void testUpdateFilter4() throws Exception {
+        DataPolicyMetadata policy1 = new DataPolicyMetadata();
+        PermissionMetaData pmd3 = new PermissionMetaData();
+        pmd3.setResourceName("pm1.g1");
+        pmd3.setCondition("e2 = 1 and e3");
+        policy1.addPermission(pmd3);
+        policy1.setName("some-role");
+        context.getAllowedDataPolicies().put("some-role", policy1);
+
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        dataManager.addData("SELECT g_0.e4, g_0.e3, g_0.e1 FROM pm1.g1 AS g_0 WHERE (g_0.e3 = TRUE) AND (g_0.e2 = 1) AND (g_0.e1 IN ('a', 'b'))", new List<?>[] {Arrays.asList(Double.valueOf(1), Boolean.TRUE, "a"), Arrays.asList(Double.valueOf(1), Boolean.TRUE, "b")});
+        dataManager.addData("UPDATE pm1.g1 SET e2 = 1 WHERE pm1.g1.e1 = 'a'", new List<?>[] {Arrays.asList(1)});
+        dataManager.addData("UPDATE pm1.g1 SET e2 = 1 WHERE pm1.g1.e1 = 'b'", new List<?>[] {Arrays.asList(1)});
+        ProcessorPlan plan = helpGetPlan(helpParse("update pm1.g1 set e2 = case when e4 = 1 then 1 else 2 end where e1 in ('a', 'b')"), RealMetadataFactory.example4(), TestOptimizer.getGenericFinder(), context);
+        List<?>[] expectedResults = new List<?>[] {Arrays.asList(2)};
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    //TODO: should add validation prior to queries being run
+    @Test(expected=QueryMetadataException.class) public void testBadFilter() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        ProcessorPlan plan = helpGetPlan(helpParse("select e2 from pm1.g2"), RealMetadataFactory.example1Cached(), new DefaultCapabilitiesFinder(), context);
+        List<?>[] expectedResults = new List<?>[0];
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    @Test(expected=QueryMetadataException.class) public void testBadFilter1() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        ProcessorPlan plan = helpGetPlan(helpParse("select * from pm1.g4"), RealMetadataFactory.example1Cached(), new DefaultCapabilitiesFinder(), context);
+        List<?>[] expectedResults = new List<?>[0];
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    /**
+     * Here the other role makes the g1 rows visible again
+     */
+    @Test public void testMultipleRoles() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        dataManager.addData("SELECT pm1.g1.e1, pm1.g1.e2 FROM pm1.g1", new List<?>[] {Arrays.asList("a", 1), Arrays.asList("b", 2)});
+        ProcessorPlan plan = helpGetPlan(helpParse("select e2 from pm1.g1"), RealMetadataFactory.example1Cached(), new DefaultCapabilitiesFinder(), context);
+        helpProcess(plan, context, dataManager, new List<?>[0]);
+
+        DataPolicyMetadata policy1 = new DataPolicyMetadata();
+        PermissionMetaData pmd3 = new PermissionMetaData();
+        pmd3.setResourceName("pm1.g1");
+        pmd3.setCondition("true");
+        policy1.addPermission(pmd3);
+        policy1.setName("some-other-role");
+        context.getAllowedDataPolicies().put("some-other-role", policy1);
+
+        dataManager = new HardcodedDataManager();
+        dataManager.addData("SELECT pm1.g1.e2 FROM pm1.g1", new List<?>[] {Arrays.asList(1), Arrays.asList(2)});
+        plan = helpGetPlan(helpParse("select e2 from pm1.g1"), RealMetadataFactory.example1Cached(), new DefaultCapabilitiesFinder(), context);
+        List<?>[] expectedResults = new List<?>[] {Arrays.asList(1), Arrays.asList(2)};
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    @Test public void testSubqueryHint() throws Exception {
+        DataPolicyMetadata policy1 = new DataPolicyMetadata();
+        PermissionMetaData pmd3 = new PermissionMetaData();
+        pmd3.setResourceName("pm1.g1");
+        pmd3.setCondition("e1 in /*+ DJ */ (select e1 from pm1.g3)");
+        policy1.addPermission(pmd3);
+        policy1.setName("some-other-role");
+        context.getAllowedDataPolicies().clear();
+        context.getAllowedDataPolicies().put("some-other-role", policy1);
+
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+
+        dataManager.addData("SELECT pm1.g3.e1 FROM pm1.g3", new List<?>[] {Arrays.asList("b"), Arrays.asList("a")});
+        dataManager.addData("SELECT pm1.g1.e1, pm1.g1.e2 FROM pm1.g1", new List<?>[] {Arrays.asList("b", 1), Arrays.asList("a", 2)});
+
+        ProcessorPlan plan = helpGetPlan(helpParse("select e1, e2 from pm1.g1"), RealMetadataFactory.example1Cached(), new DefaultCapabilitiesFinder(), context);
+        List<?>[] expectedResults = new List<?>[] {Arrays.asList("a", 2), Arrays.asList("b", 1)};
+        helpProcess(plan, context, dataManager, expectedResults);
+
+        dataManager.addData("SELECT g_0.e1 AS c_0 FROM pm1.g3 AS g_0 ORDER BY c_0", new List<?>[] {Arrays.asList("a"), Arrays.asList("b")});
+        dataManager.addData("SELECT g_0.e1 AS c_0, g_0.e2 AS c_1 FROM pm1.g1 AS g_0 WHERE g_0.e1 IN ('a', 'b') ORDER BY c_0", new List<?>[] {Arrays.asList("a", 2), Arrays.asList("b", 1)});
+
+        plan = helpGetPlan(helpParse("select e1, e2 from pm1.g1"), RealMetadataFactory.example1Cached(), TestOptimizer.getGenericFinder(), context);
+        expectedResults = new List<?>[] {Arrays.asList("a", 2), Arrays.asList("b", 1)};
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+    /**
+     * Tests an outside column in the constraint
+     */
+    @Test public void testUpdateRestriction() throws Exception {
+        HardcodedDataManager dataManager = new HardcodedDataManager();
+        dataManager.addData("SELECT g_0.e1, g_0.e2 FROM pm1.g3 AS g_0 WHERE (g_0.e1 = 'a') AND (g_0.e2 = 2)",
+        new List<?>[] {Arrays.asList("a", 2)});
+        dataManager.addData("UPDATE pm1.g3 SET e2 = 1 WHERE (e2 = 2) AND (e1 = 'user')", new List<?>[] {Arrays.asList(1)});
+
+        //can see e1 = 'a'
+        ProcessorPlan plan = helpGetPlan(helpParse("select e1, e2 from pm1.g3 where e1 = 'a' and e2 = 2"), RealMetadataFactory.example4(), TestOptimizer.getGenericFinder(), context);
+        List<?>[] expectedResults = new List<?>[] {Arrays.asList("a", 2)};
+        helpProcess(plan, context, dataManager, expectedResults);
+
+        //can only update where e1 = user()
+        plan = helpGetPlan(helpParse("update pm1.g3 set e2 = 1 where e2 = 2"), RealMetadataFactory.example4(), TestOptimizer.getGenericFinder(), context);
+        expectedResults = new List<?>[] {Arrays.asList(1)};
+        helpProcess(plan, context, dataManager, expectedResults);
+    }
+
+}

--- a/runtime/src/main/java/org/teiid/runtime/AbstractVDBDeployer.java
+++ b/runtime/src/main/java/org/teiid/runtime/AbstractVDBDeployer.java
@@ -480,6 +480,7 @@ public abstract class AbstractVDBDeployer {
             } finally {
                 deploymentStore.stopEditing();
             }
+
             DatabaseUtil.copyDatabaseGrantsAndRoles(database, vdb);
         }
     }

--- a/runtime/src/main/java/org/teiid/runtime/EmbeddedServer.java
+++ b/runtime/src/main/java/org/teiid/runtime/EmbeddedServer.java
@@ -767,8 +767,8 @@ public class EmbeddedServer extends AbstractVDBDeployer implements EventDistribu
             } catch (XMLStreamException e) {
                 throw new VirtualDatabaseException(e);
             }
+            metadata.setXmlDeployment(true);
         }
-        metadata.setXmlDeployment(true);
         deployVDB(metadata, null);
     }
 

--- a/runtime/src/test/resources/portfolio-converted-vdb.ddl
+++ b/runtime/src/test/resources/portfolio-converted-vdb.ddl
@@ -104,8 +104,6 @@ SET SCHEMA Stocks;
          
 
 --############ Grants ############
-REVOKE SELECT ON SCHEMA Accounts FROM Prices;
-
 GRANT SELECT ON SCHEMA Accounts TO ReadOnly;
 GRANT ON COLUMN "Accounts.Account.SSN" MASK 'null' TO ReadOnly;
 GRANT "Accounts.Customer" CONDITION 'state <> ''New York''' TO ReadOnly;
@@ -113,6 +111,8 @@ GRANT ON COLUMN "Accounts.Customer.SSN" MASK 'null' TO ReadOnly;
 GRANT SELECT ON SCHEMA MarketData TO ReadOnly;
 GRANT SELECT ON SCHEMA Stocks TO ReadOnly;
 GRANT ON COLUMN "Stocks.StockPrices.Price" MASK ORDER 1 'CASE WHEN hasRole(''Prices'') = true THEN Price END' TO ReadOnly;
+
+REVOKE SELECT ON SCHEMA Accounts FROM Prices;
 
 GRANT SELECT,INSERT,UPDATE,DELETE ON SCHEMA Accounts TO ReadWrite;
 GRANT ON COLUMN "Accounts.Account.SSN" MASK ORDER 1 'SSN' TO ReadWrite;

--- a/runtime/src/test/resources/portfolio-vdb.ddl
+++ b/runtime/src/test/resources/portfolio-vdb.ddl
@@ -104,8 +104,6 @@ SET SCHEMA Stocks;
          
 
 --############ Grants ############
-REVOKE SELECT ON SCHEMA Accounts FROM Prices;
-
 GRANT SELECT ON SCHEMA Accounts TO ReadOnly;
 GRANT ON COLUMN "Accounts.Account.SSN" MASK 'null' TO ReadOnly;
 GRANT "Accounts.Customer" CONDITION 'state <> ''New York''' TO ReadOnly;
@@ -113,6 +111,8 @@ GRANT ON COLUMN "Accounts.Customer.SSN" MASK 'null' TO ReadOnly;
 GRANT SELECT ON SCHEMA MarketData TO ReadOnly;
 GRANT SELECT ON SCHEMA Stocks TO ReadOnly;
 GRANT ON COLUMN "Stocks.StockPrices.Price" MASK ORDER 1 'CASE WHEN hasRole(''Prices'') = true THEN Price END' TO ReadOnly;
+
+REVOKE SELECT ON SCHEMA Accounts FROM Prices;
 
 GRANT SELECT,INSERT,UPDATE,DELETE ON SCHEMA Accounts TO ReadWrite;
 GRANT ON COLUMN "Accounts.Account.SSN" MASK ORDER 1 'SSN' TO ReadWrite;

--- a/wildfly/test-integration/common/src/test/java/org/teiid/jdbc/TestRowBasedSecurity.java
+++ b/wildfly/test-integration/common/src/test/java/org/teiid/jdbc/TestRowBasedSecurity.java
@@ -39,6 +39,7 @@ import org.mockito.Mockito;
 import org.teiid.core.util.UnitTestUtil;
 import org.teiid.metadata.Column;
 import org.teiid.metadata.MetadataFactory;
+import org.teiid.metadata.Policy.Operation;
 import org.teiid.metadata.Table;
 import org.teiid.metadata.Table.Type;
 import org.teiid.runtime.DoNothingSecurityHelper;
@@ -87,6 +88,7 @@ public class TestRowBasedSecurity {
                 t = metadataFactory.addTable("y");
                 col = metadataFactory.addColumn("col", TypeFacility.RUNTIME_NAMES.STRING, t);
                 metadataFactory.addColumn("col2", TypeFacility.RUNTIME_NAMES.STRING, t);
+                metadataFactory.addPolicy("z", "col policy", t, "col = 'e'", null, Operation.ALL);
                 metadataFactory.addPermission("z", t, null, null, null, null, null, null, "col = 'e'", null);
 
                 Table v = metadataFactory.addTable("v");


### PR DESCRIPTION
this is roughly based on pg, but the name is scoped to both the resource
and the role - that's why drop takes both arguments.

it has been simplified to only specify a using condition, which defaults
to a constraint/check.  if you want to create separate read/write
policies, you need add two policies instead of one.

this does not yet attempt to rewrite the old permission condition logic
as policies