### PR TITLE
TEIID-4594 fixes and several enhancements

### DIFF
--- a/connectors/file/translator-parquet/pom.xml
+++ b/connectors/file/translator-parquet/pom.xml
@@ -46,10 +46,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/connectors/file/translator-parquet/src/main/java/org/teiid/translator/parquet/BaseParquetExecution.java
+++ b/connectors/file/translator-parquet/src/main/java/org/teiid/translator/parquet/BaseParquetExecution.java
@@ -25,9 +25,7 @@ import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -54,7 +52,12 @@ import org.apache.parquet.schema.Type;
 import org.teiid.core.types.BinaryType;
 import org.teiid.file.VirtualFile;
 import org.teiid.file.VirtualFileConnection;
+import org.teiid.language.AndOr;
+import org.teiid.language.ColumnReference;
 import org.teiid.language.Comparison;
+import org.teiid.language.Comparison.Operator;
+import org.teiid.language.Condition;
+import org.teiid.language.IsNull;
 import org.teiid.language.LanguageObject;
 import org.teiid.language.Literal;
 import org.teiid.metadata.RuntimeMetadata;
@@ -62,8 +65,6 @@ import org.teiid.translator.DataNotAvailableException;
 import org.teiid.translator.Execution;
 import org.teiid.translator.ExecutionContext;
 import org.teiid.translator.TranslatorException;
