### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
         
         <version.org.apache.cxf>3.3.6</version.org.apache.cxf>
         <version.org.springframework>5.1.14.RELEASE</version.org.springframework>
+    	<closeTestReports>true</closeTestReports>
 	</properties>
 	<scm>
         <connection>scm:git:git://github.com/teiid/teiid.git</connection>
@@ -472,6 +473,7 @@
 					<user.dir>${basedir}/target</user.dir>
 					<java.io.tmpdir>${basedir}/target</java.io.tmpdir>
 				</systemPropertyVariables>
+				<disableXmlReport>${closeTestReports}</disableXmlReport>
 			</configuration>
 		</plugin>
 		<!-- Build a test-jar for each project, so that src/test/* resources and 


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
