### PR TITLE
First push of druid translator

### DIFF
--- a/connectors/jdbc/translator-jdbc/src/main/java/org/teiid/translator/jdbc/druid/DruidExecutionFactory.java
+++ b/connectors/jdbc/translator-jdbc/src/main/java/org/teiid/translator/jdbc/druid/DruidExecutionFactory.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags and
+ * the COPYRIGHT.txt file distributed with this work.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.teiid.translator.jdbc.druid;
+
+import org.teiid.language.*;
+import org.teiid.metadata.RuntimeMetadata;
+import org.teiid.translator.*;
+import org.teiid.translator.jdbc.*;
+import org.teiid.translator.jdbc.oracle.ConcatFunctionModifier;
+import org.teiid.translator.jdbc.oracle.OracleFormatFunctionModifier;
+
+import java.sql.Connection;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.*;
+
+import static org.teiid.translator.TypeFacility.RUNTIME_NAMES.*;
+
+/**
+ * Translator class for Apache Druid.
+ * Created by Don Krapohl 04/02/2021
+ */
+@Translator(name="druid", description="druid custom translator")
+public class DruidExecutionFactory extends JDBCExecutionFactory {
+
+    public static String DRUID = "druid"; //$NON-NLS-1$
+
+    static final String UUID_TYPE = "uuid"; //$NON-NLS-1$
+    private static final String INTEGER_TYPE = "integer"; //$NON-NLS-1$
+    private String druidBrokerURL;   //required, defaults to null
+    private String serialization="json"; //defaults to json
+    private String authentication="NONE";    //defaults to no authentication
+    private static final String TIME_FORMAT = "HH:mm:ss"; //$NON-NLS-1$
+    private static final String DATE_FORMAT = "yyyy-MM-dd"; //$NON-NLS-1$
+    private static final String DATETIME_FORMAT = DATE_FORMAT + " " + TIME_FORMAT; //$NON-NLS-1$
+    private static final String TIMESTAMP_FORMAT = DATETIME_FORMAT; // + ".FF";  //$NON-NLS-1$
+    protected Map<String, Object> formatMap = new HashMap<String, Object>();
+
+    public static final Version ZERO_17 = Version.getVersion("0.17"); //$NON-NLS-1$
+
+    protected ConvertModifier convertModifier;
+    private OracleFormatFunctionModifier parseModifier = new OracleFormatFunctionModifier("TIME_PARSE(", true); //$NON-NLS-1$
+
+    public DruidExecutionFactory() {
+        setSupportsFullOuterJoins(false);
+        setSupportsOuterJoins(false);
+        setSupportsInnerJoins(false);
+        setSupportsOrderBy(true);
+    }
+
+    public void start() throws TranslatorException {
+
+        super.start();
+        //FUNCTION REFERENCE FOR AVATICA JDBC DRIVER: http://druid.io/docs/latest/querying/sql
+        //NUMERIC FUNCTIONS
+        registerFunctionModifier(SourceSystemFunctions.LOG, new AliasModifier("ln")); //$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.TRUNCATE, new AliasModifier("trunc")); //$NON-NLS-1$
+
+        //STRING FUNCTIONS
+        registerFunctionModifier(SourceSystemFunctions.LCASE, new AliasModifier("lower")); //$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.UCASE, new AliasModifier("upper")); //$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.CONCAT, new AliasModifier("textcat")); //$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.LENGTH, new AliasModifier("char_length")); //$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.LENGTH, new AliasModifier("character_length")); //$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.LENGTH, new AliasModifier("strlen")); //$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.CONCAT, new ConcatFunctionModifier(getLanguageFactory()));
+        registerFunctionModifier(SourceSystemFunctions.CONCAT2, new AliasModifier("||")); //$NON-NLS-1$
+
+        //TIME FUNCTIONS
+        registerFunctionModifier(SourceSystemFunctions.CURDATE, new AliasModifier("CURRENT_TIMESTAMP")); //$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.CURTIME, new AliasModifier("CURRENT_DATE")); //$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.NOW, new AliasModifier("CURRENT_TIMESTAMP")); //$NON-NLS-1$
+        registerFunctionModifier(SourceSystemFunctions.TIMESTAMPADD, new TimestampAddModifier());
+
+        registerFunctionModifier(SourceSystemFunctions.DAYOFYEAR, new FunctionModifier() {
+            @Override
+            public List<?> translate(Function function) {
+                return Arrays.asList("TIME_EXTRACT(", function.getParameters().get(0), ", 'DOY' )"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            }
+        });
+
+        //source: time_format(ts, pattern), teiid: FORMATTIMESTAMP(ts, pattern)
+        registerFunctionModifier(SourceSystemFunctions.FORMATTIMESTAMP, new FunctionModifier() {
+            @Override
+            public List<?> translate(Function function) {
+                return Arrays.asList("TIME_FORMAT(", function.getParameters().get(0), ", ",
+                        function.getParameters().get(1), ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            }
+        });
+        //source: time_parse(str, pattern) teiid: PARSETIMESTAMP(string, pattern)
+        registerFunctionModifier(SourceSystemFunctions.PARSETIMESTAMP, new FunctionModifier() {
+            @Override
+            public List<?> translate(Function function) {
+                return Arrays.asList("TIME_PARSE(", function.getParameters().get(0), ", ",
+                        function.getParameters().get(1), ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            }
+        });
+        //OTHER FUNCTIONS
+        registerFunctionModifier(SourceSystemFunctions.IFNULL, new AliasModifier("nullif")); //$NON-NLS-1$
+
+        //standard function form of several predicates
+        addPushDownFunction(DRUID, "concat", STRING, STRING).setVarArgs(true); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "APPROX_COUNT_DISTINCT",BIG_INTEGER, STRING); //$NON-NLS-1$ //$NON-NLS-2$
+        addPushDownFunction(DRUID, "BLOOM_FILTER",BLOB, STRING, BIG_INTEGER); //$NON-NLS-1$ //$NON-NLS-2$
+        addPushDownFunction(DRUID, "regexp_extract", STRING, STRING, STRING, INTEGER); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "btrim",STRING, STRING, STRING); //$NON-NLS-1$ //$NON-NLS-2$
+        addPushDownFunction(DRUID, "ltrim",STRING, STRING, STRING); //$NON-NLS-1$ //$NON-NLS-2$
+        addPushDownFunction(DRUID, "rtrim",STRING, STRING, STRING); //$NON-NLS-1$ //$NON-NLS-2$
+        addPushDownFunction(DRUID, "trim",STRING, STRING, STRING, STRING); //$NON-NLS-1$ //$NON-NLS-2$
+        addPushDownFunction(DRUID, "date_trunc", TIMESTAMP, STRING, TIMESTAMP); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "TIME_FLOOR", TIMESTAMP, TIMESTAMP, STRING, STRING, STRING); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "TIME_SHIFT", TIMESTAMP, TIMESTAMP, STRING, STRING, STRING); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "TIME_EXTRACT", TIMESTAMP, TIMESTAMP, STRING, STRING); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "TIME_EXTRACT", TIMESTAMP, TIMESTAMP, STRING); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "TIME_EXTRACT", TIMESTAMP, TIMESTAMP); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "TIME_PARSE", TIMESTAMP, STRING, STRING, STRING); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "TIME_PARSE", TIMESTAMP, STRING, STRING); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "TIME_PARSE", TIMESTAMP, STRING, STRING); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "TIME_FORMAT", TIMESTAMP, TIMESTAMP, STRING, STRING ); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "TIME_FORMAT", TIMESTAMP, TIMESTAMP, STRING ); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "MILLIS_TO_TIMESTAMP", TIMESTAMP, BIG_INTEGER); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "TIMESTAMP_TO_MILLIS", BIG_INTEGER, TIMESTAMP); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "EXTRACT", BIG_INTEGER, STRING, TIMESTAMP); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "FLOOR", TIMESTAMP, TIMESTAMP, STRING); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "CEIL", TIMESTAMP, TIMESTAMP, STRING); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "PARSETIMESTAMP", TIMESTAMP, STRING, STRING); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "YEAR", INTEGER, TIMESTAMP); //$NON-NLS-1$
+        addPushDownFunction(DRUID, "YEAR", INTEGER, DATE); //$NON-NLS-1$
+
+        convertModifier = new ConvertModifier();
+        convertModifier.addTypeMapping("char", FunctionModifier.STRING); //$NON-NLS-1$
+        convertModifier.addTypeMapping("varchar", FunctionModifier.STRING); //$NON-NLS-1$
+        convertModifier.addTypeMapping("decimal", FunctionModifier.DOUBLE); //$NON-NLS-1$
+        convertModifier.addTypeMapping("float", FunctionModifier.FLOAT); //$NON-NLS-1$
+        convertModifier.addTypeMapping("real", FunctionModifier.DOUBLE); //$NON-NLS-1$
+        convertModifier.addTypeMapping("double", FunctionModifier.DOUBLE); //$NON-NLS-1$
+        convertModifier.addTypeMapping("boolean", FunctionModifier.LONG); //$NON-NLS-1$
+        convertModifier.addTypeMapping("tinyint", FunctionModifier.LONG); //$NON-NLS-1$
+        convertModifier.addTypeMapping("smallint", FunctionModifier.LONG); //$NON-NLS-1$
+        convertModifier.addTypeMapping("integer", FunctionModifier.LONG); //$NON-NLS-1$
+        convertModifier.addTypeMapping("bigint", FunctionModifier.LONG); //$NON-NLS-1$
+        convertModifier.addTypeMapping("timestamp", FunctionModifier.TIMESTAMP); //$NON-NLS-1$
+        convertModifier.addTypeMapping("date", FunctionModifier.DATE); //$NON-NLS-1$
+
+        // type conversions
+        convertModifier.addConvert(FunctionModifier.DATE, FunctionModifier.STRING, new ConvertModifier.FormatModifier("TIME_FORMAT", DATE_FORMAT)); //$NON-NLS-1$
+        convertModifier.addConvert(FunctionModifier.TIME, FunctionModifier.STRING, new ConvertModifier.FormatModifier("TIME_FORMAT", TIME_FORMAT)); //$NON-NLS-1$
+        convertModifier.addConvert(FunctionModifier.TIMESTAMP, FunctionModifier.STRING, new FunctionModifier() {
+            @Override
+            public List<?> translate(Function function) {
+                //if column and type is date, just use date format
+                Expression ex = function.getParameters().get(0);
+                String format = TIMESTAMP_FORMAT;
+                if (ex instanceof ColumnReference && "date".equalsIgnoreCase(((ColumnReference)ex).getMetadataObject().getNativeType())) { //$NON-NLS-1$
+                    format = DATETIME_FORMAT;
+                } else if (!(ex instanceof Literal) && !(ex instanceof Function)) {
+                    //this isn't needed in every case, but it's simpler than inspecting the expression more
+                    ex = ConvertModifier.createConvertFunction(getLanguageFactory(), function.getParameters().get(0), TypeFacility.RUNTIME_NAMES.TIMESTAMP);
+                }
+                return Arrays.asList("TIME_FORMAT(", ex, ", '", format, "')"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            }
+        });
+        convertModifier.addConvert(FunctionModifier.STRING, FunctionModifier.DATE, new ConvertModifier.FormatModifier("TIME_PARSE", DATE_FORMAT)); //$NON-NLS-1$
+        convertModifier.addConvert(FunctionModifier.STRING, FunctionModifier.TIME, new ConvertModifier.FormatModifier("TIME_PARSE", TIME_FORMAT)); //$NON-NLS-1$
+        convertModifier.addConvert(FunctionModifier.STRING, FunctionModifier.TIMESTAMP,
+                new ConvertModifier.FormatModifier("TIME_PARSE", TIMESTAMP_FORMAT)); //$NON-NLS-1$
+
+        convertModifier.addNumericBooleanConversions();
+        convertModifier.setWideningNumericImplicit(true);
+        registerFunctionModifier(SourceSystemFunctions.CONVERT, convertModifier);
+    }
+
+    @Override
+    public void initCapabilities(Connection connection)
+            throws TranslatorException {
+        super.initCapabilities(connection);
+    }
+
+    // overriding execution because avatica exception information is horrible
+    @Override
+    public ResultSetExecution createResultSetExecution(QueryExpression command, ExecutionContext executionContext, RuntimeMetadata metadata, Connection conn)
+            throws TranslatorException {
+        return new DruidQueryExecution(command, conn, executionContext, this);
+    }
+
+    @Override
+    public List<?> translateCommand(Command command, ExecutionContext context) {
+        return super.translateCommand(command, context);
+    }
+
+        /*
+    @Override
+    public String translateLiteralBoolean(Boolean booleanValue) {
+        if(booleanValue.booleanValue()) {
+            return "TRUE"; //$NON-NLS-1$
+        }
+        return "FALSE"; //$NON-NLS-1$
+    }
+    */
+
+    @Override
+    public String translateLiteralDate(java.sql.Date dateValue) {
+        return "DATE '" + formatDateValue(dateValue) + "'"; //$NON-NLS-1$//$NON-NLS-2$
+    }
+
+    @Override
+    public String translateLiteralTime(Time timeValue) {
+        return "TIME '" + formatDateValue(timeValue) + "'"; //$NON-NLS-1$//$NON-NLS-2$
+    }
+
+    @Override
+    public String translateLiteralTimestamp(Timestamp timestampValue) {
+        if (timestampValue.getNanos() == 0) {
+            String val = formatDateValue(timestampValue);
+            val = val.substring(0, val.length() - 2);
+            return "TIME_PARSE('" + val + "', '" + DATETIME_FORMAT + "')"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        }
+        return super.translateLiteralTimestamp(timestampValue);
+    }
+
+    @Override
+    public boolean usePreparedStatements() {
+        return false;
+    }
+
+    @Override
+    public int getTimestampNanoPrecision() {
+        return 6;
+    }
+
+    /**
+     * Postgres doesn't provide min/max(boolean), so this conversion writes a min(BooleanValue) as
+     * bool_and(BooleanValue)
+     * @see org.teiid.language.visitor.LanguageObjectVisitor#visit(org.teiid.language.AggregateFunction)
+     * @since 4.3
+     */
+    @Override
+    public List<?> translate(LanguageObject obj, ExecutionContext context) {
+        return super.translate(obj, context);
+    }
+
+    @Override
+    public NullOrder getDefaultNullOrder() {
+        return NullOrder.HIGH;
+    }
+
+
+    @Override
+    public List<String> getSupportedFunctions() {
+        List<String> supportedFunctions = new ArrayList<String>();
+//        supportedFunctions.addAll(super.getSupportedFunctions());
+        //DATA TYPE MAPPING AND CONVERSION
+
+        //NUMERIC FUNCTIONS
+        supportedFunctions.add(SourceSystemFunctions.MULTIPLY_OP);
+        supportedFunctions.add(SourceSystemFunctions.ADD_OP);
+        supportedFunctions.add(SourceSystemFunctions.DIVIDE_OP);
+        supportedFunctions.add(SourceSystemFunctions.SUBTRACT_OP);
+        supportedFunctions.add(SourceSystemFunctions.ABS);
+        supportedFunctions.add(SourceSystemFunctions.CEILING);
+        supportedFunctions.add(SourceSystemFunctions.FLOOR);
+        supportedFunctions.add(SourceSystemFunctions.EXP);
+        supportedFunctions.add(SourceSystemFunctions.LOG);
+        supportedFunctions.add(SourceSystemFunctions.LOG10);
+        supportedFunctions.add(SourceSystemFunctions.POWER);
+        supportedFunctions.add(SourceSystemFunctions.SQRT);
+        supportedFunctions.add(SourceSystemFunctions.TRUNCATE);
+        supportedFunctions.add(SourceSystemFunctions.MOD);
+        supportedFunctions.add(SourceSystemFunctions.ROUND);
+
+        //STRING FUNCTIONS
+        supportedFunctions.add("||"); //$NON-NLS-1$
+        supportedFunctions.add(SourceSystemFunctions.LENGTH);
+        supportedFunctions.add(SourceSystemFunctions.SUBSTRING);
+        supportedFunctions.add(SourceSystemFunctions.CONCAT);
+        //TIME FUNCTIONS
+        supportedFunctions.add(SourceSystemFunctions.FORMATTIMESTAMP);
+        supportedFunctions.add(SourceSystemFunctions.PARSETIMESTAMP);
+        supportedFunctions.add(SourceSystemFunctions.TIMESTAMPADD);
+        //supportedFunctions.add(SourceSystemFunctions.TIMESTAMPDIFF);
+        supportedFunctions.add(SourceSystemFunctions.YEAR);
+        supportedFunctions.add(SourceSystemFunctions.QUARTER);
+        supportedFunctions.add(SourceSystemFunctions.MONTH);
+        supportedFunctions.add(SourceSystemFunctions.WEEK);
+        supportedFunctions.add(SourceSystemFunctions.DAYOFYEAR);
+        supportedFunctions.add(SourceSystemFunctions.DAYOFMONTH);
+        supportedFunctions.add(SourceSystemFunctions.DAYOFWEEK);
+        supportedFunctions.add(SourceSystemFunctions.HOUR);
+        supportedFunctions.add(SourceSystemFunctions.MINUTE);
+        supportedFunctions.add(SourceSystemFunctions.SECOND);
+
+        //COMPARISON OPERATORS
+        supportedFunctions.add(SourceSystemFunctions.COALESCE);
+        //OTHER FUNCTIONS
+
+        return supportedFunctions;
+    }
+
+    @Override
+    public boolean supportsOrderByNullOrdering() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsSelfJoins() {
+        return false;
+    }
+    @Override
+    public boolean supportsBulkUpdate() {
+        return false;
+    }
+    @Override
+    public boolean supportsBatchedUpdates() {
+        return false;
+    }
+    @Override
+    public boolean supportsInsertWithQueryExpression() {
+        return false;
+    }
+    @Override
+    public boolean supportsCommonTableExpressions() {
+        return false; // WITH clause
+    }
+    @Override
+    public boolean supportsRowLimit() {
+        return true;
+    }
+    @Override
+    public boolean supportsInCriteria() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsIsNullCriteria() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsLikeCriteria() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsNotCriteria() {
+        return true;
+    }
+    @Override
+    public boolean supportsOrCriteria() {
+        return true;
+    }
+    @Override
+    public boolean supportsInCriteriaSubquery() {
+        return true;
+    }
+
+    // aggregate functions
+    @Override
+    public boolean supportsAggregatesSum() {
+        return true;
+    }
+    @Override
+    public boolean supportsAggregatesAvg() {
+        return true;
+    }
+    @Override
+    public boolean supportsAggregatesMin() {
+        return true;
+    }
+    @Override
+    public boolean supportsAggregatesMax() {
+        return true;
+    }
+    @Override
+    public boolean supportsAggregatesCount() {
+        return true;
+    }
+    @Override
+    public boolean supportsAggregatesCountStar() {
+        return false;
+    }
+    @Override
+    public boolean supportsAggregatesDistinct() {
+        return false;
+    }   // disable count(distinct)
+
+    @Override
+    public boolean supportsScalarSubqueries() {
+        return false;
+    }
+    @Override
+    public boolean supportsLikeRegex() {
+        return true;
+    }   // we'll be rewriting LIKE as regexp
+    @Override
+    public boolean supportsSearchedCaseExpressions() {
+        return true;
+    }
+    @Override
+    public boolean supportsUnions() {
+        return false;
+    }
+    @Override
+    public boolean supportsWindowDistinctAggregates() {
+        return false;
+    }
+    @Override
+    public boolean supportsWindowOrderByWithAggregates() {
+        return false;
+    }
+    @Override
+    public boolean supportsElementaryOlapOperations() {
+        return false;
+    }
+    @Override
+    public boolean supportsFunctionsInGroupBy() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsOnlyTimestampAddLiteral() {
+        return true;
+    }
+    @Override
+    public boolean supportsFormatLiteral(String literal,
+                                         org.teiid.translator.ExecutionFactory.Format format) {
+        if (format == Format.NUMBER) {
+            return false;
+        }
+        return parseModifier.supportsLiteral(literal);
+    }
+
+}