-
-import com.google.common.collect.Multimap;
 
 
 public class BaseParquetExecution implements Execution {
@@ -84,7 +85,7 @@ public class BaseParquetExecution implements Execution {
     private MessageColumnIO columnIO;
     private long pageRowCount;
     protected HashMap<String, String> partitionedColumnsValue;
-    protected HashSet<String> partitionedColumnsHm = new HashSet<>();
+    private FilterCompat.Filter rowGroupFilter;
 
     public BaseParquetExecution(ExecutionContext executionContext,
                                 RuntimeMetadata metadata, VirtualFileConnection connection, boolean immutable) {
@@ -96,108 +97,139 @@ public class BaseParquetExecution implements Execution {
 
     public void visit(LanguageObject command) throws TranslatorException {
         this.visitor.visitNode(command);
-
-        if (!visitor.exceptions.isEmpty()) {
-            throw visitor.exceptions.get(0);
-        }
     }
 
     @Override
     public void execute() throws TranslatorException {
         String path = this.visitor.getParquetPath();
-        if(this.visitor.getTable().getProperty(ParquetMetadataProcessor.PARTITIONED_COLUMNS) != null) {
-            path += getDirectoryPath(this.visitor.getColumnPredicates(), this.visitor.getTable().getProperty(ParquetMetadataProcessor.PARTITIONED_COLUMNS));
+        if(!this.visitor.getPartitionedColumns().isEmpty()) {
+            path += getDirectoryPath(this.visitor.getPartitionedComparisons());
         }
+        rowGroupFilter = getRowGroupFilter(this.visitor.getNonPartionedConditions());
         this.parquetFiles = VirtualFileConnection.Util.getFiles(path, this.connection, true, false);
         VirtualFile nextParquetFile = getNextParquetFile();
         if (nextParquetFile != null) {
-            this.rowIterator = readParquetFile(nextParquetFile);
+            readParquetFile(nextParquetFile);
         }
     }
 
-    private String getDirectoryPath(Multimap<String, Comparison> predicates, String partitionedColumns) throws TranslatorException {
+    private String getDirectoryPath(Map<String, Comparison> predicates) {
         StringBuilder path = new StringBuilder(); // because we are only supporting the equality comparison as of now, otherwise we would return a list of paths to iterate over
-        String[] partitionedColumnsArray = getPartitionedColumns(partitionedColumns);
-        for (String s : partitionedColumnsArray) {
-            partitionedColumnsHm.add(s);
+        for (String s : this.visitor.getPartitionedColumns()) {
             path.append("/").append(s.replaceAll("[*]", "[*][*]")).append("=");
             String value = "*";
-            Collection<Comparison> columnPredicates = predicates.get(s);
-            for(Comparison predicate: columnPredicates) {
+            Comparison predicate = predicates.get(s);
+            if (predicate != null) {
                 Literal l = (Literal) predicate.getRightExpression();
                 if (predicate.getOperator() == Comparison.Operator.EQ) {
                     value = l.getValue().toString().replaceAll("[*]", "[*][*]");
                 }
             }
+            //TODO: handle the other comparisons in the execution
             path.append(value);
-            predicates.removeAll(s);
         }
         path.append("/*");
         return path.toString();
     }
 
-    private FilterCompat.Filter getRowGroupFilter(Multimap<String, Comparison> columnPredicates) throws TranslatorException {
+    private FilterPredicate getRowGroupFilter(Condition condition) throws TranslatorException {
+        FilterPredicate filterPredicate = null;
+        if (condition instanceof AndOr) {
+            AndOr andOr = (AndOr)condition;
+            filterPredicate = getRowGroupFilter(andOr.getLeftCondition());
+            if (andOr.getOperator() == org.teiid.language.AndOr.Operator.AND) {
+                filterPredicate = FilterApi.and(filterPredicate, getRowGroupFilter(andOr.getRightCondition()));
+            } else {
+                filterPredicate = FilterApi.or(filterPredicate, getRowGroupFilter(andOr.getRightCondition()));
+            }
+            return filterPredicate;
+        }
+        if (condition instanceof IsNull) {
+            //rewrite isnull as a comparison
+            IsNull isNull = (IsNull)condition;
+            condition = new Comparison(isNull.getExpression(), new Literal(null, isNull.getExpression().getType()), isNull.isNegated()?Operator.NE:Operator.EQ);
+        }
+        if (condition instanceof Comparison) {
+            Comparison comparison = (Comparison)condition;
+            String columnName = ((ColumnReference)comparison.getLeftExpression()).getMetadataObject().getSourceName();
+            Literal l = (Literal) comparison.getRightExpression();
+            Column<?> column;
+            Comparable<?> value = null;
+            switch (comparison.getRightExpression().getType().getName()) {
+                case "java.lang.String":
+                    column = FilterApi.binaryColumn(columnName);
+                    String stringValue = (String)l.getValue();
+                    if (stringValue != null) {
+                        value = Binary.fromString(stringValue);
+                    }
+                    break;
+                case "org.teiid.core.types.BinaryType":
+                    column = FilterApi.binaryColumn(columnName);
+                    BinaryType binaryType = (BinaryType) l.getValue();
+                    if (binaryType != null) {
+                        value = Binary.fromConstantByteArray(binaryType.getBytes());
+                    }
+                    break;
+                case "java.lang.Long":
+                    column = FilterApi.longColumn(columnName);
+                    value = (Long) l.getValue();
+                    break;
+                case "java.lang.Integer":
+                    column = FilterApi.intColumn(columnName);
+                    value = (Integer) l.getValue();
+                    break;
+                case "java.lang.Boolean":
+                    column = FilterApi.booleanColumn(columnName);
+                    value = (Boolean) l.getValue();
+                    break;
+                case "java.lang.Double":
+                    column = FilterApi.doubleColumn(columnName);
+                    value = (Double) l.getValue();
+                    break;
+                case "java.lang.Float":
+                    column = FilterApi.floatColumn(columnName);
+                    value = (Float) l.getValue();
+                    break;
+                default:
+                    throw new TranslatorException("The type " + comparison.getRightExpression().getType().getName() + " is not supported for comparison.");
+            }
+            try {
+                filterPredicate = toFilterPredicate(comparison, column, value);
+
+                //the api implements java like null comparisons, so we need an additional null filter
+                if (comparison.getOperator() == Operator.NE && value != null) {
+                    filterPredicate = FilterApi.and(filterPredicate, toFilterPredicate(comparison, column, null));
+                }
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                throw new TranslatorException(e);
+            }
+        }
+        return filterPredicate;
+    }
+
+    private FilterCompat.Filter getRowGroupFilter(List<Condition> columnPredicates) throws TranslatorException {
         if(columnPredicates.size() == 0){
             return FilterCompat.NOOP;
         }
         FilterPredicate combinedFilterPredicate = null, filterPredicate;
-        for (Map.Entry<String, Collection<Comparison>> entry : columnPredicates.asMap().entrySet()) {
-            String columnName = entry.getKey();
-            Collection<Comparison> collection = entry.getValue();
-            for (Comparison comparison :
-                    collection) {
-                Literal l = (Literal) comparison.getRightExpression();
-                Column<?> column;
-                Comparable<?> value;
-                switch (comparison.getRightExpression().getType().getName()) {
-                    case "java.lang.String":
-                        column = FilterApi.binaryColumn(columnName);
-                        value = Binary.fromString((String) l.getValue());
-                        break;
-                    case "org.teiid.core.types.BinaryType":
-                        column = FilterApi.binaryColumn(columnName);
-                        BinaryType binaryType = (BinaryType) l.getValue();
-                        value = Binary.fromConstantByteArray(binaryType.getBytes());
-                        break;
-                    case "java.lang.Long":
-                        column = FilterApi.longColumn(columnName);
-                        value = (Long) l.getValue();
-                        break;
-                    case "java.lang.Integer":
-                        column = FilterApi.intColumn(columnName);
-                        value = (Integer) l.getValue();
-                        break;
-                    case "java.lang.Boolean":
-                        column = FilterApi.booleanColumn(columnName);
-                        value = (Boolean) l.getValue();
-                        break;
-                    case "java.lang.Double":
-                        column = FilterApi.doubleColumn(columnName);
-                        value = (Double) l.getValue();
-                        break;
-                    case "java.lang.Float":
-                        column = FilterApi.floatColumn(columnName);
-                        value = (Float) l.getValue();
-                        break;
-                    default:
-                        throw new TranslatorException("The type " + comparison.getRightExpression().getType().getName() + " is not supported for comparison.");
-                }
-                try {
-                    Method m = FilterApi.class.getMethod(getMethodName(comparison.getOperator()), Column.class, Comparable.class);
-                    filterPredicate = (FilterPredicate) m.invoke(null, column, value);
-                } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-                    throw new TranslatorException(e);
-                }
-                if (combinedFilterPredicate == null) {
-                    combinedFilterPredicate = filterPredicate;
-                } else {
-                    combinedFilterPredicate = FilterApi.and(combinedFilterPredicate, filterPredicate);
-                }
+        for (Condition cond : columnPredicates) {
+            filterPredicate = getRowGroupFilter(cond);
+            if (combinedFilterPredicate == null) {
+                combinedFilterPredicate = filterPredicate;
+            } else {
+                combinedFilterPredicate = FilterApi.and(combinedFilterPredicate, filterPredicate);
             }
-
         }
         assert combinedFilterPredicate != null;
         return FilterCompat.get(combinedFilterPredicate);
+    }
+
+    private FilterPredicate toFilterPredicate(Comparison comparison,
+            Column<?> column, Comparable<?> value)
+            throws NoSuchMethodException, TranslatorException,
+            IllegalAccessException, InvocationTargetException {
+        Method m = FilterApi.class.getMethod(getMethodName(comparison.getOperator()), Column.class, Comparable.class);
+        return (FilterPredicate) m.invoke(null, column, value);
     }
 
     private String getMethodName(Comparison.Operator operator) throws TranslatorException {
@@ -212,22 +244,18 @@ public class BaseParquetExecution implements Execution {
         }
     }
 
-    private RecordReader<Group> readParquetFile(VirtualFile parquetFile) throws TranslatorException {
+    private void readParquetFile(VirtualFile parquetFile) throws TranslatorException {
         try (InputStream parquetFileStream = parquetFile.openInputStream(!immutable)) {
-            if(this.visitor.getTable().getProperty(ParquetMetadataProcessor.PARTITIONED_COLUMNS) != null) {
+            if(!this.visitor.getPartitionedColumns().isEmpty()) {
                 partitionedColumnsValue = getPartitionedColumnsValues(parquetFile);
             }
             File localFile = createTempFile(parquetFileStream);
             Path path = new Path(localFile.toURI());
             Configuration config = new Configuration();
-            FilterCompat.Filter rowGroupFilter = getRowGroupFilter(this.visitor.getColumnPredicates());
             reader = ParquetFileReader.open(HadoopInputFile.fromPath(path, config), ParquetReadOptions.builder().withRecordFilter(rowGroupFilter).build());
             MessageType schema = reader.getFooter().getFileMetaData().getSchema();
             filteredSchema = getFilteredSchema(schema, this.visitor.getProjectedColumnNames());
             columnIO = new ColumnIOFactory().getColumnIO(filteredSchema);
-            PageReadStore pages = reader.readNextRowGroup();
-            pageRowCount = pages.getRowCount();
-            return columnIO.getRecordReader(pages, new GroupRecordConverter(filteredSchema), rowGroupFilter);
         } catch (IOException e) {
             throw new TranslatorException(e);
         }
@@ -250,7 +278,7 @@ public class BaseParquetExecution implements Execution {
         List<Type> allColumns = schema.getFields();
         List<Type> selectedColumns = new ArrayList<>();
         for(String columnName: expectedColumnNames) {
-            if(!partitionedColumnsHm.contains(columnName)) {
+            if(!this.visitor.getPartitionedColumns().contains(columnName)) {
                 selectedColumns.add(allColumns.get(schema.getFieldIndex(columnName)));
             }
         }
@@ -268,20 +296,22 @@ public class BaseParquetExecution implements Execution {
 
     public Group nextRow() throws TranslatorException, DataNotAvailableException {
         try {
-            while (rowIterator != null) {
-                if (pageRowCount-- <= 0) {
+            while (columnIO != null) {
+                if (this.rowIterator == null || pageRowCount-- <= 0) {
                     this.rowIterator = null;
                     PageReadStore nextRowGroup = this.reader.readNextRowGroup();
                     if(nextRowGroup == null){
                         VirtualFile nextParquetFile = getNextParquetFile();
                         if (nextParquetFile == null) {
-                            return null;
+                            columnIO = null;
+                            return null; //terminal condition
                         }
-                        this.rowIterator = readParquetFile(nextParquetFile);
-                        continue;
+                        readParquetFile(nextParquetFile);
+                        continue; //try again on the next file
                     }
                     this.pageRowCount = nextRowGroup.getRowCount();
-                    this.rowIterator = columnIO.getRecordReader(nextRowGroup, new GroupRecordConverter(filteredSchema));
+                    this.rowIterator = columnIO.getRecordReader(nextRowGroup, new GroupRecordConverter(filteredSchema), rowGroupFilter);
+                    continue;
                 }
                 Group presentRow = rowIterator.read();
                 if(presentRow == null){
@@ -304,12 +334,6 @@ public class BaseParquetExecution implements Execution {
             }
         }
         return null;
-    }
-
-    private String[] getPartitionedColumns(String partitionedColumns) {
-        String[] partitionedColumnList;
-        partitionedColumnList = partitionedColumns.split(",");
-        return partitionedColumnList;
     }
 
     @Override

--- a/connectors/file/translator-parquet/src/main/java/org/teiid/translator/parquet/ParquetExecution.java
+++ b/connectors/file/translator-parquet/src/main/java/org/teiid/translator/parquet/ParquetExecution.java
@@ -58,7 +58,7 @@ public class ParquetExecution extends BaseParquetExecution implements ResultSetE
         int field = 0;
         List<String> expectedColumnNames = this.visitor.getProjectedColumnNames();
         for (int i = 0; i < expectedColumnNames.size(); i++) {
-            if(this.partitionedColumnsHm.contains(expectedColumnNames.get(i))){
+            if(this.visitor.getPartitionedColumns().contains(expectedColumnNames.get(i))){
                 output.add(partitionedColumnsValue.get(expectedColumnNames.get(i)));
             }else {
                 Type fieldType = row.getType().getType(field);

--- a/connectors/file/translator-parquet/src/main/java/org/teiid/translator/parquet/ParquetExecutionFactory.java
+++ b/connectors/file/translator-parquet/src/main/java/org/teiid/translator/parquet/ParquetExecutionFactory.java
@@ -75,4 +75,14 @@ public class ParquetExecutionFactory extends ExecutionFactory<ConnectionFactory,
     public boolean supportsPartialFiltering() {
         return true;
     }
+
+    @Override
+    public boolean supportsOrCriteria() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsIsNullCriteria() {
+        return true;
+    }
 }

--- a/connectors/file/translator-parquet/src/main/java/org/teiid/translator/parquet/ParquetQueryVisitor.java
+++ b/connectors/file/translator-parquet/src/main/java/org/teiid/translator/parquet/ParquetQueryVisitor.java
@@ -18,43 +18,37 @@
 package org.teiid.translator.parquet;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Stack;
+import java.util.Map;
 
 import org.teiid.language.ColumnReference;
 import org.teiid.language.Comparison;
+import org.teiid.language.Condition;
 import org.teiid.language.DerivedColumn;
-import org.teiid.language.Literal;
+import org.teiid.language.LanguageUtil;
 import org.teiid.language.NamedTable;
+import org.teiid.language.Select;
+import org.teiid.language.visitor.CollectorVisitor;
 import org.teiid.language.visitor.HierarchyVisitor;
 import org.teiid.metadata.Column;
 import org.teiid.metadata.Table;
-import org.teiid.translator.TranslatorException;
-
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 
 public class ParquetQueryVisitor extends HierarchyVisitor {
 
-    protected Stack<Object> onGoingExpression = new Stack<Object>();
     private List<String> projectedColumnNames = new ArrayList<String>();
-    protected ArrayList<TranslatorException> exceptions = new ArrayList<TranslatorException>();
-
-    public Multimap<String, Comparison> getColumnPredicates() {
-        return columnPredicates;
-    }
-
-    private Multimap<String, Comparison> columnPredicates = ArrayListMultimap.create();
+    private LinkedHashSet<String> partitionedColumns = new LinkedHashSet<>();
+    private Map<String, Comparison> partitionedComparisons = new HashMap<String, Comparison>();
+    private List<Condition> nonPartionedConditions = new ArrayList<>();
 
     private Table table;
     private String parquetPath;
 
     public List<String> getProjectedColumnNames() {
         return projectedColumnNames;
-    }
-
-    public ArrayList<TranslatorException> getExceptions() {
-        return exceptions;
     }
 
     public Table getTable() {
@@ -65,40 +59,69 @@ public class ParquetQueryVisitor extends HierarchyVisitor {
         return parquetPath;
     }
 
+    public LinkedHashSet<String> getPartitionedColumns() {
+        return partitionedColumns;
+    }
+
+    public List<Condition> getNonPartionedConditions() {
+        return nonPartionedConditions;
+    }
+
+    public Map<String, Comparison> getPartitionedComparisons() {
+        return partitionedComparisons;
+    }
+
     @Override
     public void visit(NamedTable obj) {
         this.table = obj.getMetadataObject();
         this.parquetPath = this.table.getProperty(ParquetMetadataProcessor.FILE);
+        String partitionedColumnNames = this.table.getProperty(ParquetMetadataProcessor.PARTITIONED_COLUMNS);
+        if (partitionedColumnNames != null) {
+            partitionedColumns.addAll(Arrays.asList(partitionedColumnNames.split(","))); //$NON-NLS-1$
+        }
     }
 
     @Override
-    public void visit(ColumnReference obj) {
-        this.onGoingExpression.add(obj.getMetadataObject());
-    }
+    public void visit(Select obj) {
+        for (DerivedColumn column : obj.getDerivedColumns()) {
+            this.projectedColumnNames
+                    .add(((ColumnReference) column.getExpression())
+                            .getMetadataObject().getSourceName());
+        }
 
-    @Override
-    public void visit(DerivedColumn obj) {
-        visitNode(obj.getExpression());
+        //visit the from to initialize the partitioned columns
+        visitNodes(obj.getFrom());
 
-        createProjectedColumn();
-    }
-
-    private void createProjectedColumn() {
-        Column column = (Column) this.onGoingExpression.pop();
-        this.projectedColumnNames.add(column.getSourceName());
-    }
-
-    @Override
-    public void visit(Comparison obj) {
-        ColumnReference cr = (ColumnReference) obj.getLeftExpression();
-        Column column = cr.getMetadataObject();
-        String columnName = column.getSourceName();
-        columnPredicates.put(columnName, obj);
-    }
-
-    @Override
-    public void visit(Literal obj) {
-        this.onGoingExpression.push(obj.getValue());
+        for (Condition c : LanguageUtil.separateCriteriaByAnd(obj.getWhere())) {
+            Collection<ColumnReference> cols = CollectorVisitor.collectElements(c);
+            boolean partitioned = false;
+            boolean nonPartitioned = false;
+            for (ColumnReference ref : cols) {
+                if (partitionedColumns.contains(ref.getMetadataObject().getSourceName())) {
+                    partitioned = true;
+                } else {
+                    nonPartitioned = true;
+                }
+            }
+            if (partitioned && nonPartitioned) {
+                //not currently usable - spans both partitioning and non-partitioning columns
+                continue;
+            }
+            if (partitioned) {
+                if (!(c instanceof Comparison)) {
+                    //not currently usable
+                    continue;
+                }
+                Comparison comp = (Comparison)c;
+                ColumnReference cr = (ColumnReference) comp.getLeftExpression();
+                Column column = cr.getMetadataObject();
+                String columnName = column.getSourceName();
+                Comparison old = partitionedComparisons.put(columnName, comp);
+                assert old == null;
+            } else if (nonPartitioned) {
+                nonPartionedConditions.add(c);
+            }
+        }
     }
 
 }

--- a/connectors/file/translator-parquet/src/test/java/org/teiid/translator/parquet/TestParquetExecution.java
+++ b/connectors/file/translator-parquet/src/test/java/org/teiid/translator/parquet/TestParquetExecution.java
@@ -295,4 +295,49 @@ public class TestParquetExecution {
         Assert.assertEquals("[[2, Animesh]]", results.toString());
     }
 
+    @Test
+    public void testParquetExecutionWithRowFilterIsNull() throws Exception {
+        String ddl = "CREATE FOREIGN TABLE Table1 (\n" +
+                "   firstname string ,\n" +
+                "   id long ,\n" +
+                "   lastname string ,\n" +
+                "   CONSTRAINT PK0 PRIMARY KEY(id)\n" +
+                ") OPTIONS (\"teiid_parquet:FILE\" 'people1.parquet');";
+
+        VirtualFileConnection connection = new JavaVirtualFileConnection(UnitTestUtil.getTestDataPath());
+
+        ArrayList<?> results = helpExecute(ddl, connection, "select id,firstname from Table1 WHERE firstName is null");
+        Assert.assertEquals("[]", results.toString());
+    }
+
+    @Test
+    public void testParquetExecutionWithRowFilterIsNotNull() throws Exception {
+        String ddl = "CREATE FOREIGN TABLE Table1 (\n" +
+                "   firstname string ,\n" +
+                "   id long ,\n" +
+                "   lastname string ,\n" +
+                "   CONSTRAINT PK0 PRIMARY KEY(id)\n" +
+                ") OPTIONS (\"teiid_parquet:FILE\" 'people1.parquet');";
+
+        VirtualFileConnection connection = new JavaVirtualFileConnection(UnitTestUtil.getTestDataPath());
+
+        ArrayList<?> results = helpExecute(ddl, connection, "select id,firstname from Table1 WHERE firstName is not null");
+        Assert.assertEquals("[[1, Aditya], [2, Animesh], [3, Shradha]]", results.toString());
+    }
+
+    @Test
+    public void testParquetExecutionWithRowFilterOr() throws Exception {
+        String ddl = "CREATE FOREIGN TABLE Table1 (\n" +
+                "   firstname string ,\n" +
+                "   id long ,\n" +
+                "   lastname string ,\n" +
+                "   CONSTRAINT PK0 PRIMARY KEY(id)\n" +
+                ") OPTIONS (\"teiid_parquet:FILE\" 'people1.parquet');";
+
+        VirtualFileConnection connection = new JavaVirtualFileConnection(UnitTestUtil.getTestDataPath());
+
+        ArrayList<?> results = helpExecute(ddl, connection, "select id,firstname from Table1 WHERE firstName = 'Aditya' or id = 2");
+        Assert.assertEquals("[[1, Aditya], [2, Animesh]]", results.toString());
+    }
+
 }


### PR DESCRIPTION
adding or and is null support, which requires a different visitation
strategy

accounting for ne null handling (but we don't have a null value in the
test data)

making sure the rowGroupFilter is always passed to getRecordReader

handling a null nextRowGroup