### PR TITLE
Prepare to multithreaded use of PartnerConnection

### DIFF
--- a/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/salesforce/BaseSalesforceConnection.java
+++ b/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/salesforce/BaseSalesforceConnection.java
@@ -95,7 +95,8 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
     public BaseSalesforceConnection(T salesforceConfig) throws AsyncApiException, ConnectionException {
         config = createConnectorConfig(salesforceConfig);
         partnerConnection = login(salesforceConfig, config);
-
+        partnerConnection.setMruHeader(false); //Because really MRU used only in query and always false
+        partnerConnection.setQueryOptions(2000);//Because we have hard SF limit and really this value always is 2000
         String endpoint = config.getServiceEndpoint();
         // The endpoint for the Bulk API service is the same as for the normal
         // SOAP uri until the /Soap/ part. From here it's '/async/versionNumber'
@@ -199,44 +200,29 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
         return partnerConnection;
     }
 
-    public QueryResult query(String queryString, int batchSize, boolean queryAll) throws TranslatorException {
-
-        if(batchSize > 2000) {
-            batchSize = 2000;
-            LogManager.logDetail(LogConstants.CTX_CONNECTOR, "reduced.batch.size"); //$NON-NLS-1$
-        }
+    @Override
+    public QueryResult query(String queryString, boolean queryAll) throws TranslatorException {
 
         QueryResult qr = null;
-        partnerConnection.setQueryOptions(batchSize);
         try {
             if(queryAll) {
                 qr = partnerConnection.queryAll(queryString);
             } else {
-                partnerConnection.setMruHeader(false);
                 qr = partnerConnection.query(queryString);
             }
         } catch (ConnectionException e) {
             throw new TranslatorException(e);
-        } finally {
-            partnerConnection.clearMruHeader();
-            partnerConnection.clearQueryOptions();
         }
         return qr;
     }
 
-    public QueryResult queryMore(String queryLocator, int batchSize) throws TranslatorException {
-        if(batchSize > 2000) {
-            batchSize = 2000;
-            LogManager.logDetail(LogConstants.CTX_CONNECTOR, "reduced.batch.size"); //$NON-NLS-1$
-        }
-
-        partnerConnection.setQueryOptions(batchSize);
-        try {
+    @Override
+    public QueryResult queryMore(String queryLocator) throws TranslatorException {
+        
+    	try {
             return partnerConnection.queryMore(queryLocator);
         } catch (ConnectionException e) {
             throw new TranslatorException(e);
-        } finally {
-            partnerConnection.clearQueryOptions();
         }
 
     }
@@ -434,15 +420,17 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
                 job.setExternalIdFieldName(ID_FIELD_NAME);
             }
             job.setConcurrencyMode(ConcurrencyMode.Parallel);
-            if (operation == OperationEnum.query && usePkChunking) {
-                this.bulkConnection.addHeader(PK_CHUNKING_HEADER, "chunkSize=" + MAX_CHUNK_SIZE); //$NON-NLS-1$
+            synchronized(this){
+	            if (operation == OperationEnum.query && usePkChunking) {
+	                this.bulkConnection.addHeader(PK_CHUNKING_HEADER, "chunkSize=" + MAX_CHUNK_SIZE); //$NON-NLS-1$
+	            }
+	            JobInfo info = this.bulkConnection.createJob(job);
+	            //reset the header
+	            if (operation == OperationEnum.query) {
+	                this.bulkConnection = new BulkConnection(config);
+	            }
+	            return info;
             }
-            JobInfo info = this.bulkConnection.createJob(job);
-            //reset the header
-            if (operation == OperationEnum.query) {
-                this.bulkConnection = new BulkConnection(config);
-            }
-            return info;
         } catch (AsyncApiException e) {
             throw new TranslatorException(e);
         }

--- a/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/salesforce/BaseSalesforceConnection.java
+++ b/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/salesforce/BaseSalesforceConnection.java
@@ -218,7 +218,7 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
 
     @Override
     public QueryResult queryMore(String queryLocator) throws TranslatorException {
-        
+
      try {
             return partnerConnection.queryMore(queryLocator);
         } catch (ConnectionException e) {

--- a/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/salesforce/BaseSalesforceConnection.java
+++ b/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/salesforce/BaseSalesforceConnection.java
@@ -219,7 +219,7 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
     @Override
     public QueryResult queryMore(String queryLocator) throws TranslatorException {
         
-    	try {
+     try {
             return partnerConnection.queryMore(queryLocator);
         } catch (ConnectionException e) {
             throw new TranslatorException(e);
@@ -421,15 +421,15 @@ public abstract class BaseSalesforceConnection<T extends SalesforceConfiguration
             }
             job.setConcurrencyMode(ConcurrencyMode.Parallel);
             synchronized(this){
-	            if (operation == OperationEnum.query && usePkChunking) {
-	                this.bulkConnection.addHeader(PK_CHUNKING_HEADER, "chunkSize=" + MAX_CHUNK_SIZE); //$NON-NLS-1$
-	            }
-	            JobInfo info = this.bulkConnection.createJob(job);
-	            //reset the header
-	            if (operation == OperationEnum.query) {
-	                this.bulkConnection = new BulkConnection(config);
-	            }
-	            return info;
+             if (operation == OperationEnum.query && usePkChunking) {
+                 this.bulkConnection.addHeader(PK_CHUNKING_HEADER, "chunkSize=" + MAX_CHUNK_SIZE); //$NON-NLS-1$
+             }
+             JobInfo info = this.bulkConnection.createJob(job);
+             //reset the header
+             if (operation == OperationEnum.query) {
+                 this.bulkConnection = new BulkConnection(config);
+             }
+             return info;
             }
         } catch (AsyncApiException e) {
             throw new TranslatorException(e);

--- a/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/translator/salesforce/SalesforceConnection.java
+++ b/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/translator/salesforce/SalesforceConnection.java
@@ -100,9 +100,9 @@ public interface SalesforceConnection extends Connection {
 
     }
 
-    public QueryResult query(String queryString, int maxBatchSize, boolean queryAll) throws TranslatorException;
+    public QueryResult query(String queryString, boolean queryAll) throws TranslatorException;
 
-    public QueryResult queryMore(String queryLocator, int batchSize) throws TranslatorException;
+    public QueryResult queryMore(String queryLocator) throws TranslatorException;
 
     public boolean isValid();
 

--- a/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/translator/salesforce/execution/DeleteUpdateExecutionImpl.java
+++ b/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/translator/salesforce/execution/DeleteUpdateExecutionImpl.java
@@ -134,7 +134,6 @@ public abstract class DeleteUpdateExecutionImpl extends AbstractUpdateExecution 
         if (((BulkCommand)command).getParameterValues() != null) {
             throw new TranslatorException("Only bulk inserts are supported"); //$NON-NLS-1$
         }
-        int batchSize = 2000; //Salesforce limit
         String[] Ids = null;
         if (visitor.hasOnlyIDCriteria()) {
             if (criteria instanceof Comparison) {
@@ -151,7 +150,7 @@ public abstract class DeleteUpdateExecutionImpl extends AbstractUpdateExecution 
         } else {
             String query = visitor.getQuery();
             context.logCommand(query);
-            QueryResult results = getConnection().query(query, batchSize, Boolean.FALSE);
+            QueryResult results = getConnection().query(query, Boolean.FALSE);
             ArrayList<String> idList = new ArrayList<String>(results.getRecords().length);
             //5000 is the default size from StreamHandler.getMaxRecordsInBatch
             //200 was the existing default for sync updates
@@ -171,7 +170,7 @@ public abstract class DeleteUpdateExecutionImpl extends AbstractUpdateExecution 
                 if (results.isDone()) {
                     break;
                 }
-                results = connection.queryMore(results.getQueryLocator(), batchSize);
+                results = connection.queryMore(results.getQueryLocator());
             }
             if (!idList.isEmpty()) {
                 Ids = idList.toArray(new String[0]);

--- a/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/translator/salesforce/execution/DirectQueryExecution.java
+++ b/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/translator/salesforce/execution/DirectQueryExecution.java
@@ -141,7 +141,7 @@ public class DirectQueryExecution implements ProcedureExecution  {
     }
 
     private void doSelect(String select) throws TranslatorException {
-        this.results = this.connection.query(select, this.context.getBatchSize(), Boolean.FALSE);
+        this.results = this.connection.query(select, Boolean.FALSE);
     }
 
     @Override
@@ -183,7 +183,7 @@ public class DirectQueryExecution implements ProcedureExecution  {
         else {
             if(!result.isDone()) {
                 // fetch more results
-                this.results = this.connection.queryMore(results.getQueryLocator(), context.getBatchSize());
+                this.results = this.connection.queryMore(results.getQueryLocator());
                 this.currentBatch = loadBatch(this.results);
 
                 // read next row

--- a/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/translator/salesforce/execution/QueryExecutionImpl.java
+++ b/connectors/salesforce/translator-salesforce/src/main/java/org/teiid/translator/salesforce/execution/QueryExecutionImpl.java
@@ -266,7 +266,7 @@ public class QueryExecutionImpl implements ResultSetExecution {
                 LogManager.logDetail(LogConstants.CTX_CONNECTOR,  getLogPreamble(), "Ingoring bulk hint as the query is not bulk eligible"); //$NON-NLS-1$
             }
 
-            results = connection.query(finalQuery, this.context.getBatchSize(), visitor.getQueryAll());
+            results = connection.query(finalQuery, visitor.getQueryAll());
         }
     }
 
@@ -333,7 +333,7 @@ public class QueryExecutionImpl implements ResultSetExecution {
 
     private void loadBatch() throws TranslatorException {
         if(null != resultBatch) { // if we have an old batch, then we have to get new results
-            results = connection.queryMore(results.getQueryLocator(), context.getBatchSize());
+            results = connection.queryMore(results.getQueryLocator());
         }
         resultBatch = new ArrayList<List<Object>>();
         topResultIndex = 0;

--- a/connectors/salesforce/translator-salesforce/src/test/java/org/teiid/translator/salesforce/execution/TestQueryExecutionImpl.java
+++ b/connectors/salesforce/translator-salesforce/src/test/java/org/teiid/translator/salesforce/execution/TestQueryExecutionImpl.java
@@ -73,8 +73,8 @@ public class TestQueryExecutionImpl {
         QueryResult finalQr = new QueryResult();
         finalQr.setRecords(new SObject[] {so});
         finalQr.setDone(true);
-        Mockito.stub(sfc.query("SELECT Name FROM Account", 0, false)).toReturn(qr);
-        Mockito.stub(sfc.queryMore(null, 0)).toReturn(finalQr);
+        Mockito.stub(sfc.query("SELECT Name FROM Account", false)).toReturn(qr);
+        Mockito.stub(sfc.queryMore(null)).toReturn(finalQr);
         QueryExecutionImpl qei = new QueryExecutionImpl(command, sfc, Mockito.mock(RuntimeMetadata.class), Mockito.mock(ExecutionContext.class), new SalesForceExecutionFactory());
         qei.execute();
         assertNotNull(qei.next());
@@ -95,7 +95,7 @@ public class TestQueryExecutionImpl {
         so1.addField("Account", so);
         qr.setRecords(new SObject[] {so1});
         qr.setDone(true);
-        Mockito.stub(sfc.query("SELECT Account.Name, Id FROM Contact WHERE AccountId != NULL", 0, false)).toReturn(qr);
+        Mockito.stub(sfc.query("SELECT Account.Name, Id FROM Contact WHERE AccountId != NULL", false)).toReturn(qr);
         QueryExecutionImpl qei = new QueryExecutionImpl(command, sfc, Mockito.mock(RuntimeMetadata.class), Mockito.mock(ExecutionContext.class), new SalesForceExecutionFactory());
         qei.execute();
         assertEquals(Arrays.asList("account name", "contact id"), qei.next());
@@ -115,7 +115,7 @@ public class TestQueryExecutionImpl {
         so.addField("Contacts", so1);
         qr.setRecords(new SObject[] {so});
         qr.setDone(true);
-        Mockito.stub(sfc.query("SELECT Name, (SELECT Id FROM Contacts) FROM Account", 0, false)).toReturn(qr);
+        Mockito.stub(sfc.query("SELECT Name, (SELECT Id FROM Contacts) FROM Account", false)).toReturn(qr);
         QueryExecutionImpl qei = new QueryExecutionImpl(command, sfc, Mockito.mock(RuntimeMetadata.class), Mockito.mock(ExecutionContext.class), new SalesForceExecutionFactory());
         qei.execute();
         assertEquals(Arrays.asList("account name", "contact id"), qei.next());
@@ -139,7 +139,7 @@ public class TestQueryExecutionImpl {
         so.addField("ChildAccounts", so2);
         qr.setRecords(new SObject[] {so});
         qr.setDone(true);
-        Mockito.stub(sfc.query("SELECT Name, (SELECT Id FROM ChildAccounts) FROM Account", 0, false)).toReturn(qr);
+        Mockito.stub(sfc.query("SELECT Name, (SELECT Id FROM ChildAccounts) FROM Account", false)).toReturn(qr);
         QueryExecutionImpl qei = new QueryExecutionImpl(command, sfc, Mockito.mock(RuntimeMetadata.class), Mockito.mock(ExecutionContext.class), new SalesForceExecutionFactory());
         qei.execute();
         assertEquals(Arrays.asList("account name", "account id1"), qei.next());

--- a/connectors/salesforce/translator-salesforce/src/test/java/org/teiid/translator/salesforce/execution/TestSalesForceDirectQueryExecution.java
+++ b/connectors/salesforce/translator-salesforce/src/test/java/org/teiid/translator/salesforce/execution/TestSalesForceDirectQueryExecution.java
@@ -72,12 +72,12 @@ public class TestSalesForceDirectQueryExecution {
         s.addField("Name", "The Name");
 
         Mockito.stub(qr.getRecords()).toReturn(results);
-        Mockito.stub(connection.query("SELECT Account.Id, Account.Type, Account.Name FROM Account", 0, false)).toReturn(qr);
+        Mockito.stub(connection.query("SELECT Account.Id, Account.Type, Account.Name FROM Account", false)).toReturn(qr);
 
         DirectQueryExecution execution = (DirectQueryExecution)TRANSLATOR.createExecution(command, ec, rm, connection);
         execution.execute();
 
-        Mockito.verify(connection, Mockito.times(1)).query("SELECT Account.Id, Account.Type, Account.Name FROM Account", 0, false);
+        Mockito.verify(connection, Mockito.times(1)).query("SELECT Account.Id, Account.Type, Account.Name FROM Account", false);
 
         assertArrayEquals(new Object[] {"The ID", "The Type", "The Name"}, (Object[])execution.next().get(0));
 

--- a/connectors/salesforce/translator-salesforce/src/test/java/org/teiid/translator/salesforce/execution/TestUpdates.java
+++ b/connectors/salesforce/translator-salesforce/src/test/java/org/teiid/translator/salesforce/execution/TestUpdates.java
@@ -87,7 +87,7 @@ public class TestUpdates {
         qr.setSize(1);
         qr.setDone(true);
 
-        Mockito.stub(connection.query(queryArgument.capture(), Mockito.anyInt(), Mockito.anyBoolean())).toReturn(qr);
+        Mockito.stub(connection.query(queryArgument.capture(), Mockito.anyBoolean())).toReturn(qr);
         Mockito.stub(connection.delete(new String[] {"x"})).toReturn(1);
 
         while(true) {
@@ -100,7 +100,7 @@ public class TestUpdates {
             }
         }
 
-        Mockito.verify(connection, Mockito.times(1)).query(queryArgument.capture(), Mockito.anyInt(), Mockito.anyBoolean());
+        Mockito.verify(connection, Mockito.times(1)).query(queryArgument.capture(), Mockito.anyBoolean());
 
         String query = queryArgument.getValue();
         assertEquals("SELECT Id FROM Contact ", query);
@@ -152,7 +152,7 @@ public class TestUpdates {
         qr.setSize(1);
         qr.setDone(true);
 
-        Mockito.stub(connection.query(queryArgument.capture(), Mockito.anyInt(), Mockito.anyBoolean())).toReturn(qr);
+        Mockito.stub(connection.query(queryArgument.capture(), Mockito.anyBoolean())).toReturn(qr);
 
         JobInfo jobInfo = Mockito.mock(JobInfo.class);
 
@@ -181,7 +181,7 @@ public class TestUpdates {
             }
         }
 
-        Mockito.verify(connection, Mockito.times(1)).query(queryArgument.capture(), Mockito.anyInt(), Mockito.anyBoolean());
+        Mockito.verify(connection, Mockito.times(1)).query(queryArgument.capture(), Mockito.anyBoolean());
 
         String query = queryArgument.getValue();
         assertEquals("SELECT Id FROM Contact WHERE ContactName LIKE '_a' ", query);
@@ -205,7 +205,7 @@ public class TestUpdates {
         qr.setSize(0);
         qr.setDone(true);
 
-        Mockito.stub(connection.query(queryArgument.capture(), Mockito.anyInt(), Mockito.anyBoolean())).toReturn(qr);
+        Mockito.stub(connection.query(queryArgument.capture(), Mockito.anyBoolean())).toReturn(qr);
 
         while(true) {
             try {
@@ -217,7 +217,7 @@ public class TestUpdates {
             }
         }
 
-        Mockito.verify(connection, Mockito.times(1)).query(queryArgument.capture(), Mockito.anyInt(), Mockito.anyBoolean());
+        Mockito.verify(connection, Mockito.times(1)).query(queryArgument.capture(), Mockito.anyBoolean());
 
         String query = queryArgument.getValue();
         assertEquals("SELECT Id FROM Contact WHERE ContactName = 'abc' ", query);
@@ -245,7 +245,7 @@ public class TestUpdates {
 
         ArgumentCaptor<List> data = ArgumentCaptor.forClass(List.class);
 
-        Mockito.stub(connection.query(queryArgument.capture(), Mockito.anyInt(), Mockito.anyBoolean())).toReturn(qr);
+        Mockito.stub(connection.query(queryArgument.capture(), Mockito.anyBoolean())).toReturn(qr);
         Mockito.stub(connection.update(data.capture())).toReturn(1);
 
         while(true) {
@@ -258,7 +258,7 @@ public class TestUpdates {
             }
         }
 
-        Mockito.verify(connection, Mockito.times(1)).query(queryArgument.capture(), Mockito.anyInt(), Mockito.anyBoolean());
+        Mockito.verify(connection, Mockito.times(1)).query(queryArgument.capture(), Mockito.anyBoolean());
 
         String query = queryArgument.getValue();
         assertEquals("SELECT Id FROM Contact ", query);

--- a/connectors/salesforce/translator-salesforce/src/test/java/org/teiid/translator/salesforce/execution/visitors/TestVisitors.java
+++ b/connectors/salesforce/translator-salesforce/src/test/java/org/teiid/translator/salesforce/execution/visitors/TestVisitors.java
@@ -336,12 +336,12 @@ public class TestVisitors {
 
         ArgumentCaptor<String> queryArgument = ArgumentCaptor.forClass(String.class);
         QueryResult qr = Mockito.mock(QueryResult.class);
-        Mockito.stub(connection.query(queryArgument.capture(), Mockito.anyInt(), Mockito.anyBoolean())).toReturn(qr);
+        Mockito.stub(connection.query(queryArgument.capture(), Mockito.anyBoolean())).toReturn(qr);
 
         Execution execution = factory.createExecution(command, ec, rm, connection);
         execution.execute();
 
-        Mockito.verify(connection, Mockito.times(1)).query(queryArgument.capture(), Mockito.anyInt(), Mockito.anyBoolean());
+        Mockito.verify(connection, Mockito.times(1)).query(queryArgument.capture(), Mockito.anyBoolean());
 
         assertEquals(expected, queryArgument.getValue().trim());
     }


### PR DESCRIPTION
Hi. We had discussion about MT of PartnerConnection. You really use shared state of headers and options. So, for preparing of multithreaded manner of use PartnerConnection I moved this options to constructor. Because this options really always set as constants. And as additional, create of bulk job made sunchronized. 

This made for further add new functionality in spring-boot-teiid project with connection pool.