--- a/connectors/jdbc/translator-jdbc/src/main/java/org/teiid/translator/jdbc/druid/DruidQueryExecution.java
+++ b/connectors/jdbc/translator-jdbc/src/main/java/org/teiid/translator/jdbc/druid/DruidQueryExecution.java
@@ -1,0 +1,37 @@
+package org.teiid.translator.jdbc.druid;
+
+import org.teiid.language.Command;
+import org.teiid.translator.ExecutionContext;
+import org.teiid.translator.ResultSetExecution;
+import org.teiid.translator.TranslatorException;
+import org.teiid.translator.jdbc.JDBCBaseExecution;
+import org.teiid.translator.jdbc.JDBCExecutionFactory;
+import org.teiid.translator.jdbc.JDBCQueryExecution;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Objects;
+
+/**
+ * Query execution class for Apache Druid.
+ * Created by Don Krapohl 04/02/2021
+ */
+public class DruidQueryExecution extends JDBCQueryExecution {
+    public DruidQueryExecution(Command command, Connection connection, ExecutionContext context, JDBCExecutionFactory env) {
+        super(command, connection, context, env);
+    }
+
+    @Override
+    public void execute() throws TranslatorException {
+        try {
+            super.execute();
+        }
+        catch (Exception translatorException)
+        {
+			// Avatica jdbc error message is not usually at the top of the stack
+            throw new TranslatorException(translatorException.getCause());
+
+        }
+
+    }
+}

