### PR TITLE
Lazy validation

### DIFF
--- a/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/salesforce/BaseSalesforceConnection.java
+++ b/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/salesforce/BaseSalesforceConnection.java
@@ -160,16 +160,12 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
             s = s.substring(index+1, end);
             return Long.valueOf(s);
         } catch (NumberFormatException e) {
-            checkValid();
             throw new TranslatorException(e);
         } catch (MalformedURLException e) {
-            checkValid();
             throw new TranslatorException(e);
         } catch (UnsupportedEncodingException e) {
-            checkValid();
             throw new TranslatorException(e);
         } catch (IOException e) {
-            checkValid();
             throw new TranslatorException(e);
         } finally {
             if (is != null) {

--- a/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/salesforce/BaseSalesforceConnection.java
+++ b/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/salesforce/BaseSalesforceConnection.java
@@ -230,7 +230,7 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
                 partnerConnection.setMruHeader(false);
                 qr = partnerConnection.query(queryString);
             }
-        } catch (Exception e) {
+        } catch (ConnectionException e) {
             throw new TranslatorException(e);
         } finally {
             partnerConnection.clearMruHeader();
@@ -253,7 +253,7 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
         partnerConnection.setQueryOptions(batchSize);
         try {
             return partnerConnection.queryMore(queryLocator);
-        } catch (Exception e) {
+        } catch (ConnectionException e) {
             throw new TranslatorException(e);
         } finally {
             partnerConnection.clearQueryOptions();
@@ -269,7 +269,7 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
         DeleteResult[] results = null;
         try {
             results = partnerConnection.delete(ids);
-        } catch (Exception e) {
+        } catch (ConnectionException e) {
             throw new TranslatorException(e);
         }
 
@@ -309,12 +309,11 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
         UpsertResult[] results;
         try {
             results = partnerConnection.upsert(ID_FIELD_NAME, objects);
-        } catch (Exception e) {
+        } catch (ConnectionException e) {
             throw new TranslatorException(e);
         }
         for (UpsertResult result : results) {
             if(!result.isSuccess()) {
-                checkValid();
                 throw new TranslatorException(result.getErrors()[0].getMessage());
             }
         }
@@ -336,7 +335,7 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
         SaveResult[] result;
         try {
             result = partnerConnection.create(objects);
-        } catch (Exception e) {
+        } catch (ConnectionException e) {
             throw new TranslatorException(e);
         }
         return analyzeResult(result);
@@ -358,7 +357,7 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
         SaveResult[] result;
             try {
                 result = partnerConnection.update(params.toArray(new SObject[params.size()]));
-            } catch (Exception e) {
+            } catch (ConnectionException e) {
                 throw new TranslatorException(e);
             }
         return analyzeResult(result);
@@ -405,7 +404,7 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
             GetUpdatedResult updated;
             try {
                 updated = partnerConnection.getUpdated(objectType, startDate, endDate);
-            } catch (Exception e) {
+            } catch (ConnectionException e) {
                 throw new TranslatorException(e);
             }
             UpdatedResult result = new UpdatedResult();
@@ -424,7 +423,7 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
             GetDeletedResult deleted;
             try {
                 deleted = partnerConnection.getDeleted(objectName, startCalendar, endCalendar);
-            } catch (Exception e) {
+            } catch (ConnectionException e) {
                 throw new TranslatorException(e);
             }
             DeletedResult result = new DeletedResult();
@@ -451,9 +450,12 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
     public SObject[] retrieve(String fieldList, String sObjectType, List<String> ids) throws TranslatorException {
         try {
             return partnerConnection.retrieve(fieldList, sObjectType, ids.toArray(new String[ids.size()]));
-        } catch (Throwable e) {
+        }catch (ConnectionException e) { 
             checkValid();
             throw new TranslatorException(e);
+        }catch (Throwable e) {
+            checkValid();
+            throw e;
         }
 
     }
@@ -461,18 +463,24 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
     public DescribeGlobalResult getObjects() throws TranslatorException {
         try {
             return partnerConnection.describeGlobal();
-        } catch (Throwable e) {
+        }catch (ConnectionException e) { 
             checkValid();
             throw new TranslatorException(e);
+        }catch (Throwable e) {
+            checkValid();
+            throw e;
         }
     }
 
     public DescribeSObjectResult[] getObjectMetaData(String... objectName) throws TranslatorException {
         try {
             return partnerConnection.describeSObjects(objectName);
-        } catch (Throwable e) {
+        }catch (ConnectionException e) { 
             checkValid();
             throw new TranslatorException(e);
+        }catch (Throwable e) {
+            checkValid();
+            throw e;
         }
     }
 

--- a/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/salesforce/BaseSalesforceConnection.java
+++ b/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/salesforce/BaseSalesforceConnection.java
@@ -450,7 +450,7 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
     public SObject[] retrieve(String fieldList, String sObjectType, List<String> ids) throws TranslatorException {
         try {
             return partnerConnection.retrieve(fieldList, sObjectType, ids.toArray(new String[ids.size()]));
-        }catch (ConnectionException e) { 
+        }catch (ConnectionException e) {
             checkValid();
             throw new TranslatorException(e);
         }catch (Throwable e) {
@@ -463,7 +463,7 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
     public DescribeGlobalResult getObjects() throws TranslatorException {
         try {
             return partnerConnection.describeGlobal();
-        }catch (ConnectionException e) { 
+        }catch (ConnectionException e) {
             checkValid();
             throw new TranslatorException(e);
         }catch (Throwable e) {
@@ -475,7 +475,7 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
     public DescribeSObjectResult[] getObjectMetaData(String... objectName) throws TranslatorException {
         try {
             return partnerConnection.describeSObjects(objectName);
-        }catch (ConnectionException e) { 
+        }catch (ConnectionException e) {
             checkValid();
             throw new TranslatorException(e);
         }catch (Throwable e) {

--- a/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/salesforce/BaseSalesforceConnection.java
+++ b/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/salesforce/BaseSalesforceConnection.java
@@ -159,18 +159,23 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
             s = s.substring(index+1, end);
             return Long.valueOf(s);
         } catch (NumberFormatException e) {
+            checkValid();
             throw new TranslatorException(e);
         } catch (MalformedURLException e) {
+            checkValid();
             throw new TranslatorException(e);
         } catch (UnsupportedEncodingException e) {
+            checkValid();
             throw new TranslatorException(e);
         } catch (IOException e) {
+            checkValid();
             throw new TranslatorException(e);
         } finally {
             if (is != null) {
                 try {
                     is.close();
                 } catch (IOException e) {
+                    checkValid();
                 }
             }
         }
@@ -442,10 +447,6 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
 
     }
 
-    public boolean isAlive() {
-        return checkValid();
-    }
-
     @Override
     public JobInfo createBulkJob(String objectName, OperationEnum operation, boolean usePkChunking) throws TranslatorException {
         try {
@@ -521,6 +522,7 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
                             switch (batchInfoItem.getState()) {
                             case Failed:
                             case NotProcessed:
+                                checkValid();
                                 throw new TranslatorException(batchInfoItem.getStateMessage());
                             case Completed:
                                 anyComplete = true;
@@ -543,6 +545,7 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
                     case Queued:
                     throwDataNotAvailable(info);
                      default:
+                        checkValid();
                         throw new TranslatorException(batch.getStateMessage());
                 }
             } catch (AsyncApiException e) {
@@ -602,6 +605,7 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
             switch (bi.getState()) {
             case Failed:
             case NotProcessed:
+                checkValid();
                 throw new TranslatorException(bi.getStateMessage());
             case Completed:
                 if (completedId == null) {
@@ -642,6 +646,7 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
                     try {
                         inputStream.close();
                     } catch (IOException e) {
+                        checkValid();
                     }
                 }
             };

--- a/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/translator/salesforce/SalesforceConnection.java
+++ b/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/translator/salesforce/SalesforceConnection.java
@@ -104,7 +104,7 @@ public interface SalesforceConnection extends Connection {
 
     public QueryResult queryMore(String queryLocator, int batchSize) throws TranslatorException;
 
-    public boolean isValid();
+    public boolean checkValid();
 
     public int delete(String[] ids) throws TranslatorException ;
 


### PR DESCRIPTION
Every time connection validation changed to lazy. Because make call 
{code}
partnerConnection.getServerTimestamp()
{code} 
every inbound request it is very expensive and give low performance.
Connection "is alive" now will fired if we get Exceptions.