### PR TITLE
Fixed wrong table names for geometry metadata tables

### DIFF
--- a/connectors/jdbc/translator-jdbc/src/main/java/org/teiid/translator/jdbc/postgresql/PostgreSQLMetadataProcessor.java
+++ b/connectors/jdbc/translator-jdbc/src/main/java/org/teiid/translator/jdbc/postgresql/PostgreSQLMetadataProcessor.java
@@ -73,12 +73,12 @@ public class PostgreSQLMetadataProcessor
 
     @Override
     protected String getGeographyMetadataTableName() {
-        return "public.geometry_columns"; //$NON-NLS-1$
+        return "public.geography_columns"; //$NON-NLS-1$
     }
 
     @Override
     protected String getGeometryMetadataTableName() {
-        return "public.geography_columns"; //$NON-NLS-1$
+        return "public.geometry_columns"; //$NON-NLS-1$
     }
 
     @Override


### PR DESCRIPTION
Based on exceptions in the log file I found an error in the PostgreSQLMetadataProcessor. The table names for geometry metadata tables are mixed-up. 