--- a/connectors/jdbc/translator-jdbc/src/main/java/org/teiid/translator/jdbc/druid/TimestampAddModifier.java
+++ b/connectors/jdbc/translator-jdbc/src/main/java/org/teiid/translator/jdbc/druid/TimestampAddModifier.java
@@ -1,0 +1,74 @@
+package org.teiid.translator.jdbc.druid;
+
+import org.teiid.language.Function;
+import org.teiid.language.Literal;
+import org.teiid.language.SQLConstants;
+import org.teiid.translator.jdbc.ExtractFunctionModifier;
+import org.teiid.translator.jdbc.FunctionModifier;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Modification of timestamp class for Apache Druid.
+ * Based on OracleTimestampModifier
+ * Created by Don Krapohl 04/02/2021
+ */
+public class TimestampAddModifier extends FunctionModifier {
+    private static Map<String, String> INTERVAL_MAP = new HashMap<String, String>();
+
+    static {
+        INTERVAL_MAP.put(SQLConstants.NonReserved.SQL_TSI_DAY, ExtractFunctionModifier.DAY);
+        INTERVAL_MAP.put(SQLConstants.NonReserved.SQL_TSI_HOUR, ExtractFunctionModifier.HOUR);
+        INTERVAL_MAP.put(SQLConstants.NonReserved.SQL_TSI_MINUTE, ExtractFunctionModifier.MINUTE);
+        INTERVAL_MAP.put(SQLConstants.NonReserved.SQL_TSI_MONTH, ExtractFunctionModifier.MONTH);
+        INTERVAL_MAP.put(SQLConstants.NonReserved.SQL_TSI_SECOND, ExtractFunctionModifier.SECOND);
+        INTERVAL_MAP.put(SQLConstants.NonReserved.SQL_TSI_YEAR, ExtractFunctionModifier.YEAR);
+    }
+
+    @Override
+    public List<?> translate(Function function) {
+        ArrayList<Object> result = new ArrayList<Object>();
+        result.add(function.getParameters().get(2));
+        result.add(" + (INTERVAL '"); //$NON-NLS-1$
+        Literal intervalType = (Literal) function.getParameters().get(0);
+        String interval = ((String) intervalType.getValue()).toUpperCase();
+        String newInterval = INTERVAL_MAP.get(interval);
+        //by capabilities this must be a literal integer
+        int value = (Integer) ((Literal) function.getParameters().get(1)).getValue();
+        long adjustedValue = value;
+        if (newInterval != null) {
+            result.add(value);
+        } else if (interval.equals(SQLConstants.NonReserved.SQL_TSI_QUARTER)) {
+            newInterval = ExtractFunctionModifier.MONTH;
+            adjustedValue = value * 3l;
+            result.add(adjustedValue);
+        } else if (interval.equals(SQLConstants.NonReserved.SQL_TSI_FRAC_SECOND)) {
+            newInterval = ExtractFunctionModifier.SECOND;
+            result.add(String.format("0.%09d", value)); //$NON-NLS-1$
+            adjustedValue = 1;
+        } else {
+            newInterval = ExtractFunctionModifier.DAY;
+            adjustedValue = value * 7l;
+            result.add(adjustedValue);
+        }
+        result.add("' "); //$NON-NLS-1$
+        result.add(newInterval);
+        result.add("("); //$NON-NLS-1$
+        result.add(precision(Math.abs(adjustedValue)));
+        result.add("))"); //$NON-NLS-1$
+        return result;
+    }
+
+    static int precision(long value) {
+        int precision = 1;
+        while (value >= 10) {
+            precision++;
+            value /= 10;
+        }
+        return precision;
+    }
+
+}

--- a/connectors/jdbc/translator-jdbc/src/test/java/org/teiid/translator/jdbc/druid/TestDruidTranslator.java
+++ b/connectors/jdbc/translator-jdbc/src/test/java/org/teiid/translator/jdbc/druid/TestDruidTranslator.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags and
+ * the COPYRIGHT.txt file distributed with this work.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Basic testing class for Apache Druid Translator.
+ * Created by Don Krapohl 04/02/2021
+ */
+package org.teiid.translator.jdbc.druid;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.teiid.cdk.CommandBuilder;
+import org.teiid.cdk.api.TranslationUtility;
+import org.teiid.core.types.DataTypeManager;
+import org.teiid.core.util.UnitTestUtil;
+import org.teiid.dqp.internal.datamgr.ExecutionContextImpl;
+import org.teiid.dqp.internal.datamgr.FakeExecutionContextImpl;
+import org.teiid.language.Array;
+import org.teiid.language.*;
+import org.teiid.language.visitor.CollectorVisitor;
+import org.teiid.metadata.*;
+import org.teiid.query.metadata.CompositeMetadataStore;
+import org.teiid.query.metadata.QueryMetadataInterface;
+import org.teiid.query.metadata.TransformationMetadata;
+import org.teiid.query.sql.lang.SPParameter;
+import org.teiid.query.unittest.RealMetadataFactory;
+import org.teiid.translator.ExecutionContext;
+import org.teiid.translator.TranslatorException;
+import org.teiid.translator.TypeFacility;
+import org.teiid.translator.jdbc.*;
+import org.teiid.translator.jdbc.oracle.OracleExecutionFactory;
+import org.teiid.translator.jdbc.oracle.OracleMetadataProcessor;
+import org.teiid.util.Version;
+
+import java.sql.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.teiid.language.LanguageFactory;
+@SuppressWarnings("nls")
+public class TestDruidTranslator {
+	
+    private DruidExecutionFactory TRANSLATOR;
+    private static ExecutionContext EMPTY_CONTEXT = new FakeExecutionContextImpl();
+    private static final LanguageFactory LANG_FACTORY = new LanguageFactory();
+
+    @Before 
+    public void setup() throws Exception {
+        TRANSLATOR = new DruidExecutionFactory();
+        TRANSLATOR.setUseBindVariables(false);
+        TRANSLATOR.setDatabaseVersion(Version.DEFAULT_VERSION);
+        TRANSLATOR.start();
+    }
+
+    private String getTestVDB() {
+        return TranslationHelper.PARTS_VDB;
+    }
+
+    private String getTestBQTVDB() {
+        return TranslationHelper.BQT_VDB;
+    }
+
+    public void helpTestVisitor(String vdb, String input, String expectedOutput) throws TranslatorException {
+        TranslationHelper.helpTestVisitor(vdb, input, expectedOutput, TRANSLATOR);
+    }
+    @Test
+    public void testPushDownFuctions() throws TranslatorException {
+
+        String input = "SELECT reverse('abc') FROM BQT1.MediumA"; //$NON-NLS-1$
+        String output = "SELECT reverse('abc') FROM MediumA"; //$NON-NLS-1$
+        helpTestVisitor(getTestBQTVDB(), input, output);
+    }
+
+    @Test
+    public void testStringConversion() throws TranslatorException {
+
+        String input = "SELECT lcase(part_name) FROM Parts"; //$NON-NLS-1$
+        String output = "SELECT lower(PARTS.PART_NAME) FROM PARTS"; //$NON-NLS-1$
+        helpTestVisitor(getTestVDB(), input, output);
+
+    }
+
+    @Test
+    public void testTimeFunctions() throws TranslatorException {
+
+        String input = "select FORMATTIMESTAMP(timestampvalue, 'yyyy-MM-dd') from BQT1.MediumA"; //$NON-NLS-1$
+        String output = "SELECT TIME_FORMAT(MediumA.TimestampValue, 'yyyy-MM-dd') FROM MediumA"; //$NON-NLS-1$
+        helpTestVisitor(getTestBQTVDB(), input, output);
+
+        input = "select PARSETIMESTAMP(formattimestamp(timestampvalue, 'yyyy-MM-dd'), 'yyyy-MM-dd') from BQT1.MediumA"; //$NON-NLS-1$
+        output = "SELECT TIME_PARSE(TIME_FORMAT(MediumA.TimestampValue, 'yyyy-MM-dd'), 'yyyy-MM-dd') FROM MediumA"; //$NON-NLS-1$
+        helpTestVisitor(getTestBQTVDB(), input, output);
+
+        input = "select TIMESTAMPADD(SQL_TSI_DAY, 1, timestampvalue) from BQT1.MediumA"; //$NON-NLS-1$
+        output = "SELECT MediumA.TimestampValue + (INTERVAL '1' DAY(1)) FROM MediumA"; //$NON-NLS-1$
+        helpTestVisitor(getTestBQTVDB(), input, output);
+
+        //input = "select TIMESTAMPDIFF(SQL_TSI_DAY, NOW(), timestampvalue) from BQT1.MediumA"; //$NON-NLS-1$
+        //output = "SELECT MediumA.TimestampValue + (INTERVAL '1' DAY(1)) FROM MediumA"; //$NON-NLS-1$
+        //helpTestVisitor(getTestBQTVDB(), input, output);
+    }
+    @Test
+    public void testStringToTimestamp() throws Exception {
+        helpTest(LANG_FACTORY.createLiteral("2004-06-29 23:59:59.987", String.class), "timestamp",
+                "TIME_PARSE('2004-06-29 23:59:59.987', 'YYYY-MM-DD HH24:MI:SS.FF')"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    public void helpTest(Expression srcExpression, String tgtType, String expectedExpression) throws Exception {
+        Function func = LANG_FACTORY.createFunction("convert",  //$NON-NLS-1$
+                Arrays.asList(
+                        srcExpression,
+                        LANG_FACTORY.createLiteral(tgtType, String.class)),
+                TypeFacility.getDataTypeClass(tgtType));
+
+        assertEquals("Error converting from " + srcExpression.getType() + " to " + tgtType, //$NON-NLS-1$ //$NON-NLS-2$
+                expectedExpression, helpGetString(func));
+    }
+    public String helpGetString(Expression expr) throws Exception {
+        DruidExecutionFactory trans = new DruidExecutionFactory();
+        trans.start();
+
+        SQLConversionVisitor sqlVisitor = TRANSLATOR.getSQLConversionVisitor();
+        sqlVisitor.append(expr);
+
+        return sqlVisitor.toString();
+    }
+
+}


### PR DESCRIPTION
We're using this in production right now so it works in Teiid 10.3.X with Avatica 0.17 jdbc driver.

Capturing for public consumption:  

1. Put Avatica driver at the path modules\system\layers\base\org\apache\calcite\main\
2. Add module.xml with content
 `<module xmlns="urn:jboss:module:1.0" name="org.apache.calcite">
  <resources>
    <resource-root path="avatica-1.17.0.jar"/>
  </resources>
  <dependencies>
    <module name="javax.api"/>
  </dependencies>
</module>`
3. Add to standalone-(whichever you use).xml
`				<datasource .......>
                    <connection-url>jdbc:avatica:remote:url=(YOUR CONNECTION STRING)</connection-url>
                    <driver>org.apache.calcite</driver>
                </datasource>	`
4. Add to standalone-(whichever you use).xml
`<translator name="druid" module="org.jboss.teiid.translator.jdbc"/>`
